### PR TITLE
Phylogeo

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -249,7 +249,7 @@ rule traits:
     output:
         node_data = "results/traits.json",
     params:
-        columns = "country",
+        columns = "division",
         sampling_bias_correction = 2
     shell:
         """

--- a/config/weights.tsv
+++ b/config/weights.tsv
@@ -1,0 +1,13 @@
+China	1.0
+Taiwan	0.1
+Thailand	0.1
+Japan	0.1
+South Korea	0.1
+Singapore	0.1
+Australia	0.1
+France	0.1
+Belgium	0.1
+Germany	0.1
+United Kingdom	0.1
+Finland	0.1
+USA	0.1

--- a/config/weights.tsv
+++ b/config/weights.tsv
@@ -1,4 +1,4 @@
-division	Hubei	50.0
+division	Hubei	100.0
 division	Jiangxi	1.0
 division	Chongqing	1.0
 division	Sichuan	1.0

--- a/config/weights.tsv
+++ b/config/weights.tsv
@@ -1,13 +1,30 @@
-China	1.0
-Taiwan	0.1
-Thailand	0.1
-Japan	0.1
-South Korea	0.1
-Singapore	0.1
-Australia	0.1
-France	0.1
-Belgium	0.1
-Germany	0.1
-United Kingdom	0.1
-Finland	0.1
-USA	0.1
+division	Hubei	50.0
+division	Jiangxi	1.0
+division	Chongqing	1.0
+division	Sichuan	1.0
+division	Yunnan	1.0
+division	Jiangsu	1.0
+division	Zhejiang	1.0
+division	Guangdong	1.0
+division	Taiwan	1.0
+division	Nonthaburi	1.0
+division	Aichi	1.0
+division	Tokyo	1.0
+division	Kyoto	1.0
+division	Gyeonggi	1.0
+division	Singapore	1.0
+division	Thanh Hoa	1.0
+division	Queensland	1.0
+division	New South Wales	1.0
+division	Victoria	1.0
+division	Ile De France	1.0
+division	Flanders	1.0
+division	Bavaria	1.0
+division	England	1.0
+division	Lapland	1.0
+division	Washington	1.0
+division	California	1.0
+division	Arizona	1.0
+division	Illinois	1.0
+division	Wisconsin	1.0
+division	Massachusetts	1.0


### PR DESCRIPTION
Include phylogeographic reconstruction of `division`. This requires running augur with https://github.com/nextstrain/augur/pull/431 + https://github.com/nextstrain/augur/pull/443.

We likely need to monitor this to make sure it's behaving as intended, but I think is a big step up.