### PR TITLE
handle >hCoV/Kuwait/KU001/2020 sequence in GISAID fasta

### DIFF
--- a/scripts/normalize_gisaid_fasta.sh
+++ b/scripts/normalize_gisaid_fasta.sh
@@ -25,7 +25,7 @@ echo "Normalizing GISAID file $GISAID_SARSCOV2_IN to $GISAID_SARSCOV2_OUT (min l
 # Eliminate duplicate sequences (keep only the first seen)
 
 #cat $GISAID_SARSCOV2_IN |
-	sed 's/^>[hn]Co[Vv]-19\//>/g' $GISAID_SARSCOV2_IN |	# remove leading prefix
+	sed 's/^>[hn]Co[Vv]\(-19\)\?\//>/g' $GISAID_SARSCOV2_IN |	# remove leading prefix
 	sed 's/ //g' |					# remove embedded spaces
 	sed 's/|.*$//' | 				# remove trailing metadata
 	awk "BEGIN{RS=\">\";FS=\"\n\"}length>$MIN_LENGTH{print \">\"\$0}" |	# remove short seqs


### PR DESCRIPTION
The naming of the Kuwait/KU001/2020 sequence on GISAID uses a previously unseen prefix of "hCoV" that does not match the regex used in scripts/normalize_gisaid_fasta.sh, causing this sequence to be excluded from downstream analysis based on the GISAID download due to no matching sequence name in metadata.tsv. This change allows normalize_gisaid_fasta.sh to recognize and remove both the "hCoV" and "hCoV-19" prefixes.

Related to #53 