### PR TITLE
Build the tree with multiple threads

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -165,11 +165,13 @@ rule tree:
         alignment = rules.mask.output.alignment
     output:
         tree = "results/tree_raw.nwk"
+    threads: 4
     shell:
         """
         augur tree \
             --alignment {input.alignment} \
-            --output {output.tree}
+            --output {output.tree} \
+            --nthreads {threads}
         """
 
 rule refine:


### PR DESCRIPTION
### Description of proposed changes    

To speed up ncov builds a little more, this uses Snakemake's built-in threads keyword to specify a default number of threads to use for tree building. This commit specifically sets number of threads to 4 instead of using augur tree's default of 1 thread.

Snakemake will scale down the number of threads used to match the value of `--cores` or `--jobs`. The user can override the rule's thread setting by passing `--set-threads tree=8`, for example.