### PR TITLE
Send Slack message on Regions deployment failure

### DIFF
--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -231,17 +231,19 @@ rule deploy_to_staging:
     input:
         *rules.all_regions.input
     params:
-        slack_message = json.dumps({"text":f"Deployed <https://nextstrain.org/staging/ncov|nextstrain.org/staging/ncov> {deploy_origin}"}),
-        slack_webhook = config["slack_webhook"] or "",
+        slack_message = f"Deployed <https://nextstrain.org/staging/ncov|nextstrain.org/staging/ncov> {deploy_origin}",
+        slack_token = config["slack_token"] or "",
+        slack_channel = config["slack_channel"] or "",
         s3_staging_url = config["s3_staging_url"]
     shell:
         """
         nextstrain deploy {params.s3_staging_url:q} {input:q}
 
-        if [[ -n "{params.slack_webhook}" ]]; then
-            curl {params.slack_webhook:q} \
-                --header 'Content-type: application/json' \
-                --data-raw {params.slack_message:q} \
+        if [[ -n "{params.slack_token}" ]]; then
+            curl https://slack.com/api/chat.postMessage \
+                --header "Authorization: Bearer "{params.slack_token:q} \
+                --form-string channel={params.slack_channel:q} \
+                --form-string text={params.slack_message:q} \
                 --fail --silent --show-error \
                 --include
         fi

--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -248,14 +248,18 @@ rule deploy_to_staging:
         """
 
 onerror:
-    slack_webhook = config["slack_webhook"] or ""
-    slack_message = json.dumps({"text": f"Build {deploy_origin} failed."})
+    slack_token = config["slack_token"] or ""
+    slack_channel = config["slack_channel"] or ""
+    slack_message = f"Build {deploy_origin} failed."
 
-    if slack_webhook:
+    if slack_token:
         shell(f"""
-            curl {{slack_webhook:q}} \
-                --header 'Content-type: application/json' \
-                --data-raw {{slack_message:q}} \
+            curl https://slack.com/api/files.upload \
+                --header "Authorization: Bearer "{{slack_token:q}} \
+                --form-string channels={{slack_channel:q}} \
+                --form-string initial_comment={{slack_message:q}} \
+                --form file=@{{log:q}} \
+                --form filetype=text \
                 --fail --silent --show-error \
                 --include
         """)

--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -251,12 +251,11 @@ onerror:
     slack_webhook = config["slack_webhook"] or ""
     slack_message = json.dumps({"text": f"Failed deployment {deploy_origin}."}),
 
-    shell(f"""
-        if [[ -n "{{slack_webhook}}" ]]; then
+    if slack_webhook:
+        shell(f"""
             curl {{slack_webhook:q}} \
                 --header 'Content-type: application/json' \
                 --data-raw {{slack_message:q}} \
                 --fail --silent --show-error \
                 --include
-        fi
-    """)
+        """)

--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -246,3 +246,17 @@ rule deploy_to_staging:
                 --include
         fi
         """
+
+onerror:
+    slack_webhook = config["slack_webhook"] or ""
+    slack_message = json.dumps({"text": f"Failed deployment {deploy_origin}."}),
+
+    shell(f"""
+        if [[ -n "{{slack_webhook}}" ]]; then
+            curl {{slack_webhook:q}} \
+                --header 'Content-type: application/json' \
+                --data-raw {{slack_message:q}} \
+                --fail --silent --show-error \
+                --include
+        fi
+    """)

--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -216,6 +216,16 @@ rule adjust_metadata_regions:
         fi
         """
 
+
+#
+# Deployment and error handlers, including Slack messaging integrations.
+#
+
+from os import environ
+
+SLACK_TOKEN   = environ["SLACK_TOKEN"]   = config["slack_token"]   or ""
+SLACK_CHANNEL = environ["SLACK_CHANNEL"] = config["slack_channel"] or ""
+
 try:
     deploy_origin = (
         f"from AWS Batch job `{environ['AWS_BATCH_JOB_ID']}`"
@@ -232,17 +242,15 @@ rule deploy_to_staging:
         *rules.all_regions.input
     params:
         slack_message = f"Deployed <https://nextstrain.org/staging/ncov|nextstrain.org/staging/ncov> {deploy_origin}",
-        slack_token = config["slack_token"] or "",
-        slack_channel = config["slack_channel"] or "",
         s3_staging_url = config["s3_staging_url"]
     shell:
         """
         nextstrain deploy {params.s3_staging_url:q} {input:q}
 
-        if [[ -n "{params.slack_token}" ]]; then
+        if [[ -n "$SLACK_TOKEN" && -n "$SLACK_CHANNEL" ]]; then
             curl https://slack.com/api/chat.postMessage \
-                --header "Authorization: Bearer "{params.slack_token:q} \
-                --form-string channel={params.slack_channel:q} \
+                --header "Authorization: Bearer $SLACK_TOKEN" \
+                --form-string channel="$SLACK_CHANNEL" \
                 --form-string text={params.slack_message:q} \
                 --fail --silent --show-error \
                 --include
@@ -250,15 +258,13 @@ rule deploy_to_staging:
         """
 
 onerror:
-    slack_token = config["slack_token"] or ""
-    slack_channel = config["slack_channel"] or ""
     slack_message = f"Build {deploy_origin} failed."
 
-    if slack_token:
+    if SLACK_TOKEN and SLACK_CHANNEL:
         shell(f"""
             curl https://slack.com/api/files.upload \
-                --header "Authorization: Bearer "{{slack_token:q}} \
-                --form-string channels={{slack_channel:q}} \
+                --header "Authorization: Bearer $SLACK_TOKEN" \
+                --form-string channels="$SLACK_CHANNEL" \
                 --form-string initial_comment={{slack_message:q}} \
                 --form file=@{{log:q}} \
                 --form filetype=text \

--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -249,7 +249,7 @@ rule deploy_to_staging:
 
 onerror:
     slack_webhook = config["slack_webhook"] or ""
-    slack_message = json.dumps({"text": f"Failed deployment {deploy_origin}."}),
+    slack_message = json.dumps({"text": f"Build {deploy_origin} failed."})
 
     if slack_webhook:
         shell(f"""

--- a/config/Snakefile.yaml
+++ b/config/Snakefile.yaml
@@ -4,5 +4,7 @@
 ---
 s3_staging_url: s3://nextstrain-staging
 slack_webhook: ~
+slack_token: ~
+slack_channel: "#ncov-gisaid-updates"
 sequences: "data/sequences.fasta"
 metadata: "data/metadata.tsv"

--- a/config/Snakefile.yaml
+++ b/config/Snakefile.yaml
@@ -3,7 +3,6 @@
 # or --configfile options.
 ---
 s3_staging_url: s3://nextstrain-staging
-slack_webhook: ~
 slack_token: ~
 slack_channel: "#ncov-gisaid-updates"
 sequences: "data/sequences.fasta"


### PR DESCRIPTION
Send a Slack notification if any part of the Snakemake Regions job
errors out.

----

Note: I only added this functionality in Snakefile_Regions, because that was the only file that was configured to send Slack requests.  