### PR TITLE
remove exclusion of reverse-complemented sequences

### DIFF
--- a/config/exclude.txt
+++ b/config/exclude.txt
@@ -149,9 +149,6 @@ USA/CruiseA-26/2020
 # way too divergent
 # Russia/StPetersburg-3524/2020
 
-# temporarily excluded because is currently reverse complement
-Peru/010/2020
-
 # Japan Diamond Princess sequences
 Japan/DP0005/2020
 Japan/DP0027/2020


### PR DESCRIPTION
Since https://github.com/nextstrain/augur/pull/467 is merged, the exclusion of reverse-complemented sequences (e.g. Peru/010/2020) can be undone. This PR fixes #252.