### PR TITLE
Add a "deploy_to_staging" rule to be used by automatic builds

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -3,6 +3,8 @@ def get_todays_date():
     date = datetime.today().strftime('%Y-%m-%d')
     return date
 
+configfile: "config/Snakefile.yaml"
+
 rule all:
     input:
         auspice_json = "auspice/ncov.json",
@@ -412,6 +414,25 @@ rule branching_process_R0:
                     --output {output[1]}
         """
 
+rule deploy_to_staging:
+    input:
+        *rules.all.input
+    params:
+        slack_message = json.dumps({"text":"Deployed <https://nextstrain.org/staging/ncov|nextstrain.org/staging/ncov>"}),
+        slack_webhook = config["slack_webhook"] or "",
+        s3_staging_url = config["s3_staging_url"]
+    shell:
+        """
+        nextstrain deploy {params.s3_staging_url:q} {input:q}
+
+        if [[ -n "{params.slack_webhook}" ]]; then
+            curl {params.slack_webhook:q} \
+                --header 'Content-type: application/json' \
+                --data-raw {params.slack_message:q} \
+                --fail --silent --show-error \
+                --include
+        fi
+        """
 
 rule clean:
     message: "Removing directories: {params}"

--- a/config/Snakefile.yaml
+++ b/config/Snakefile.yaml
@@ -1,0 +1,6 @@
+# This file contains defaults for the "config" object used in the Snakefile.
+# To temporarily override or provide a value, you can use snakemake's --config
+# or --configfile options.
+---
+s3_staging_url: s3://nextstrain-staging
+slack_webhook: ~


### PR DESCRIPTION
Uploads files to an S3 bucket for nextstrain.org and optionally sends a
Slack alert to a configured webhook.

The S3 bucket defaults to s3://nextstrain-staging, the live staging
source, but it can be overridden for testing using snakemake's --config
or --configfile options.

The optional Slack webhook can be provided using the same config
options.  By default no message is sent.