### PR TITLE
Color by Exposure History

### DIFF
--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -57,6 +57,9 @@
     },
     {
       "key": "genbank_accession"
+    },
+    {
+      "key": "division_exposure"
     }
   ],
   "geo_resolutions": [

--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -59,7 +59,9 @@
       "key": "genbank_accession"
     },
     {
-      "key": "division_exposure"
+      "key": "division_exposure",
+      "title": "Exposure History",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [

--- a/config/auspice_config_gisaid.json
+++ b/config/auspice_config_gisaid.json
@@ -55,6 +55,11 @@
     },
     {
       "key": "genbank_accession"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Exposure History",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [

--- a/config/auspice_config_zh.json
+++ b/config/auspice_config_zh.json
@@ -57,6 +57,11 @@
     },
     {
       "key": "genbank_accession"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Exposure History",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [

--- a/scripts/modify_tree_according_to_division_exposure.py
+++ b/scripts/modify_tree_according_to_division_exposure.py
@@ -42,6 +42,7 @@ def modify(node):
     }
 
     # change actual NODE division_exposure to have collection division 
+    node["node_attrs"]["division_exposure_backup"] = node["node_attrs"]["division_exposure"]
     node["node_attrs"]["division_exposure"] = node["node_attrs"]["division"]
     return n
 
@@ -60,8 +61,13 @@ def switch_division(node):
     if (division and not division_exposure):
         raise Exception("Where there's division we should always have division_exposure")
     if division_exposure:
+      if node["name"] == "Germany/BavPat2/2020":
+        import ipdb; ipdb.set_trace()
       node["node_attrs"]["division"] = division_exposure
-      del node["node_attrs"]["division_exposure"]
+      if "division_exposure_backup" in node["node_attrs"] and node["node_attrs"]["division_exposure_backup"]["value"] != node["node_attrs"]["division_exposure"]["value"]:
+        node["node_attrs"]["division_exposure"]["value"] = node["node_attrs"]["division_exposure_backup"]["value"]
+      else:
+        del node["node_attrs"]["division_exposure"]
 
 def reset_colors(colorings, values_wanted, colors):
     """

--- a/scripts/modify_tree_according_to_division_exposure.py
+++ b/scripts/modify_tree_according_to_division_exposure.py
@@ -67,6 +67,7 @@ def switch_division(node):
       # if has a 'real' exposure history, then put this back in place now! Delete all others.
       if "division_exposure_backup" in node["node_attrs"] and node["node_attrs"]["division_exposure_backup"]["value"] != node["node_attrs"]["division_exposure"]["value"]:
         node["node_attrs"]["division_exposure"]["value"] = node["node_attrs"]["division_exposure_backup"]["value"]
+        del node["node_attrs"]["division_exposure_backup"]
       else:
         del node["node_attrs"]["division_exposure"]
 

--- a/scripts/modify_tree_according_to_division_exposure.py
+++ b/scripts/modify_tree_according_to_division_exposure.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from functools import partial
+import copy
 
 def traverse(node, fun):
     """ Traverse the tree calling `fun(node)` on each node """
@@ -41,8 +42,9 @@ def modify(node):
         "children": [node]
     }
 
-    # change actual NODE division_exposure to have collection division 
+    # Story a backup of the original exposure, to put back in later
     node["node_attrs"]["division_exposure_backup"] = node["node_attrs"]["division_exposure"]
+    # change actual NODE division_exposure to have collection division
     node["node_attrs"]["division_exposure"] = node["node_attrs"]["division"]
     return n
 
@@ -61,9 +63,8 @@ def switch_division(node):
     if (division and not division_exposure):
         raise Exception("Where there's division we should always have division_exposure")
     if division_exposure:
-      if node["name"] == "Germany/BavPat2/2020":
-        import ipdb; ipdb.set_trace()
-      node["node_attrs"]["division"] = division_exposure
+      node["node_attrs"]["division"] = copy.copy(division_exposure)
+      # if has a 'real' exposure history, then put this back in place now! Delete all others.
       if "division_exposure_backup" in node["node_attrs"] and node["node_attrs"]["division_exposure_backup"]["value"] != node["node_attrs"]["division_exposure"]["value"]:
         node["node_attrs"]["division_exposure"]["value"] = node["node_attrs"]["division_exposure_backup"]["value"]
       else:


### PR DESCRIPTION
This PR adjusts @jameshadfield 's `modify_tree_according_to_divsion_exposure.py` simply to store the original division exposure before processing, then, if it's "real" (if there's a difference between the stored `division_exposure` and the `division`), then to put this 'back' on as an attribute. 

Allows to colour by 'Exposure History':
![image](https://user-images.githubusercontent.com/14290674/76900365-7d518180-6899-11ea-8867-6f961348672d.png)
