### PR TITLE
Travis CI coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: false
+dist: bionic
+language: python
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+
+cache: pip
+
+addons:
+  apt:
+    update: true
+    packages:
+      - mafft
+      - iqtree
+      - raxml
+      - fasttree
+      - vcftools
+      - snakemake
+
+install:
+  - pip3 install nextstrain-augur
+
+script:
+  - cp example_data/sequences.fasta data
+  - snakemake -p

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/nextstrain/ncov.svg?branch=master)](https://travis-ci.org/nextstrain/ncov)
+[![Build Status](https://travis-ci.com/nextstrain/ncov.svg?branch=master)](https://travis-ci.com/nextstrain/ncov)
 
 ## About  
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/nextstrain/ncov.svg?branch=master)](https://travis-ci.org/nextstrain/ncov)
+
 ## About  
 
 This is a [Nextstrain](https://nextstrain.org) build for novel coronavirus, alternately known as hCoV-19 or SARS-CoV-2 that is responsible for the COVID-19 pandemic. This build is visible at [nextstrain.org/ncov](https://nextstrain.org/ncov).


### PR DESCRIPTION
### Description of proposed changes    
Implement basic Travis CI coverage

This relies on `example_data`.

This Travis config uses the Snakefile.  If you wish, I can rewrite it to be more like this example: https://github.com/nextstrain/avian-flu/blob/master/.travis.yml

### Testing
Builds succeed for Python 3.6, 3.7. and 3.8: https://travis-ci.org/github/peterbecich/ncov/builds/668257014