### PR TITLE
Align sequences in smaller partitions to speed up builds

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -79,6 +79,21 @@ rule filter:
             --output {output.sequences}
         """
 
+checkpoint partition_sequences:
+    input:
+        sequences = rules.filter.output.sequences
+    output:
+        split_sequences = directory("results/split_sequences")
+    params:
+        sequences_per_group = 150
+    shell:
+        """
+        python3 scripts/partition-sequences.py \
+            --sequences {input.sequences} \
+            --sequences-per-group {params.sequences_per_group} \
+            --output-dir {output.split_sequences}
+        """
+
 rule align:
     message:
         """
@@ -86,19 +101,36 @@ rule align:
           - gaps relative to reference are considered real
         """
     input:
-        sequences = "results/filtered.fasta",
+        sequences = "results/split_sequences/{i}.fasta",
         reference = files.reference
     output:
-        alignment = "results/aligned.fasta"
+        alignment = "results/split_alignments/{i}.fasta"
+    threads: 2
     shell:
         """
         augur align \
             --sequences {input.sequences} \
             --reference-sequence {input.reference} \
             --output {output.alignment} \
-            --nthreads auto \
+            --nthreads {threads} \
             --remove-reference \
             --fill-gaps
+        """
+
+def _get_alignments(wildcards):
+    checkpoint_output = checkpoints.partition_sequences.get(**wildcards).output[0]
+    return expand("results/split_alignments/{i}.fasta",
+                  i=glob_wildcards(os.path.join(checkpoint_output, "{i}.fasta")).i)
+
+rule aggregate_alignments:
+    message: "Collecting alignments"
+    input:
+        alignments = _get_alignments
+    output:
+        alignment = "results/aligned.fasta"
+    shell:
+        """
+        cat {input.alignments} > {output.alignment}
         """
 
 rule mask:
@@ -110,7 +142,7 @@ rule mask:
           - masking other sites: {params.mask_sites}
         """
     input:
-        alignment = rules.align.output.alignment
+        alignment = rules.aggregate_alignments.output.alignment
     output:
         alignment = "results/masked.fasta"
     params:

--- a/scripts/partition-sequences.py
+++ b/scripts/partition-sequences.py
@@ -1,0 +1,36 @@
+"""Split sequences for multiple sequence alignment into smaller chunks to speed up alignment.
+"""
+import argparse
+from augur.align import read_sequences
+from Bio import SeqIO
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sequences", required=True, nargs="+", help="FASTA file of sequences to partition into smaller chunks")
+    parser.add_argument("--sequences-per-group", required=True, type=int, help="number of sequences to include in each group")
+    parser.add_argument("--output-dir", required=True, help="directory to write out partitioned sequences")
+
+    args = parser.parse_args()
+
+    # Read sequences with augur to benefit from additional checks for duplicates.
+    sequences = list(read_sequences(*args.sequences).values())
+
+    # Create the requested output directory.
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(exist_ok=True)
+
+    # Determine partition indices.
+    indices = list(range(0, len(sequences), args.sequences_per_group))
+
+    # Add a final index to represent the end of the last partition.
+    if indices[-1] != len(sequences):
+        indices.append(len(sequences))
+
+    # Partition sequences into groups of no more than the requested number.
+    for i in range(len(indices) - 1):
+        # Save partitioned sequences to a new FASTA file named after the partition number.
+        print("Write out %i sequences for partition %i" % (indices[i + 1] - indices[i], i))
+        output_path = output_dir / Path("%i.fasta" % i)
+        SeqIO.write(sequences[indices[i]:indices[i + 1]], output_path, 'fasta')


### PR DESCRIPTION
### Description of proposed changes   

Aligning all available sequences with a single mafft process uses too much
memory. This commit introduces a Python script and Snakemake data-dependent
execution logic to partition sequences into smaller sets, align each set
individually, and aggregate the alignments into a single file.

Note that this commit also explicitly sets the number of threads to use for
augur align using Snakemake's threads keyword [1]. With the splitting of
alignments into multiple partitions, it is now possible to parallelize
alignments with multiple jobs using Snakemake's `-j` flag. It is faster to run 2
alignment jobs in parallel with 2 threads than to run 1 job at a time with 4
threads (3 min vs. 6 min on my MacBook). It is also dangerous to run multiple
jobs in parallel with Snakemake and the 'auto' threads option for augur align
because each job will try to use all available threads. Snakemake's threads
keyword is smart enough to only use the minimum of cores requested by the user
or available on the system.

[1] https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#threads

 ### Testing

I've noticed some minor stochastic variation in alignment outputs for split alignments that are concatenated compared to the corresponding full alignments. I haven't been able to track down the nature of this variation, but so far it does not seem to substantially alter the resulting trees.