### PR TITLE
update for hCoV/nCoV capitalization in new seqs

### DIFF
--- a/scripts/normalize_gisaid_fasta.sh
+++ b/scripts/normalize_gisaid_fasta.sh
@@ -25,7 +25,7 @@ echo "Normalizing GISAID file $GISAID_SARSCOV2_IN to $GISAID_SARSCOV2_OUT (min l
 # Eliminate duplicate sequences (keep only the first seen)
 
 #cat $GISAID_SARSCOV2_IN |
-	sed 's/^>hCoV-19\//>/g' $GISAID_SARSCOV2_IN |	# remove leading BetaCo[vV]
+	sed 's/^>[hn]Co[Vv]-19\//>/g' $GISAID_SARSCOV2_IN |	# remove leading BetaCo[vV]
 	sed 's/ //g' |					# remove embedded spaces
 	sed 's/|.*$//' | 				# remove trailing metadata
 	awk "BEGIN{RS=\">\";FS=\"\n\"}length>$MIN_LENGTH{print \">\"\$0}" |	# remove short seqs

--- a/scripts/normalize_gisaid_fasta.sh
+++ b/scripts/normalize_gisaid_fasta.sh
@@ -12,8 +12,8 @@ fi
 
 if [[ -z "$MIN_LENGTH" ]]
 then
-	echo "Using default minimum length of 15000"
-	MIN_LENGTH=15000
+	echo "Using default minimum length of 25000"
+	MIN_LENGTH=25000
 fi
 
 echo "Normalizing GISAID file $GISAID_SARSCOV2_IN to $GISAID_SARSCOV2_OUT (min length $MIN_LENGTH)"

--- a/scripts/normalize_gisaid_fasta.sh
+++ b/scripts/normalize_gisaid_fasta.sh
@@ -18,14 +18,14 @@ fi
 
 echo "Normalizing GISAID file $GISAID_SARSCOV2_IN to $GISAID_SARSCOV2_OUT (min length $MIN_LENGTH)"
 
-# Remove leading 'BetaCoV' and 'BetaCov' from sequence names
+# Remove leading virus name prefix from sequence names
 # Remove embedded spaces in sequence names (Hong Kong sequences)
 # Remove trailing |EPI_ISL_id|datestamp from sequence names
 # Remove sequences shorter than minimum length
 # Eliminate duplicate sequences (keep only the first seen)
 
 #cat $GISAID_SARSCOV2_IN |
-	sed 's/^>[hn]Co[Vv]-19\//>/g' $GISAID_SARSCOV2_IN |	# remove leading BetaCo[vV]
+	sed 's/^>[hn]Co[Vv]-19\//>/g' $GISAID_SARSCOV2_IN |	# remove leading prefix
 	sed 's/ //g' |					# remove embedded spaces
 	sed 's/|.*$//' | 				# remove trailing metadata
 	awk "BEGIN{RS=\">\";FS=\"\n\"}length>$MIN_LENGTH{print \">\"\$0}" |	# remove short seqs


### PR DESCRIPTION
A recent batch of Netherlands sequences included alternate capitalization in the sequence name prefix ("hCov-19" instead of "hCoV-19") and sequences from Georgia used the prefix "nCoV-19".

This pull request changes the sed commands rewriting the sequence names to support these new sequences by making the 'v' comparison case-insensitive and accepting an 'n' in place of the 'h'.