### PR TITLE
Add a check for minimum augur version

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,6 +1,24 @@
 from os import environ
+from packaging import version
 from socket import getfqdn
 from getpass import getuser
+from snakemake.logging import logger
+import sys
+
+#
+# Verify that required versions of dependencies are installed.
+#
+MIN_AUGUR_VERSION = "7.0.2"
+
+try:
+    from augur.__version__ import __version__ as augur_version
+except ModuleNotFoundError:
+    logger.error("ERROR: Could not find augur. Follow installation instructions at https://nextstrain.org/docs/ and try again.")
+    sys.exit(1)
+
+if version.parse(augur_version) < version.parse(MIN_AUGUR_VERSION):
+    logger.error("ERROR: Found version '%s' of augur, but version '%s' or greater is required" % (augur_version, MIN_AUGUR_VERSION))
+    sys.exit(1)
 
 def get_todays_date():
     from datetime import datetime

--- a/Snakefile
+++ b/Snakefile
@@ -4,6 +4,7 @@ from socket import getfqdn
 from getpass import getuser
 from snakemake.logging import logger
 import sys
+from shutil import which
 
 #
 # Verify that required versions of dependencies are installed.
@@ -19,6 +20,13 @@ except ModuleNotFoundError:
 if version.parse(augur_version) < version.parse(MIN_AUGUR_VERSION):
     logger.error("ERROR: Found version '%s' of augur, but version '%s' or greater is required" % (augur_version, MIN_AUGUR_VERSION))
     sys.exit(1)
+
+SHELL_COMMANDS_NEEDED = ["augur", "iqtree", "mafft"]
+for sh_cmd in SHELL_COMMANDS_NEEDED:
+    if not which(sh_cmd):
+        logger.error(f"ERROR: `{sh_cmd}` is not available as a shell command. Please follow installation instructions at https://nextstrain.org/docs/ and try again.")
+        sys.exit(1)
+
 
 def get_todays_date():
     from datetime import datetime


### PR DESCRIPTION
Avoid issues caused by outdated augur installations by explicitly checking for a
specified minimum augur version. If the appropriate augur version is installed,
the appropriate TreeTime should also have been installed via setup.py, so this
commit does not introduce a minimum TreeTime version.

Closes #336.