### PR TITLE
Focus filter sparse

### DIFF
--- a/scripts/priorities.py
+++ b/scripts/priorities.py
@@ -6,9 +6,107 @@ from random import shuffle
 from collections import defaultdict
 import Bio
 import numpy as np
-import Bio.SeqIO
+from Bio.SeqIO.FastaIO import SimpleFastaParser
 from Bio.Seq import Seq
 from Bio import AlignIO
+from scipy import sparse
+
+
+INITIALISATION_LENGTH = 1000000
+
+# Function adapted from https://github.com/gtonkinhill/pairsnp-python
+def calculate_snp_matrix(fastafile, consensus=None, zipped=False):
+    # This function generate a sparse matrix where differences to the consensus are coded as integers.
+
+    row = np.empty(INITIALISATION_LENGTH)
+    col = np.empty(INITIALISATION_LENGTH, dtype=np.int64)
+    val = np.empty(INITIALISATION_LENGTH, dtype=np.int8)
+
+    r = 0
+    n_snps = 0
+    nseqs = 0
+    seq_names = []
+    current_length = INITIALISATION_LENGTH
+    if zipped:
+        fh = gzip.open(fastafile, 'rt')
+    else:
+        fh = open(fastafile, 'rt')
+    with fh as fasta:
+        for h,s in SimpleFastaParser(fasta):
+            if consensus is None:
+                align_length = len(s)
+                # Take consensus as first sequence
+                consensus = np.fromstring(s.lower(), dtype=np.int8)
+                consensus[(consensus!=97) & (consensus!=99) & (consensus!=103) & (consensus!=116)] = 97
+            else:
+                align_length = len(consensus)
+
+            nseqs +=1
+            seq_names.append(h)
+
+            if(len(s)!=align_length):
+                raise ValueError('Fasta file appears to have sequences of different lengths!')
+
+            s = np.fromstring(s.lower(), dtype=np.int8)
+            s[(s!=97) & (s!=99) & (s!=103) & (s!=116)] = 110
+            snps = consensus!=s
+            right = n_snps + np.sum(snps)
+
+            if right >= (current_length/2):
+                current_length = current_length + INITIALISATION_LENGTH
+                row.resize(current_length)
+                col.resize(current_length)
+                val.resize(current_length)
+
+            row[n_snps:right] = r
+            col[n_snps:right] = np.flatnonzero(snps)
+            val[n_snps:right] = s[snps]
+            r += 1
+            n_snps = right
+    fh.close()
+
+    if nseqs==0:
+        raise ValueError('No sequences found!')
+
+    row = row[0:right] 
+    col = col[0:right]
+    val = val[0:right]
+
+    sparse_snps = sparse.csc_matrix((val, (row, col)), shape=(nseqs, align_length))
+
+    return {'snps': sparse_snps, 'consensus': consensus, 'names': seq_names}
+
+
+def calculate_distance_matrix(sparse_matrix_A, sparse_matrix_B, consensus):
+
+    n_seqs_A = sparse_matrix_A.shape[0]
+    n_seqs_B = sparse_matrix_B.shape[0]
+
+    d = (1*(sparse_matrix_A==97)) * (sparse_matrix_B.transpose()==97)
+    d = d + (1*(sparse_matrix_A==99) * (sparse_matrix_B.transpose()==99))
+    d = d + (1*(sparse_matrix_A==103) * (sparse_matrix_B.transpose()==103))
+    d = d + (1*(sparse_matrix_A==116) * (sparse_matrix_B.transpose()==116))
+
+    d = d.todense()
+
+    n_comp = (1*(sparse_matrix_A==110) * ((sparse_matrix_B==110).transpose())).todense()
+    d = d + n_comp
+
+    temp_total = np.zeros((n_seqs_A, n_seqs_B))
+    temp_total[:] = (1*(sparse_matrix_A>0)).sum(1)
+    temp_total += (1*(sparse_matrix_B>0)).sum(1).transpose()    
+
+    total_differences_shared = (1*(sparse_matrix_A>0)) * (sparse_matrix_B.transpose()>0)
+
+    n_total = np.zeros((n_seqs_A, n_seqs_B))
+    n_sum = (1*(sparse_matrix_A==110)).sum(1)
+    n_total[:] = n_sum
+    n_total += (1*(sparse_matrix_B==110)).sum(1).transpose()  
+
+    diff_n = n_total - 2*n_comp
+    d = temp_total - total_differences_shared.todense() - d - diff_n
+
+    return d
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -16,38 +114,28 @@ if __name__ == '__main__':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument("--alignment", type=str, required=True, help="FASTA file of alignment")
-    parser.add_argument("--metadata", type = str, required=True, help="metadata")
+    # parser.add_argument("--metadata", type = str, required=True, help="metadata")
     parser.add_argument("--focal-alignment", type = str, required=True, help="focal smaple of sequences")
     parser.add_argument("--output", type=str, required=True, help="FASTA file of output alignment")
     args = parser.parse_args()
 
     # load entire alignment and the alignment of focal sequences (upper case -- probably not necessary)
-    all_seqs_dict = {x.id: x.upper() for x in AlignIO.read(args.alignment, format = 'fasta')}
-    focal_seqs_dict = {x.id:x.upper() for x in AlignIO.read(args.focal_alignment, format='fasta')}
+    context_seqs_dict = calculate_snp_matrix(args.alignment)
+    focal_seqs_dict = calculate_snp_matrix(args.focal_alignment, consensus = context_seqs_dict['consensus'])
     print("Done reading the alignments.")
 
-    # convert focal sequences to a numpy masked array
-    focal_sequences = list(focal_seqs_dict.keys())
-    focal_seqs_array = np.ma.array([focal_seqs_dict[x] for x in focal_sequences])
-    focal_seqs_array.mask = np.bitwise_or(focal_seqs_array.data=='N', focal_seqs_array.data=='-')
-    fraction_masked_in_focal = focal_seqs_array.mask.mean(axis=1)
-
     # remove focal sequences from all sequence to provide context data set
-    context_seqs = [v for k,v in all_seqs_dict.items() if k not in focal_seqs_dict]
-    # convert context set to masked arry
-    context_seq_array = np.ma.array(context_seqs)
-    context_seq_array.mask = np.bitwise_or(context_seq_array.data=='N', context_seq_array.data=='-')
-    print("Done converting the alignments.")
+    keep = [(i, name) for i, name in enumerate(context_seqs_dict['names']) if name not in set(focal_seqs_dict['names'])]
+    context_seqs_dict['snps'] = context_seqs_dict['snps'].tocsr()[[i for i, name in keep],:].tocsc()
+    context_seqs_dict['names'] = [name for i, name in keep]
+
     # for each context sequence, calculate minimal distance to focal set
+    d = calculate_distance_matrix(focal_seqs_dict['snps'], context_seqs_dict['snps'], consensus = context_seqs_dict['consensus'])
+    closest_match = np.argmin(d, axis=1)[:,0]
+
     minimal_distance_to_focal_set = {}
-    for i, seq in enumerate(context_seqs):
-        closest_match = (np.ma.sum(focal_seqs_array!=context_seq_array[i], axis=1) 
-                         + fraction_masked_in_focal).argmin()
-        min_dist = np.ma.sum(focal_seqs_array[closest_match]!=context_seq_array[i])
-        if i%100==0:
-            print(f"compared {i} out of {len(context_seqs)} sequences")
-        # for each context sequence, store distance and index of closest focal match
-        minimal_distance_to_focal_set[seq.id] = (min_dist, closest_match)
+    for focal_index, context_index in enumerate(np.nditer(closest_match)):
+        minimal_distance_to_focal_set[context_seqs_dict['names'][context_index]] = (d[focal_index, context_index], focal_index)
 
     # for each focal sequence with close matches (using the index), we list all close contexts
     close_matches = defaultdict(list)
@@ -60,11 +148,11 @@ if __name__ == '__main__':
 
     # export priorities
     with open(args.output, 'w') as fh:
-        for i, seq in enumerate(context_seqs):
+        for i, seqid in enumerate(context_seqs_dict['names']):
             # use distance as negative priority
             # penalize masked (N or -) -- 333 masked sites==one mutations
             # penalize if many sequences are close to the same focal one by using the index of the shuffled list of neighbours
             # currently each position in this lists reduced priority by 0.2, i.e. 5 other sequences == one mutation
-            position = close_matches[minimal_distance_to_focal_set[seq.id][1]].index(seq.id)
-            priority = -minimal_distance_to_focal_set[seq.id][0] - 0.003*np.sum(context_seq_array[i].mask) - 0.2*position
-            fh.write(f"{seq.id}\t{priority:1.2f}\n")
+            position = close_matches[minimal_distance_to_focal_set[seqid][1]].index(seqid)
+            priority = -minimal_distance_to_focal_set[seqid][0] - 0.003*np.sum(context_seq_array[i].mask) - 0.2*position
+            fh.write(f"{seqid}\t{priority:1.2f}\n")

--- a/scripts/priorities.py
+++ b/scripts/priorities.py
@@ -130,12 +130,12 @@ if __name__ == '__main__':
     context_seqs_dict['names'] = [name for i, name in keep]
 
     # for each context sequence, calculate minimal distance to focal set
-    d = calculate_distance_matrix(focal_seqs_dict['snps'], context_seqs_dict['snps'], consensus = context_seqs_dict['consensus'])
+    d = calculate_distance_matrix(context_seqs_dict['snps'], focal_seqs_dict['snps'], consensus = context_seqs_dict['consensus'])
     closest_match = np.argmin(d, axis=1)[:,0]
 
     minimal_distance_to_focal_set = {}
-    for focal_index, context_index in enumerate(np.nditer(closest_match)):
-        minimal_distance_to_focal_set[context_seqs_dict['names'][context_index]] = (d[focal_index, context_index], focal_index)
+    for context_index, focal_index in enumerate(np.nditer(closest_match)):
+        minimal_distance_to_focal_set[context_seqs_dict['names'][context_index]] = (d[context_index, focal_index], int(focal_index))
 
     # for each focal sequence with close matches (using the index), we list all close contexts
     close_matches = defaultdict(list)
@@ -154,5 +154,5 @@ if __name__ == '__main__':
             # penalize if many sequences are close to the same focal one by using the index of the shuffled list of neighbours
             # currently each position in this lists reduced priority by 0.2, i.e. 5 other sequences == one mutation
             position = close_matches[minimal_distance_to_focal_set[seqid][1]].index(seqid)
-            priority = -minimal_distance_to_focal_set[seqid][0] - 0.003*np.sum(context_seq_array[i].mask) - 0.2*position
+            priority = -minimal_distance_to_focal_set[seqid][0] - 0.003* int((1*(context_seqs_dict['snps'][i,:]==110)).sum(1)[0]) - 0.2*position
             fh.write(f"{seqid}\t{priority:1.2f}\n")

--- a/scripts/priorities.py
+++ b/scripts/priorities.py
@@ -36,7 +36,7 @@ def calculate_snp_matrix(fastafile, consensus=None, zipped=False):
             if consensus is None:
                 align_length = len(s)
                 # Take consensus as first sequence
-                consensus = np.fromstring(s.lower(), dtype=np.int8)
+                consensus = np.frombuffer(s.lower().encode('utf-8'), dtype=np.int8).copy()
                 consensus[(consensus!=97) & (consensus!=99) & (consensus!=103) & (consensus!=116)] = 97
             else:
                 align_length = len(consensus)
@@ -47,7 +47,7 @@ def calculate_snp_matrix(fastafile, consensus=None, zipped=False):
             if(len(s)!=align_length):
                 raise ValueError('Fasta file appears to have sequences of different lengths!')
 
-            s = np.fromstring(s.lower(), dtype=np.int8)
+            s = np.frombuffer(s.lower().encode('utf-8'), dtype=np.int8).copy()
             s[(s!=97) & (s!=99) & (s!=103) & (s!=116)] = 110
             snps = consensus!=s
             right = n_snps + np.sum(snps)
@@ -114,7 +114,7 @@ if __name__ == '__main__':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument("--alignment", type=str, required=True, help="FASTA file of alignment")
-    # parser.add_argument("--metadata", type = str, required=True, help="metadata")
+    parser.add_argument("--metadata", type = str, required=True, help="metadata")
     parser.add_argument("--focal-alignment", type = str, required=True, help="focal smaple of sequences")
     parser.add_argument("--output", type=str, required=True, help="FASTA file of output alignment")
     args = parser.parse_args()
@@ -135,7 +135,7 @@ if __name__ == '__main__':
 
     minimal_distance_to_focal_set = {}
     for context_index, focal_index in enumerate(np.nditer(closest_match)):
-        minimal_distance_to_focal_set[context_seqs_dict['names'][context_index]] = (d[context_index, focal_index], int(focal_index))
+        minimal_distance_to_focal_set[context_seqs_dict['names'][context_index]] = (int(d[context_index, focal_index]), int(focal_index))
 
     # for each focal sequence with close matches (using the index), we list all close contexts
     close_matches = defaultdict(list)
@@ -145,6 +145,8 @@ if __name__ == '__main__':
     for f in close_matches:
         shuffle(close_matches[f])
         close_matches[f].sort(key=lambda x:minimal_distance_to_focal_set[x][0])
+
+    
 
     # export priorities
     with open(args.output, 'w') as fh:

--- a/scripts/priorities.py
+++ b/scripts/priorities.py
@@ -76,7 +76,7 @@ def calculate_snp_matrix(fastafile, consensus=None, zipped=False):
 
     return {'snps': sparse_snps, 'consensus': consensus, 'names': seq_names}
 
-
+# Function adapted from https://github.com/gtonkinhill/pairsnp-python
 def calculate_distance_matrix(sparse_matrix_A, sparse_matrix_B, consensus):
 
     n_seqs_A = sparse_matrix_A.shape[0]


### PR DESCRIPTION
### Description of proposed changes    
- Adapts the `priorities.py` script to take advantage of scipy sparse matrix libraries as used in pairsnp to calculate pairwise SNP distances.

- It produces slightly different results as there is no weight for the fraction masked (`fraction_masked_in_focal`) as in the previous version

### Related issue(s)  

### Testing
What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

### Thank you for contributing to Nextstrain!
