### PR TITLE
Move hardcoded settings from Snakefiles into a config file

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -3,8 +3,12 @@ from packaging import version
 from socket import getfqdn
 from getpass import getuser
 from snakemake.logging import logger
+from snakemake.utils import validate
 import sys
 from shutil import which
+
+configfile: "config/config.yaml"
+validate(config, schema="schemas/config.schema.yaml")
 
 #
 # Verify that required versions of dependencies are installed.
@@ -36,13 +40,12 @@ def get_todays_date():
 # For information on how to run 'regions' runs, see Snakefile_Regions
 
 # Add new regions here!
-REGIONS = ["_africa", "_asia", "_europe", "_north-america", "_oceania", "_south-america", "_global"]
+REGIONS = config["regions"]
 
 wildcard_constraints:
     region = "|".join(REGIONS) + "||",
     date = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"
 
-configfile: "config/Snakefile.yaml"
 localrules: download
 
 # simple rule to call snakemake for outsider users
@@ -95,10 +98,10 @@ rule filter:
     output:
         sequences = "results/filtered.fasta"
     params:
-        min_length = 25000,
-        exclude_where = "date='2020' date='2020-01-XX' date='2020-02-XX' date='2020-03-XX' date='2020-04-XX' date='2020-01' date='2020-02' date='2020-03' date='2020-04'",
-        group_by = "division year month",
-        sequences_per_group = 2000
+        min_length = config["filter"]["min_length"],
+        exclude_where = config["filter"]["exclude_where"],
+        group_by = config["filter"]["group_by"],
+        sequences_per_group = config["filter"]["sequences_per_group"]
     shell:
         """
         augur filter \
@@ -119,7 +122,7 @@ checkpoint partition_sequences:
     output:
         split_sequences = directory("results/split_sequences/pre/")
     params:
-        sequences_per_group = 150
+        sequences_per_group = config["partition_sequences"]["sequences_per_group"]
     shell:
         """
         python3 scripts/partition-sequences.py \
@@ -194,9 +197,9 @@ rule mask:
     output:
         alignment = "results/masked.fasta"
     params:
-        mask_from_beginning = 130,
-        mask_from_end = 50,
-        mask_sites = "18529 29849 29851 29853"
+        mask_from_beginning = config["mask"]["mask_from_beginning"],
+        mask_from_end = config["mask"]["mask_from_end"],
+        mask_sites = config["mask"]["mask_sites"]
     shell:
         """
         python3 scripts/mask-alignment.py \
@@ -259,13 +262,13 @@ rule refine:
         node_data = "results/branch_lengths{region}.json"
     threads: 1
     params:
-        root = "Wuhan-Hu-1/2019 Wuhan/WH01/2019",
-        clock_rate = 0.0008,
-        clock_std_dev = 0.0004,
-        coalescent = "skyline",
-        date_inference = "marginal",
-        divergence_unit = "mutations",
-        clock_filter_iqd = 4
+        root = config["refine"]["root"],
+        clock_rate = config["refine"]["clock_rate"],
+        clock_std_dev = config["refine"]["clock_std_dev"],
+        coalescent = config["refine"]["coalescent"],
+        date_inference = config["refine"]["date_inference"],
+        divergence_unit = config["refine"]["divergence_unit"],
+        clock_filter_iqd = config["refine"]["clock_filter_iqd"]
     shell:
         """
         augur refine \
@@ -316,7 +319,7 @@ rule haplotype_status:
     output:
         node_data = "results/haplotype_status{region}.json"
     params:
-        reference_node_name = "USA/WA1/2020"
+        reference_node_name = config["reference_node_name"]
     shell:
         """
         python3 scripts/annotate-haplotype-status.py \
@@ -363,7 +366,7 @@ rule traits:
         node_data = "results/traits{region}.json",
     params:
         columns = _get_exposure_trait_for_wildcards,
-        sampling_bias_correction = 2.5
+        sampling_bias_correction = config["traits"]["sampling_bias_correction"]
     shell:
         """
         augur traits \
@@ -430,10 +433,10 @@ rule tip_frequencies:
     output:
         tip_frequencies_json = "auspice/ncov{region}_tip-frequencies.json"
     params:
-        min_date = 2020.0,
-        pivot_interval = 1,
-        narrow_bandwidth = 0.05,
-        proportion_wide = 0.0
+        min_date = config["frequencies"]["min_date"],
+        pivot_interval = config["frequencies"]["pivot_interval"],
+        narrow_bandwidth = config["frequencies"]["narrow_bandwidth"],
+        proportion_wide = config["frequencies"]["proportion_wide"]
     shell:
         """
         augur frequencies \

--- a/Snakefile_Priorities
+++ b/Snakefile_Priorities
@@ -5,7 +5,7 @@ include: "Snakefile"
 
 ruleorder: export_priorities > export
 
-REGIONS = ["_africa", "_asia", "_europe", "_north-america", "_oceania", "_south-america"]
+REGIONS = config["regions_for_priorities"]
 
 # I recognise some rules here are a little redundant - happy to change file
 # names so that they don't conflict with Region builds, but wanted this
@@ -31,9 +31,9 @@ rule subsample_focus:
     output:
         sequences = "results/subsample_focus{region}.fasta"
     params:
-        group_by = "division year month",
-        seq_per_group_global = 150, # i.e. if not regional build
-        seq_per_group_regional = 300
+        group_by = config["subsample_focus_for_priorities"]["group_by"],
+        seq_per_group_global = config["subsample_focus_for_priorities"]["seq_per_group_global"],
+        seq_per_group_regional = config["subsample_focus_for_priorities"]["seq_per_group_regional"]
     shell:
         """
         #Figure out what region being wanted

--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -68,9 +68,9 @@ rule subsample_focus:
     output:
         sequences = "results/subsample_focus{region}.fasta"
     params:
-        group_by = "division year month",
-        seq_per_group_global = 40, # i.e. if not regional build
-        seq_per_group_regional = 260
+        group_by = config["subsample_focus"]["group_by"],
+        seq_per_group_global = config["subsample_focus"]["seq_per_group_global"],
+        seq_per_group_regional = config["subsample_focus"]["seq_per_group_regional"]
     shell:
         """
         #Figure out what region being wanted
@@ -146,8 +146,8 @@ rule subsample_context:
     output:
         sequences = "results/subsample_context{region}.fasta"
     params:
-        group_by = "country year month",
-        sequences_per_group = 20
+        group_by = config["subsample_context"]["group_by"],
+        sequences_per_group = config["subsample_context"]["sequences_per_group"]
     shell:
         """
         #Figure out what region being wanted

--- a/config/Snakefile.yaml
+++ b/config/Snakefile.yaml
@@ -1,9 +1,0 @@
-# This file contains defaults for the "config" object used in the Snakefile.
-# To temporarily override or provide a value, you can use snakemake's --config
-# or --configfile options.
----
-s3_staging_url: s3://nextstrain-staging
-slack_token: ~
-slack_channel: "#ncov-gisaid-updates"
-sequences: "data/sequences.fasta"
-metadata: "data/metadata.tsv"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,101 @@
+# This file contains defaults for the "config" object used in the Snakefile.
+# To temporarily override or provide a value, you can use snakemake's --config
+# or --configfile options.
+---
+s3_staging_url: s3://nextstrain-staging
+slack_webhook: ~
+slack_channel: "#ncov-gisaid-updates"
+sequences: "data/sequences.fasta"
+metadata: "data/metadata.tsv"
+
+reference_node_name: "USA/WA1/2020"
+
+# Filter settings
+filter:
+  # Require nearly full-length genomes.
+  min_length: 25000
+
+  # Omit sequences with incomplete date annotations.
+  exclude_where: "date='2020' date='2020-01-XX' date='2020-02-XX' date='2020-03-XX' date='2020-04-XX' date='2020-01' date='2020-02' date='2020-03' date='2020-04'"
+
+  # Select a subset of sequences per unique geographic and temporal group.
+  # This limits the number of sequences in the base build to prevent long runtimes.
+  group_by: "division year month"
+  sequences_per_group: 2000
+
+# Alignment settings
+# Alignments are partitioned into smaller groups to speed up the overall alignment process.
+# The number of sequences per group determines the run time of a single alignment job.
+partition_sequences:
+  sequences_per_group: 150
+
+# Mask settings determine how the multiple sequence alignment is masked prior to phylogenetic inference.
+mask:
+  # Number of bases to mask from the beginning and end of the alignment. These regions of the genome
+  # are difficult to sequence accurately.
+  mask_from_beginning: 130
+  mask_from_end: 50
+
+  # Specific sites to mask in the reference genome's coordinates.
+  # These are 1-indexed coordinates of sites that have been identified as prone to sequencing errors.
+  mask_sites: "18529 29849 29851 29853"
+
+# TreeTime settings
+refine:
+  root: "Wuhan-Hu-1/2019 Wuhan/WH01/2019"
+  clock_rate: 0.0008
+  clock_std_dev: 0.0004
+  coalescent: "skyline"
+  date_inference: "marginal"
+  divergence_unit: "mutations"
+  clock_filter_iqd: 4
+
+traits:
+  sampling_bias_correction: 2.5
+
+# Frequencies settings
+frequencies:
+  min_date: 2020.0
+
+  # Number of months between pivots
+  pivot_interval: 1
+
+  # KDE bandwidths in proportion of a year to use per strain.
+  narrow_bandwidth: 0.05
+  proportion_wide: 0.0
+
+#
+# Region-specific settings
+# TODO: consider moving these settings into their own config file to complement the base config file.
+#
+
+# Regions to build specific builds for using intelligent subsampling.
+regions: ["_africa", "_asia", "_europe", "_north-america", "_oceania", "_south-america", "_global"]
+
+# Subsampling settings for region of focus and context.
+subsample_focus:
+  group_by: "division year month"
+  seq_per_group_regional: 260
+
+  # Sequences per group if the current build is not a regional build.
+  seq_per_group_global: 40
+
+subsample_context:
+  group_by: "country year month"
+  sequences_per_group: 20
+
+#
+# Priorities-specific settings
+# TODO: consider how to merge these with the region-specific settings to avoid redundancy.
+#
+
+regions_for_priorities: ["_africa", "_asia", "_europe", "_north-america", "_oceania", "_south-america"]
+
+# Subsampling settings for region of focus and context.
+# TODO: merge these with "subsample_focus" settings above
+subsample_focus_for_priorities:
+  group_by: "division year month"
+  seq_per_group_regional: 300
+
+  # Sequences per group if the current build is not a regional build.
+  seq_per_group_global: 150

--- a/docs/running.md
+++ b/docs/running.md
@@ -62,7 +62,13 @@ tail +2 ./data/our_metadata.tsv >> ./data/metadata.tsv
 ```
 (Please double check the columns in this new metadata TSV match up. It's not a problem if there are more entries in the metadata than there are genomes.)
 
+## Configuring your build
 
+The default build is parameterized by a [Snakemake configuration file](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html) named `config/config.yaml`.
+Inspect this [YAML file](https://yaml.org/) and modify any parameters as needed for your own analyses.
+When you run the default build using the instructions below, the build commands will reflect your changes.
+
+If you need to change the default build in a way that isn't represented by the configuration file, [create a new issue in the ncov repository](https://github.com/nextstrain/ncov/issues/new) to let us know.
 
 ## Running the default build
 

--- a/schemas/config.schema.yaml
+++ b/schemas/config.schema.yaml
@@ -1,0 +1,6 @@
+$schema: "http://json-schema.org/draft-06/schema#"
+
+description: snakemake configuration file
+
+type: object
+


### PR DESCRIPTION
## Description of proposed changes    

Moves hardcoded parameters from Snakefile (e.g., clock rate for augur refine, etc.) into a YAML config file. Renames the existing config file from "Snakefile.yaml" to "config.yaml" to follow [standards recommended by Snakemake docs](https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html). Also adds validation of the config file with a simple config schema that can be expanded as necessary for critical parameters that would benefit from type checking (e.g., min length of sequences for augur filter).

This approach allows users to modify key parameters of the pipeline by editing a YAML file or passing them through the command line `--config` argument without needing to understand or edit Snakemake files.

## Discussion points

Moving all parameters into a single config file revealed that the regions and priorities rules both define a `subsample_focus` rule, but they use slightly different parameter values. Specifically, the regions rule uses 280 regional and 120 global sequences while the priorities rule uses 300 regional and 150 global sequences. Do these numbers need to be different or can we pick one set to use across both files?

There is a trade-off to moving parameters from the Snakefile to a separate file. On the one hand, this change increases the visibility of what can be configured in the pipeline, allows parameters to be validated, and exposes parameters to users through more standard interfaces (YAML files and command line arguments). On the other hand, this change separates the config parameters from their original context in the commands for each rule.

I've tried to address this latter change by organizing config parameters by rule name such that the config file organization generally mirrors the Snakefile organization. I have also added comments to clarify the purpose of specific parameters. Such comments could be extended to all parameters. This approach follows the example of Snakemake's creator's own [pipeline config files](https://github.com/snakemake-workflows/single-cell-rna-seq/blob/master/config.yaml).

## Testing

I've confirmed that the commands for base, region-specific, and priorities rules include the expected parameters loaded from the config file.