### PR TITLE
Take travel history into account when reconstructing Division across the tree

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -304,6 +304,20 @@ rule export:
             --output {output.auspice_json}
         """
 
+rule incorporate_travel_history:
+    message: "Adjusting main auspice JSON to take into account travel history"
+    input:
+        lat_longs = rules.recode_lat_longs.output.lat_longs,
+        colors = rules.colors.output.colors,
+        auspice_json = rules.export.output.auspice_json
+    output:
+        auspice_json = "results/ncov_with_accessions_and_travel_branches.json"
+    shell:
+        """
+        python3 ./scripts/modify_tree_according_to_division_exposure.py \
+            {input.auspice_json} {input.colors} {input.lat_longs} {output.auspice_json}
+        """
+
 rule export_gisaid:
     message: "Exporting data files for for auspice"
     input:
@@ -363,9 +377,9 @@ rule export_zh:
         """
 
 rule fix_colorings:
-    message: "Remove extraneous colorings"
+    message: "Remove extraneous colorings for main build"
     input:
-        auspice_json = rules.export.output.auspice_json
+        auspice_json = rules.incorporate_travel_history.output.auspice_json
     output:
         auspice_json = "auspice/ncov.json"
     shell:
@@ -376,7 +390,7 @@ rule fix_colorings:
         """
 
 rule fix_colorings_gisaid:
-    message: "Remove extraneous colorings"
+    message: "Remove extraneous colorings for the GISAID build"
     input:
         auspice_json = rules.export_gisaid.output.auspice_json
     output:
@@ -389,7 +403,7 @@ rule fix_colorings_gisaid:
         """
 
 rule fix_colorings_zh:
-    message: "Remove extraneous colorings"
+    message: "Remove extraneous colorings for the Chinese language build"
     input:
         auspice_json = rules.export_zh.output.auspice_json
     output:
@@ -404,7 +418,7 @@ rule fix_colorings_zh:
 rule dated_json:
     message: "Copying dated Auspice JSON"
     input:
-        auspice_json = rules.export.output.auspice_json
+        auspice_json = rules.fix_colorings.output.auspice_json
     output:
         dated_auspice_json = rules.all.input.dated_auspice_json
     shell:

--- a/Snakefile
+++ b/Snakefile
@@ -217,7 +217,7 @@ rule traits:
     output:
         node_data = "results/traits.json",
     params:
-        columns = "division",
+        columns = "division_exposure",
         sampling_bias_correction = 2.5
     shell:
         """
@@ -263,6 +263,18 @@ rule colors:
             --output {output.colors}
         """
 
+rule recode_lat_longs:
+    message: "Copying division lat/longs to division_exposure"
+    input:
+        lat_longs = files.lat_longs
+    output:
+        lat_longs = "results/lat_longs.tsv"
+    shell:
+        """
+        cp {input.lat_longs} {output.lat_longs} && \
+        grep 'division' {input.lat_longs} | sed 's/division/division_exposure/' >> {output.lat_longs}
+        """
+
 rule export:
     message: "Exporting data files for for auspice"
     input:
@@ -271,10 +283,10 @@ rule export:
         branch_lengths = rules.refine.output.node_data,
         nt_muts = rules.ancestral.output.node_data,
         aa_muts = rules.translate.output.node_data,
-        # traits = rules.traits.output.node_data,
+        traits = rules.traits.output.node_data,
         auspice_config = files.auspice_config,
         colors = rules.colors.output.colors,
-        lat_longs = files.lat_longs,
+        lat_longs = rules.recode_lat_longs.output.lat_longs,
         description = files.description,
         clades = rules.clades.output.clade_data
     output:
@@ -284,7 +296,7 @@ rule export:
         augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \
-            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.clades} \
+            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.traits} {input.clades} \
             --auspice-config {input.auspice_config} \
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \
@@ -300,10 +312,10 @@ rule export_gisaid:
         branch_lengths = rules.refine.output.node_data,
         nt_muts = rules.ancestral.output.node_data,
         aa_muts = rules.translate.output.node_data,
-        # traits = rules.traits.output.node_data,
+        traits = rules.traits.output.node_data,
         auspice_config = files.auspice_config_gisaid,
         colors = rules.colors.output.colors,
-        lat_longs = files.lat_longs,
+        lat_longs = rules.recode_lat_longs.output.lat_longs,
         description = files.description,
         clades = rules.clades.output.clade_data
     output:
@@ -313,7 +325,7 @@ rule export_gisaid:
         augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \
-            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.clades} \
+            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.traits} {input.clades} \
             --auspice-config {input.auspice_config} \
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \
@@ -329,10 +341,10 @@ rule export_zh:
         branch_lengths = rules.refine.output.node_data,
         nt_muts = rules.ancestral.output.node_data,
         aa_muts = rules.translate.output.node_data,
-        # traits = rules.traits.output.node_data,
+        traits = rules.traits.output.node_data,
         auspice_config = files.auspice_config_zh,
         colors = rules.colors.output.colors,
-        lat_longs = files.lat_longs,
+        lat_longs = rules.recode_lat_longs.output.lat_longs,
         description = files.description_zh,
         clades = rules.clades.output.clade_data
     output:
@@ -342,7 +354,7 @@ rule export_zh:
         augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \
-            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.clades} \
+            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.traits} {input.clades} \
             --auspice-config {input.auspice_config} \
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \

--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -13,6 +13,11 @@
       "type": "categorical"
     },
     {
+      "key": "division_exposure", 
+      "title": "Admin division of suspected COVID-19 exposure", 
+      "type": "categorical" 
+    },
+    {
       "key": "country",
       "title": "Country",
       "type": "categorical"
@@ -57,18 +62,23 @@
   "geo_resolutions": [
     "location",
     "division",
+    { 
+      "key": "division_exposure", 
+      "title": "Admin division of suspected COVID-19 exposure" 
+    }, 
     "country"
   ],
   "display_defaults": {
     "color_by": "division",
     "distance_measure": "num_date",
-    "geo_resolution": "division",
+    "geo_resolution": "division_exposure",
     "map_triplicate": true,
     "branch_label": "none"
   },
   "filters": [
     "location",
     "division",
+    "division_exposure",
     "country",
     "host",
     "author",

--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -13,11 +13,6 @@
       "type": "categorical"
     },
     {
-      "key": "division_exposure", 
-      "title": "Admin division of suspected COVID-19 exposure", 
-      "type": "categorical" 
-    },
-    {
       "key": "country",
       "title": "Country",
       "type": "categorical"
@@ -62,16 +57,12 @@
   "geo_resolutions": [
     "location",
     "division",
-    { 
-      "key": "division_exposure", 
-      "title": "Admin division of suspected COVID-19 exposure" 
-    }, 
     "country"
   ],
   "display_defaults": {
-    "color_by": "division_exposure",
+    "color_by": "division",
     "distance_measure": "num_date",
-    "geo_resolution": "division_exposure",
+    "geo_resolution": "division",
     "map_triplicate": true,
     "branch_label": "none"
   },

--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -69,7 +69,7 @@
     "country"
   ],
   "display_defaults": {
-    "color_by": "division",
+    "color_by": "division_exposure",
     "distance_measure": "num_date",
     "geo_resolution": "division_exposure",
     "map_triplicate": true,

--- a/config/auspice_config_gisaid.json
+++ b/config/auspice_config_gisaid.json
@@ -67,6 +67,7 @@
   "filters": [
     "location",
     "division",
+    "division_exposure",
     "country",
     "host",
     "author",

--- a/config/auspice_config_zh.json
+++ b/config/auspice_config_zh.json
@@ -69,6 +69,7 @@
   "filters": [
     "location",
     "division",
+    "division_exposure",
     "country",
     "host",
     "author",

--- a/config/lat_longs.tsv
+++ b/config/lat_longs.tsv
@@ -114,6 +114,7 @@ division	Hong Kong	22.3964	114.1095
 division	Hubei	31.095477	112.676644
 division	Ile De France	48.724751	2.491522
 division	Illinois	40.088552	-89.301876
+division	Iran	34.5732	51.876
 division	Japan	35.68536	139.75309
 division	Jiangsu	33.077761	119.825116
 division	Jiangxi	27.458973	115.535326

--- a/config/ordering.tsv
+++ b/config/ordering.tsv
@@ -111,6 +111,7 @@ division	Seoul
 division	South Korea
 division	Kathmandu
 division	Kerala
+division	Iran
 division	Thanh Hoa
 division	Sihanoukville
 division	Nonthaburi

--- a/config/ordering.tsv
+++ b/config/ordering.tsv
@@ -116,12 +116,11 @@ division	Thanh Hoa
 division	Sihanoukville
 division	Nonthaburi
 division	Singapore
-division	Gyeonggi
 division	Queensland
 division	New South Wales
 division	Victoria
 division	Auckland
-division	Ile De France
+division	Ile de France
 division	Auvergne Rhone Alpes
 division	Flanders
 division	Bavaria
@@ -130,7 +129,7 @@ division	North Rhine Westphalia
 division	Andel
 division	Utrecht
 division	Drenthe
-division	North brabant
+division	North Brabant
 division	Flevoland
 division	South Holland
 division	North Holland

--- a/config/weights.tsv
+++ b/config/weights.tsv
@@ -25,7 +25,7 @@ division	Kathmandu	1.0
 division	Kyoto	1.0
 division	Lapland	1.0
 division	Lazio	1.0
-division	Lombardy	100.0
+division	Lombardy	20.0
 division	Mexico City	1.0
 division	Massachusetts	1.0
 division	Nara	1.0

--- a/scripts/assign-colors.py
+++ b/scripts/assign-colors.py
@@ -51,14 +51,3 @@ if __name__ == '__main__':
             for trait_value, color in zipped:
                 f.write(trait_name + "\t" + trait_value + "\t" + color + "\n")
             f.write("\n")
-
-            # We want `division_exposure` to mirror `division` in order to improve
-            # comprehension when switching between the two. This means that _all_
-            # demes exclusive to `division_exposure` should be added to the ordering
-            # TSV under `division`. `augur export` won't export values which don't appear
-            # in the tree, so the legend won't be cluttered, but the colors will be
-            # consistent
-            if trait_name == "division":
-                for trait_value, color in zipped:
-                    f.write(trait_name + "_exposure\t" + trait_value + "\t" + color + "\n")
-                f.write("\n")

--- a/scripts/fix-colorings.py
+++ b/scripts/fix-colorings.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
     parser.add_argument('--output', type=str, metavar="JSON", required=True, help="output Auspice JSON")
     args = parser.parse_args()
 
-    with open(args.input, "rU") as f:
+    with open(args.input, "r") as f:
         input_json = json.load(f)
 
     fixed_colorings = []

--- a/scripts/modify_tree_according_to_division_exposure.py
+++ b/scripts/modify_tree_according_to_division_exposure.py
@@ -1,0 +1,103 @@
+import json
+import sys
+from functools import partial
+
+def traverse(node, fun):
+    """ Traverse the tree calling `fun(node)` on each node """
+    fun(node)
+    for child in node.get("children", []):
+        traverse(child, fun)
+
+def modify_branches(node):
+    """ Traverse the tree calling `fun` on each child """
+    for idx, child in enumerate(node.get("children", [])):
+        node["children"][idx] = modify(child)
+        modify_branches(child)
+
+
+def modify(node):
+    """
+    Modify the branch to NODE, if NODE is a terminal node and the `division_exposure`
+    of NODE differs from the `division`.
+    This creates an intermediate branch, with a single child, such that we have
+    PARENT-INTERMEDIATE-NODE.
+    """
+    if "children" in node:
+        return node
+    division = node["node_attrs"].get("division", {}).get("value", "")
+    recoded = node["node_attrs"].get("division_exposure", {}).get("value", "")
+    if not division or not recoded or division == recoded:
+        return node
+
+
+    ## Make a new node which is the INTERMEDIATE (i.e. a single child, which is `node` with slight modifications)
+    n = {
+        "name": node["name"]+"_travel_history",
+        "node_attrs": {
+            "div": node["node_attrs"]["div"],
+            "num_date": node["node_attrs"]["num_date"],
+            "division_exposure": node["node_attrs"]["division_exposure"]
+        },
+        "children": [node]
+    }
+
+    # change actual NODE division_exposure to have collection division 
+    node["node_attrs"]["division_exposure"] = node["node_attrs"]["division"]
+    return n
+
+
+def collect_division_exposures(values, node):
+    v = node["node_attrs"].get("division_exposure", {}).get("value", None)
+    if v:
+        values.add(v)
+
+
+def update_colors(colorings, values_wanted, colors):
+    trait = [x for x in colorings if x["key"]=="division_exposure"][0]
+    values_present = {x[0] for x in trait["scale"]}
+    for x in values_wanted:
+        if x not in values_present:
+            print(x, colors[x])
+            trait["scale"].append([x, colors[x]])
+
+def update_latlongs(geo_resolutions, values_wanted, latlongs):
+    trait = [x for x in geo_resolutions if x["key"]=="division_exposure"][0]
+    for x in values_wanted:
+        if x not in trait["demes"].keys():
+            print(x, latlongs[x])
+            trait["demes"][x] = latlongs[x]
+
+if __name__ == '__main__':
+
+    with open(sys.argv[1]) as fh:
+        input_json = json.load(fh)
+
+    # Read colorings & lat-longs
+    colors = {}
+    with open(sys.argv[2]) as fh:
+        for line in fh:
+            fields = line.strip().split("\t")
+            if len(fields)==3 and fields[0]=="division_exposure":
+                colors[fields[1]] = fields[2]
+    latlongs = {}
+    with open(sys.argv[3]) as fh:
+        for line in fh:
+            fields = line.strip().split("\t")
+            if len(fields)==4 and fields[0]=="division":
+                latlongs[fields[1]] = {"latitude": float(fields[2]), "longitude": float(fields[3])}
+
+    # Modify branches
+    modify_branches(input_json["tree"])
+
+    # Collect all `division_exposure` values (we may have created ones which didn't previously exist)
+    division_exposure_values = set()
+    traverse(input_json["tree"], partial(collect_division_exposures, division_exposure_values))
+
+    # Ensure the colors & lat-longsare up-to-date
+    update_colors(input_json["meta"]["colorings"], division_exposure_values, colors)
+    update_latlongs(input_json["meta"]["geo_resolutions"], division_exposure_values, latlongs)
+
+    with open(sys.argv[4], 'w') as fh:
+        json.dump(input_json, fh, indent=2)
+
+


### PR DESCRIPTION
This PR modifies `division` to take into account travel history. 