### PR TITLE
make sequence and metadata input files configurable

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -34,8 +34,8 @@ files = rules.files.params
 rule download:
     message: "Downloading metadata and fasta files from S3"
     output:
-        sequences = "data/sequences.fasta",
-        metadata = "data/metadata.tsv"
+        sequences = config["sequences"],
+        metadata = config["metadata"]
     shell:
         """
         aws s3 cp s3://nextstrain-ncov-private/sequences.fasta data/

--- a/Snakefile
+++ b/Snakefile
@@ -38,8 +38,8 @@ rule download:
         metadata = config["metadata"]
     shell:
         """
-        aws s3 cp s3://nextstrain-ncov-private/sequences.fasta data/
-        aws s3 cp s3://nextstrain-ncov-private/metadata.tsv data/
+        aws s3 cp s3://nextstrain-ncov-private/sequences.fasta {output.sequences:q}
+        aws s3 cp s3://nextstrain-ncov-private/metadata.tsv {output.metadata:q}
         """
 
 rule filter:

--- a/config/Snakefile.yaml
+++ b/config/Snakefile.yaml
@@ -4,3 +4,5 @@
 ---
 s3_staging_url: s3://nextstrain-staging
 slack_webhook: ~
+sequences: "data/sequences.fasta"
+metadata: "data/metadata.tsv"


### PR DESCRIPTION
Introduces configurable parameters for sequences.fasta and metadata.tsv. This allows custom input file names or input files outside the git repository. Example:

```
snakemake -p --config metadata=/san/ncov/mymetadata.tsv sequences=/san/ncov/mysequences.fasta
```

Advantage: `git pull` does not return conflicts because of uncommited changes.