### PR TITLE
Annotate haplotype status and tip frequencies

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -240,6 +240,22 @@ rule ancestral:
             --infer-ambiguous
         """
 
+rule haplotype_status:
+    message: "Annotating haplotype status relative to {params.reference_node_name}"
+    input:
+        nt_muts = rules.ancestral.output.node_data
+    output:
+        node_data = "results/haplotype_status.json"
+    params:
+        reference_node_name = "USA/WA1/2020"
+    shell:
+        """
+        python3 scripts/annotate-haplotype-status.py \
+            --ancestral-sequences {input.nt_muts} \
+            --reference-node-name {params.reference_node_name:q} \
+            --output {output.node_data}
+        """
+
 rule translate:
     message: "Translating amino acid sequences"
     input:
@@ -336,6 +352,7 @@ rule export:
         metadata = rules.download.output.metadata,
         branch_lengths = rules.refine.output.node_data,
         nt_muts = rules.ancestral.output.node_data,
+        haplotype_status = rules.haplotype_status.output.node_data,
         aa_muts = rules.translate.output.node_data,
         traits = rules.traits.output.node_data,
         auspice_config = files.auspice_config,
@@ -351,7 +368,7 @@ rule export:
         augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \
-            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.traits} {input.clades} {input.recency} \
+            --node-data {input.branch_lengths} {input.nt_muts} {input.haplotype_status} {input.aa_muts} {input.traits} {input.clades} {input.recency} \
             --auspice-config {input.auspice_config} \
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \

--- a/Snakefile
+++ b/Snakefile
@@ -354,14 +354,21 @@ rule tip_frequencies:
         metadata = rules.download.output.metadata
     output:
         tip_frequencies_json = "auspice/ncov_tip-frequencies.json"
+    params:
+        min_date = 2020.0,
+        pivot_interval = 1,
+        narrow_bandwidth = 0.05,
+        proportion_wide = 0.0
     shell:
         """
         augur frequencies \
             --method kde \
             --metadata {input.metadata} \
             --tree {input.tree} \
-            --pivot-interval 1 \
-            --censored \
+            --min-date {params.min_date} \
+            --pivot-interval {params.pivot_interval} \
+            --narrow-bandwidth {params.narrow_bandwidth} \
+            --proportion-wide {params.proportion_wide} \
             --output {output.tip_frequencies_json}
         """
 
@@ -372,7 +379,6 @@ rule export:
         metadata = rules.download.output.metadata,
         branch_lengths = rules.refine.output.node_data,
         nt_muts = rules.ancestral.output.node_data,
-        haplotype_status = rules.haplotype_status.output.node_data,
         aa_muts = rules.translate.output.node_data,
         traits = rules.traits.output.node_data,
         auspice_config = files.auspice_config,
@@ -388,7 +394,7 @@ rule export:
         augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \
-            --node-data {input.branch_lengths} {input.nt_muts} {input.haplotype_status} {input.aa_muts} {input.traits} {input.clades} {input.recency} \
+            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.traits} {input.clades} {input.recency} \
             --auspice-config {input.auspice_config} \
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \

--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -70,6 +70,11 @@
       "key": "division_exposure",
       "title": "Exposure History",
       "type": "categorical"
+    },
+    {
+      "key": "haplotype_status",
+      "title": "Haplotype Status",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [

--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -104,6 +104,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }

--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -70,11 +70,6 @@
       "key": "division_exposure",
       "title": "Exposure History",
       "type": "categorical"
-    },
-    {
-      "key": "haplotype_status",
-      "title": "Haplotype Status",
-      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -95,8 +90,8 @@
     "division",
     "division_exposure",
     "country",
-    "host",
     "region",
+    "host",
     "author",
     "originating_lab",
     "submitting_lab"
@@ -104,7 +99,6 @@
   "panels": [
     "tree",
     "map",
-    "entropy",
-    "frequencies"
+    "entropy"
   ]
 }

--- a/config/auspice_config_gisaid.json
+++ b/config/auspice_config_gisaid.json
@@ -85,8 +85,8 @@
     "division",
     "division_exposure",
     "country",
-    "host",
     "region",
+    "host",
     "author",
     "originating_lab",
     "submitting_lab"

--- a/config/auspice_config_zh.json
+++ b/config/auspice_config_zh.json
@@ -3,7 +3,7 @@
   "build_url": "https://github.com/nextstrain/ncov",
   "maintainers": [
     {"name": "the Nextstrain team", "url": "https://nextstrain.org/"}
-  ],  
+  ],
   "colorings": [
     {
       "key": "location",
@@ -90,8 +90,8 @@
     "division",
     "division_exposure",
     "country",
-    "host",
     "region",
+    "host",
     "author",
     "originating_lab",
     "submitting_lab"

--- a/scripts/annotate-haplotype-status.py
+++ b/scripts/annotate-haplotype-status.py
@@ -1,0 +1,36 @@
+"""Annotate haplotype status for all sequences that match a given reference node name.
+"""
+import argparse
+from augur.utils import write_json
+import json
+import sys
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ancestral-sequences", required=True, help="node data JSON of nucleotide mutations including observed and inferred by TreeTime")
+    parser.add_argument("--reference-node-name", required=True, help="name of the node whose sequence flags the desired haplotype")
+    parser.add_argument("--attribute-name", default="haplotype_status", help="name of attribute for haplotype status")
+    parser.add_argument("--output", required=True, help="node data JSON with annotated haplotype status based on the given reference node's sequence")
+
+    args = parser.parse_args()
+
+    with open(args.ancestral_sequences, "r") as fh:
+        sequences = json.load(fh)
+
+    if args.reference_node_name not in sequences["nodes"]:
+        print("ERROR: Could not find the requested reference node named '%s' in the given ancestral sequences." % args.reference_node_name, file=sys.stderr)
+        sys.exit(1)
+
+    haplotype_sequence = sequences["nodes"][args.reference_node_name]["sequence"]
+    haplotype_status = {"nodes": {}}
+
+    for node in sequences["nodes"]:
+        if sequences["nodes"][node]["sequence"] == haplotype_sequence:
+            status = "haplotype matches %s" % args.reference_node_name
+        else:
+            status = "haplotype does not match %s" % args.reference_node_name
+
+        haplotype_status["nodes"][node] = {args.attribute_name: status}
+
+    write_json(haplotype_status, args.output)


### PR DESCRIPTION
Adds support for annotating nodes that have identical nucleotide or amino acid sequences to a given reference node and also calculating tip frequencies using the KDE method. The combination of these two features allows us to annotate a specific nucleotide haplotype of interest (USA/WA1/2020) and then inspect the frequencies of that haplotype through time.

Enabling tip frequencies in auspice also allows us to investigate changes in frequencies through time across different node (color-by) attributes.