### PR TITLE
3/20 sitrep: remove reference to color of Canadian sequence

### DIFF
--- a/narratives/ncov_sit-rep_2020-03-20.md
+++ b/narratives/ncov_sit-rep_2020-03-20.md
@@ -129,7 +129,7 @@ So, when reading this narrative, keep in mind that the size of each circle on th
 
 Identifying where a given case was infected is important for understanding which areas are experiencing local transmission versus primarily travel-associated cases. Sequence data can help us differentiate between these scenarios.
 <br><br>
-Here, the tree is colored by the travel history of a case (when known). Looking at the green Canadian sequence in the middle, we see that they have a reported travel history to Europe. This infection groups with other European sequences, showing that this case almost certainly is a travel-related infection.
+Here, the tree is colored by the travel history of a case (when known). Looking at the Canadian sequence from March 5th (near the middle of the tree), we see that they have a reported travel history to Europe. This infection groups with other European sequences, showing that this case almost certainly is a travel-related infection.
 
 <!-- ############ SLIDE BREAK ############# -->
 <!-- This is left-side text 7 -->


### PR DESCRIPTION
Removed reference to the color of the Canadian sequence on slide 6. 

Colorings for travel history are currently not consistent across browsers (this is probably a bug). On my laptop, the sequence looks yellow (Firefox) or blue (chrome). So long as this is true, color shouldn't be used to identify sequences when coloring by division_exposure.

I switched to identifying the sequence by date, but feel free to change my wording, or fix this in another way! Just wanted to let you know. @sidneymbell  @cassiawag 

---
Different colorings by division_exposure in the narrative:

Yellow (in Firefox)
![yellow_firefox](https://user-images.githubusercontent.com/804366/77223275-41781f80-6b18-11ea-8ac0-fa44fc7fc86b.png)

Blue (in Chrome)
![blue_chrome](https://user-images.githubusercontent.com/804366/77223258-142b7180-6b18-11ea-8f53-96cf01fcf814.png)
