### PR TITLE
Remove extra period in zh narrative

### DIFF
--- a/narratives/ncov_sit-rep_zh_2020-01-30.md
+++ b/narratives/ncov_sit-rep_zh_2020-01-30.md
@@ -1,5 +1,5 @@
 ---
-title: 新型冠状病毒传播基因组分析。 状况报告2020-01-30。
+title: 新型冠状病毒传播基因组分析。 状况报告2020-01-30
 authors: "Trevor Bedford, Richard Neher, James Hadfield, Emma Hodcroft, Misja Ilcisin, Nicola Müller, Alvin X. Han, Fengjun Zhang, Wei Ding"
 authorLinks: "https://nextstrain.org"
 affiliations: "Fred Hutch, Seattle, USA and Biozentrum, Basel, Switzerland"


### PR DESCRIPTION
Cosmetic change to [nextstrain.org](nextstrain.org) only. 
![Screen Shot 2020-02-01 at 12 28 33 PM](https://user-images.githubusercontent.com/4110995/73598572-f44fd800-44ee-11ea-9e0a-878ad03bd548.png)
