### PR TITLE
Fix up some URLs

### DIFF
--- a/config/description.md
+++ b/config/description.md
@@ -7,7 +7,7 @@ We observe clustering of related infections. These are a cluster of two infectio
 Here, we estimate the time of the most recent common ancestor of sequenced viruses:
 
 <div>
-  <img alt="tmrca" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_poisson-tmrca.png"/>
+  <img alt="tmrca" width="500" src="https://data.nextstrain.org/ncov_poisson-tmrca.png"/>
 </div>
 
 Site numbering and genome structure uses [BetaCoV/Wuhan-Hu-1/2019](https://www.ncbi.nlm.nih.gov/nuccore/MN908947) as reference. The phylogeny is rooted relative to early samples from Wuhan. Temporal resolution assumes a nucleotide substitution rate of 3 &times; 10^-4 subs per site per year. There were SNPs present in the nCoV samples in the first and last few bases of the alignment that were masked as likely sequencing artifacts. The sample Wuhan/IPBCAMS-WH-05/2020 has been dropped from the analysis due to the appearance of clustered, spurious SNPs. Full details on bioinformatic processing can be found [here](https://github.com/nextstrain/ncov).

--- a/config/description_zh.md
+++ b/config/description_zh.md
@@ -6,7 +6,7 @@
 在此，我们估算已测序病毒距离最近共同祖先的时间。
 
 <div>
-  <img alt="tmrca" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_poisson-tmrca.png"/>
+  <img alt="tmrca" width="500" src="https://data.nextstrain.org/ncov_poisson-tmrca.png"/>
 </div>
 
 位点编号和基因组结构采用[BetaCoV/Wuhan-Hu-1/2019](https://www.ncbi.nlm.nih.gov/nuccore/MN908947)作为参照。系统发生树植根于早期武汉病例的样本。时间分辨率假定核苷酸取代率在 3 &times; 10^-4 个单位年，单位点的核苷酸取代。单核苷酸多态性出现在新型冠状病毒样本序列对比中最前和最后的几个碱基被标注为可能的测序错误。有关生物信息处理的完整详细信息，请参见[此处](https://github.com/nextstrain/ncov)。由于出现了可疑的单核苷酸多态集群，因此从分析中删除了样本Wuhan/IPBCAMS-WH-05/2020。

--- a/narratives/ncov_sit-rep-pt_2020-01-25.md
+++ b/narratives/ncov_sit-rep-pt_2020-01-25.md
@@ -141,7 +141,7 @@ Others have unique or shared mutations and so sit on lines, or 'branches', going
 You can see how many mutations a branch has by hovering your mouse over it.
 ```
 
-# [Phylogenetic analysis](http://localhost:4000/ncov/2020-01-25?m=div&d=tree)
+# [Phylogenetic analysis](https://nextstrain.org/ncov/2020-01-25?m=div&d=tree)
 
 Here we present a phylogeny of 27 strains of nCoV that have been publicly shared.
 Information on how the analysis was performed is available [in this GitHub repository](github.com/nextstrain/ncov).

--- a/narratives/ncov_sit-rep-pt_2020-01-25.md
+++ b/narratives/ncov_sit-rep-pt_2020-01-25.md
@@ -132,7 +132,7 @@ When a sequence sits on a long line on its own, like C or E, this means it has u
 A and B also have unique mutations (the green circle) not shared by the other sequences, but they are identical to each other.
 
 <div>
-  <img alt="cartoon of phylogenetic tree and corresponding alignment, with samples labelled A-E" width="500" src="https://nextstrain-data.s3.amazonaws.com/toy_alignment_tree.png"/>
+  <img alt="cartoon of phylogenetic tree and corresponding alignment, with samples labelled A-E" width="500" src="https://data.nextstrain.org/toy_alignment_tree.png"/>
 </div>
 
 At the moment, the novel coronavirus (nCoV) phylogeny may not look much like a 'tree'.
@@ -233,7 +233,7 @@ Here, we assume a star-like phylogeny structure along with a Poisson distributio
 **We find that the common ancestor most likely existed between mid-Nov and the beginning of Dec 2019.**
 
 <div>
-  <img alt="graph of TMRCA estimates based on different mutation rates" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_poisson-tmrca.png"/>
+  <img alt="graph of TMRCA estimates based on different mutation rates" width="500" src="https://data.nextstrain.org/ncov_poisson-tmrca.png"/>
 </div>
 
 As the more samples are sequenced, we expect the tree to show more structure, such that the star-like phylogeny topology is no longer a good assumption.
@@ -261,12 +261,12 @@ Together with our previous estimates of the age of the outbreak and information 
 
 If we assume the outbreak started at the beginning of November 2019 (12 weeks ago), we find that R0 should range between 1.5 and 2.5, depending on how large ('n') the outbreak is now.
 <div>
-  <img alt="graph of R0 estimates with epidemic start 12 weeks ago" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-early.png"/>
+  <img alt="graph of R0 estimates with epidemic start 12 weeks ago" width="500" src="https://data.nextstrain.org/ncov_branching-R0-early.png"/>
 </div>
 
 If we assume a more recent start, at the beginning of December 2019 (8 weeks ago), the estimates for R0 range between 1.8 and 3.5:
 <div>
-  <img alt="graph of R0 estimates with epidemic start 8 weeks ago" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-recent.png"/>
+  <img alt="graph of R0 estimates with epidemic start 8 weeks ago" width="500" src="https://data.nextstrain.org/ncov_branching-R0-recent.png"/>
 </div>
 ```
 

--- a/narratives/ncov_sit-rep_2020-01-23.md
+++ b/narratives/ncov_sit-rep_2020-01-23.md
@@ -131,7 +131,7 @@ When a sequence sits on a long line on its own, like C or E, this means it has u
 A and B also have unique mutations (the green circle) not shared by the other sequences, but they are identical to each other.
 
 <div>
-  <img alt="cartoon of phylogenetic tree and corresponding alignment, with samples labelled A-E" width="500" src="https://nextstrain-data.s3.amazonaws.com/toy_alignment_tree.png"/>
+  <img alt="cartoon of phylogenetic tree and corresponding alignment, with samples labelled A-E" width="500" src="https://data.nextstrain.org/toy_alignment_tree.png"/>
 </div>
 
 At the moment, the novel coronavirus (nCoV) phylogeny may not look much like a 'tree'.
@@ -225,7 +225,7 @@ Here, we assume a star-like phylogeny structure along with a Poisson distributio
 **We find that the common ancestor most likely existed between mid-Nov and early-Dec 2019.**
 
 <div>
-  <img alt="graph of TMRCA estimates based on different mutation rates" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_poisson-tmrca.png"/>
+  <img alt="graph of TMRCA estimates based on different mutation rates" width="500" src="https://data.nextstrain.org/ncov_poisson-tmrca.png"/>
 </div>
 
 As the more samples are sequenced, we expect the tree to show more structure, such that the star-like phylogeny topology is no longer a good assumption.
@@ -251,12 +251,12 @@ Together with our previous estimates of the age of the outbreak and information 
 
 If we assume the outbreak started at the beginning of November 2019 (12 weeks ago), we find that R0 should range between 1.5 and 2.5, depending on how large ('n') the outbreak is now.
 <div>
-  <img alt="graph of R0 estimates with epidemic start 12 weeks ago" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-early.png"/>
+  <img alt="graph of R0 estimates with epidemic start 12 weeks ago" width="500" src="https://data.nextstrain.org/ncov_branching-R0-early.png"/>
 </div>
 
 If we assume a more recent start, at the beginning of December 2019 (8 weeks ago), the estimates for R0 range between 1.8 and 3.5:
 <div>
-  <img alt="graph of R0 estimates with epidemic start 8 weeks ago" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-recent.png"/>
+  <img alt="graph of R0 estimates with epidemic start 8 weeks ago" width="500" src="https://data.nextstrain.org/ncov_branching-R0-recent.png"/>
 </div>
 ```
 

--- a/narratives/ncov_sit-rep_2020-01-25.md
+++ b/narratives/ncov_sit-rep_2020-01-25.md
@@ -141,7 +141,7 @@ Others have unique or shared mutations and so sit on lines, or 'branches', going
 You can see how many mutations a branch has by hovering your mouse over it.
 ```
 
-# [Phylogenetic analysis](http://localhost:4000/ncov/2020-01-25?m=div&d=tree)
+# [Phylogenetic analysis](https://nextstrain.org/ncov/2020-01-25?m=div&d=tree)
 
 Here we present a phylogeny of 27 strains of nCoV that have been publicly shared.
 Information on how the analysis was performed is available [in this GitHub repository](github.com/nextstrain/ncov).

--- a/narratives/ncov_sit-rep_2020-01-25.md
+++ b/narratives/ncov_sit-rep_2020-01-25.md
@@ -132,7 +132,7 @@ When a sequence sits on a long line on its own, like C or E, this means it has u
 A and B also have unique mutations (the green circle) not shared by the other sequences, but they are identical to each other.
 
 <div>
-  <img alt="cartoon of phylogenetic tree and corresponding alignment, with samples labelled A-E" width="500" src="https://nextstrain-data.s3.amazonaws.com/toy_alignment_tree.png"/>
+  <img alt="cartoon of phylogenetic tree and corresponding alignment, with samples labelled A-E" width="500" src="https://data.nextstrain.org/toy_alignment_tree.png"/>
 </div>
 
 At the moment, the novel coronavirus (nCoV) phylogeny may not look much like a 'tree'.
@@ -233,7 +233,7 @@ Here, we assume a star-like phylogeny structure along with a Poisson distributio
 **We find that the common ancestor most likely existed between mid-Nov and the beginning of Dec 2019.**
 
 <div>
-  <img alt="graph of TMRCA estimates based on different mutation rates" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_poisson-tmrca.png"/>
+  <img alt="graph of TMRCA estimates based on different mutation rates" width="500" src="https://data.nextstrain.org/ncov_poisson-tmrca.png"/>
 </div>
 
 As the more samples are sequenced, we expect the tree to show more structure, such that the star-like phylogeny topology is no longer a good assumption.
@@ -261,12 +261,12 @@ Together with our previous estimates of the age of the outbreak and information 
 
 If we assume the outbreak started at the beginning of November 2019 (12 weeks ago), we find that R0 should range between 1.5 and 2.5, depending on how large ('n') the outbreak is now.
 <div>
-  <img alt="graph of R0 estimates with epidemic start 12 weeks ago" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-early.png"/>
+  <img alt="graph of R0 estimates with epidemic start 12 weeks ago" width="500" src="https://data.nextstrain.org/ncov_branching-R0-early.png"/>
 </div>
 
 If we assume a more recent start, at the beginning of December 2019 (8 weeks ago), the estimates for R0 range between 1.8 and 3.5:
 <div>
-  <img alt="graph of R0 estimates with epidemic start 8 weeks ago" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-recent.png"/>
+  <img alt="graph of R0 estimates with epidemic start 8 weeks ago" width="500" src="https://data.nextstrain.org/ncov_branching-R0-recent.png"/>
 </div>
 ```
 

--- a/narratives/ncov_sit-rep_es_2020-01-25.md
+++ b/narratives/ncov_sit-rep_es_2020-01-25.md
@@ -146,7 +146,7 @@ Otros tienen mutaciones únicas o compartidas y, por lo tanto, aparecen en las l
 Podrás ver cuántas mutaciones tiene una rama al pasar el mouse sobre ella.
 ```
 
-# [Análisis filogenético](http://localhost:4000/ncov/2020-01-25?m=div&d=tree)
+# [Análisis filogenético](https://nextstrain.org/ncov/2020-01-25?m=div&d=tree)
 
 Aquí presentamos una filogenia de 27 cepas del nCoV que se han compartido públicamente.
 La información sobre cómo se realizó el análisis está disponible [en este repositorio de GitHub](github.com/nextstrain/ncov).

--- a/narratives/ncov_sit-rep_es_2020-01-25.md
+++ b/narratives/ncov_sit-rep_es_2020-01-25.md
@@ -137,7 +137,7 @@ Cuando una secuencia se encuentra sola en una línea larga, como C o E, signific
 A y B también tienen mutaciones únicas (el círculo verde) que no comparten con las otras secuencias, pero A y B son idénticas entre sí.
 
 <div>
-  <img alt="Ilustración del árbol filogenético y del alineamiento de secuencias correspondiente, con las muestras rotuladas como A-E" width="500" src="https://nextstrain-data.s3.amazonaws.com/toy_alignment_tree.png"/>
+  <img alt="Ilustración del árbol filogenético y del alineamiento de secuencias correspondiente, con las muestras rotuladas como A-E" width="500" src="https://data.nextstrain.org/toy_alignment_tree.png"/>
 </div>
 
 Por el momento, la  filogenia del nuevo coronavirus (nCoV) en la diapositiva siguiente puede que no se parezca mucho a un 'árbol'.
@@ -237,7 +237,7 @@ Hemos asumido una estructura filogenética con forma de estrella y una distribuc
 **Encontramos que el antepasado común de los virus secuenciados probablemente existió entre mediados de noviembre y principios de diciembre de 2019.**
 
 <div>
-  <img alt="Gráfico de las estimaciones de TACMR basado en diferentes tasas de mutación" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_poisson-tmrca.png"/>
+  <img alt="Gráfico de las estimaciones de TACMR basado en diferentes tasas de mutación" width="500" src="https://data.nextstrain.org/ncov_poisson-tmrca.png"/>
 </div>
 
 A medida que se secuencian más muestras, esperamos que el árbol muestre más estructura, de modo que la topología de filogenia con forma de estrella ya no sea una suposición adecuada.
@@ -266,14 +266,14 @@ Junto con nuestras estimaciones anteriores de la 'edad' del brote y la informaci
 Si asumimos que el brote comenzó a principios de noviembre de 2019 (hace 12 semanas), encontramos que el R0 debería oscilar entre 1.5 y 2.5, dependiendo de qué tan grande ('n') sea el brote ahora.
 
 <div>
-  <img alt="Gráfico de estimaciones de R0 con el inicio del brote ocurriendo hace 12 semanas" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-early.png"/>
+  <img alt="Gráfico de estimaciones de R0 con el inicio del brote ocurriendo hace 12 semanas" width="500" src="https://data.nextstrain.org/ncov_branching-R0-early.png"/>
 </div>
 
 
 Si suponemos un comienzo más reciente, por ejemplo, a principios de diciembre de 2019 (hace 8 semanas), las estimaciones para R0 oscilan entre 1.8 y 3.5:
 
 <div>
-  <img alt="Gráfico de estimaciones de R0 con el inicio del brote ocurriendo hace 8 semanas" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-recent.png"/>
+  <img alt="Gráfico de estimaciones de R0 con el inicio del brote ocurriendo hace 8 semanas" width="500" src="https://data.nextstrain.org/ncov_branching-R0-recent.png"/>
 </div>
 ```
 

--- a/narratives/ncov_sit-rep_fr_2020-01-25.md
+++ b/narratives/ncov_sit-rep_fr_2020-01-25.md
@@ -141,7 +141,7 @@ Others have unique or shared mutations and so sit on lines, or 'branches', going
 You can see how many mutations a branch has by hovering your mouse over it.
 ```
 
-# [Phylogenetic analysis](http://localhost:4000/ncov/2020-01-25?m=div&d=tree)
+# [Phylogenetic analysis](https://nextstrain.org/ncov/2020-01-25?m=div&d=tree)
 
 Here we present a phylogeny of 27 strains of nCoV that have been publicly shared.
 Information on how the analysis was performed is available [in this GitHub repository](github.com/nextstrain/ncov).

--- a/narratives/ncov_sit-rep_fr_2020-01-25.md
+++ b/narratives/ncov_sit-rep_fr_2020-01-25.md
@@ -132,7 +132,7 @@ When a sequence sits on a long line on its own, like C or E, this means it has u
 A and B also have unique mutations (the green circle) not shared by the other sequences, but they are identical to each other.
 
 <div>
-  <img alt="cartoon of phylogenetic tree and corresponding alignment, with samples labelled A-E" width="500" src="https://nextstrain-data.s3.amazonaws.com/toy_alignment_tree.png"/>
+  <img alt="cartoon of phylogenetic tree and corresponding alignment, with samples labelled A-E" width="500" src="https://data.nextstrain.org/toy_alignment_tree.png"/>
 </div>
 
 At the moment, the novel coronavirus (nCoV) phylogeny may not look much like a 'tree'.
@@ -233,7 +233,7 @@ Here, we assume a star-like phylogeny structure along with a Poisson distributio
 **We find that the common ancestor most likely existed between mid-Nov and the beginning of Dec 2019.**
 
 <div>
-  <img alt="graph of TMRCA estimates based on different mutation rates" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_poisson-tmrca.png"/>
+  <img alt="graph of TMRCA estimates based on different mutation rates" width="500" src="https://data.nextstrain.org/ncov_poisson-tmrca.png"/>
 </div>
 
 As the more samples are sequenced, we expect the tree to show more structure, such that the star-like phylogeny topology is no longer a good assumption.
@@ -261,12 +261,12 @@ Together with our previous estimates of the age of the outbreak and information 
 
 If we assume the outbreak started at the beginning of November 2019 (12 weeks ago), we find that R0 should range between 1.5 and 2.5, depending on how large ('n') the outbreak is now.
 <div>
-  <img alt="graph of R0 estimates with epidemic start 12 weeks ago" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-early.png"/>
+  <img alt="graph of R0 estimates with epidemic start 12 weeks ago" width="500" src="https://data.nextstrain.org/ncov_branching-R0-early.png"/>
 </div>
 
 If we assume a more recent start, at the beginning of December 2019 (8 weeks ago), the estimates for R0 range between 1.8 and 3.5:
 <div>
-  <img alt="graph of R0 estimates with epidemic start 8 weeks ago" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-recent.png"/>
+  <img alt="graph of R0 estimates with epidemic start 8 weeks ago" width="500" src="https://data.nextstrain.org/ncov_branching-R0-recent.png"/>
 </div>
 ```
 

--- a/narratives/ncov_sit-rep_zh_2020-01-25.md
+++ b/narratives/ncov_sit-rep_zh_2020-01-25.md
@@ -134,7 +134,7 @@ A和B也具有其他序列不共有的独特突变（绿色圆圈），但彼此
 
 ```
 
-# [系统发生树分析](http://localhost:4000/ncov/2020-01-25?m=div&d=tree)
+# [系统发生树分析](https://nextstrain.org/ncov/2020-01-25?m=div&d=tree)
 
 这里我们呈现公开共享的27种新型冠状病毒的系统发生树。 [GitHub存储库](github.com/nextstrain/ncov)中提供了有关如何执行分析的资料。
 

--- a/narratives/ncov_sit-rep_zh_2020-01-25.md
+++ b/narratives/ncov_sit-rep_zh_2020-01-25.md
@@ -124,7 +124,7 @@ abstract: "这份报告使用了来自GISAID和Genbank公开共享的2019新型�
 A和B也具有其他序列不共有的独特突变（绿色圆圈），但彼此相同。
 
 <div>
-  <img alt="cartoon of phylogenetic tree and corresponding alignment, with samples labelled A-E" width="500" src="https://nextstrain-data.s3.amazonaws.com/toy_alignment_tree.png"/>
+  <img alt="cartoon of phylogenetic tree and corresponding alignment, with samples labelled A-E" width="500" src="https://data.nextstrain.org/toy_alignment_tree.png"/>
 </div>
 
 目前，新型冠状病毒的系统发生树可能看起来并不像“树”。
@@ -219,7 +219,7 @@ A和B也具有其他序列不共有的独特突变（绿色圆圈），但彼此
 **我们发现最近共同祖先出现在于2019年11月中旬和12月上旬。**
 
 <div>
-  <img alt="基于不同突变率的TMRA估计图" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_poisson-tmrca.png"/>
+  <img alt="基于不同突变率的TMRA估计图" width="500" src="https://data.nextstrain.org/ncov_poisson-tmrca.png"/>
 </div>
 
 随着更多样本将被测序，我们估计该系统发生树会呈现更多的结构，导致星状拓扑结构将不再是一个好的假设模型。
@@ -246,12 +246,12 @@ A和B也具有其他序列不共有的独特突变（绿色圆圈），但彼此
 
 如果我们假设爆发起始于2019年11月上旬（12星期之前），我们发现R0值将会在 1.5 到 2.5 范围内, 此范围主要取决于现在爆发有多大（'n'）。
 <div>
-  <img alt="流行开始于12星期前情况下的R0值预估图" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-early.png"/>
+  <img alt="流行开始于12星期前情况下的R0值预估图" width="500" src="https://data.nextstrain.org/ncov_branching-R0-early.png"/>
 </div>
 
 如果我们假设爆发起始于更近的2019年12月（8个星期前），R0值的预估将会在 1.8 and 3.5之间：
 <div>
-  <img alt="流行开始于8星期前情况下的R0值预估图" width="500" src="https://nextstrain-data.s3.amazonaws.com/ncov_branching-R0-recent.png"/>
+  <img alt="流行开始于8星期前情况下的R0值预估图" width="500" src="https://data.nextstrain.org/ncov_branching-R0-recent.png"/>
 </div>
 ```
 


### PR DESCRIPTION
Two changes:

1. Switch back to data.nextstrain.org now that it supports HTTPS.
    Not an urgent change, but loading will be faster (and cheaper) from CloudFront than S3.

2. Fix mistaken references to localhost:4000