### PR TITLE
Explicitly pass a string path to SeqIO.write when partitioning sequences for alignment

### DIFF
--- a/scripts/partition-sequences.py
+++ b/scripts/partition-sequences.py
@@ -33,4 +33,4 @@ if __name__ == "__main__":
         # Save partitioned sequences to a new FASTA file named after the partition number.
         print("Write out %i sequences for partition %i" % (indices[i + 1] - indices[i], i))
         output_path = output_dir / Path("%i.fasta" % i)
-        SeqIO.write(sequences[indices[i]:indices[i + 1]], output_path, 'fasta')
+        SeqIO.write(sequences[indices[i]:indices[i + 1]], str(output_path), 'fasta')


### PR DESCRIPTION
This fixes a bug on some systems (and potentially versions of BioPython) that do not accept a PosixPath as a valid input. Here we convert the PosixPath object to a string. Since this approach is currently used by augur align's write_seqs, for example, it should work here in a more cross-platform manner.
