### PR TITLE
Edits to tutorials

### DIFF
--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -2,7 +2,7 @@
 
 Running the phylodynamics analysis described in this repo requires 2 main inputs: the sequence data, in FASTA format, and metadata in TSV format.
 Here we describe the format of the metadata which the pipeline expects.
-An example of this can be seen with the metadata [metadata.tsv](../data/metadata.tsv) for shared sequences which is what we use for the global analysis at [nextstrain.org/ncov/global](https://nextstrain.org/ncov/global). 
+An example of this can be seen with the metadata [metadata.tsv](../data/metadata.tsv) for shared sequences which are used for the global analysis at [nextstrain.org/ncov/global](https://nextstrain.org/ncov/global).
 
 #### A few points before we dive in:
 - The _order_ of the fields doesn't matter; but if you are going to join your metadata with the global collection then it's easiest to keep them in the same order!
@@ -10,7 +10,7 @@ An example of this can be seen with the metadata [metadata.tsv](../data/metadata
 - A tab character -- `\t` -- separates columns. Read more about the TSV format [here](https://en.wikipedia.org/wiki/Tab-separated_values).
 - Data is case sensitive
 - The "geographic" columns, such as "region" and "country" will be used to plot the samples on the map.
-Adding a new value to these columns isn't a problem at all, but lat/long coordinates will also need to be defined for this in a seaparate file (documentation forthcoming).
+Adding a new value to these columns isn't a problem at all, but lat/long coordinates will also need to be defined for this in a separate file (documentation forthcoming).
 - A lot of these fields will be available to interact with as "colorings" of the data in Auspice (the interactive visualisation used within Nextstrain). However which exact columns are used, and which colours are used for each value is completely customisable (documentation forthcoming).
 - See also the [augur documentation](https://nextstrain-augur.readthedocs.io/en/stable/faq/metadata.html) relating to metadata formatting
 
@@ -53,7 +53,7 @@ If this genome is shared via [GenBank](https://www.ncbi.nlm.nih.gov/genbank/) th
 
 **Column 5: `date`** (really important!)
 
-This describes the sample collection data (_not_ sequencing date!) and must be formated according as `YYYY-MM-DD`. 
+This describes the sample collection data (_not_ sequencing date!) and must be formated according as `YYYY-MM-DD`.
 Our example was collected on Feb 27, 2020 and is therefore represented as "2020-02-27".
 
 You can specify unknown dates or month by replacing the respected values by `XX` (ex: `2013-01-XX` or `2011-XX-XX`) and completely unknown dates can be shown with `20XX-XX-XX` (which does not restrict the sequence to being in the 21st century - they could be earlier).
@@ -62,21 +62,21 @@ Please be aware that our current pipeline will filter out any genomes with an un
 **Column 6: `region`**
 
 The region the sample was collected in -- for our example this is "Oceania".
-Please use one of "Africa", "Asia", "Europe", "North America", "Oceania" or "South America".
-If you sequence a genome from Antartica please get in touch!
+Please use either "Africa", "Asia", "Europe", "North America", "Oceania" or "South America".
+If you sequence a genome from Antartica, please get in touch!
 
 
 **Column 7: `country`**
 
 The country the sample was collected in. Our example, "NewZealand/01/2020", was collected in ....... New Zealand.
 You can run `tail +2 data/metadata.tsv | cut -f 7 | sort | uniq` to see all the countries currently present in the metadata.
-As of April 10 there were 64! 🌎
+As of April 10, there were 64! 🌎
 
 **Column 8: `division`**
 
 Division currently doesn't have a precise definition and we use it differently for different regions.
-For instance, for samples in the USA we are detailing the state in which the sample was collected here. For other countries, it might be a county, region, or other administrative sub-division.
-To see the divisions which are currently set for your country you can run the following command (replace "New Zealand" with your country):
+For instance for samples in the USA, division is the state in which the sample was collected here. For other countries, it might be a county, region, or other administrative sub-division.
+To see the divisions which are currently set for your country, you can run the following command (replace "New Zealand" with your country):
 ```bash
 tail +2 data/metadata.tsv | cut -f 7,8 | grep "^New Zealand" | cut -f 2 | sort | uniq
 ```
@@ -84,7 +84,7 @@ tail +2 data/metadata.tsv | cut -f 7,8 | grep "^New Zealand" | cut -f 2 | sort |
 **Column 9: `location`**
 
 Similarly to `division`, but for a smaller geographic resolution. This data is often unavailable, and missing data here is typically represented by an empty field or the same value as `division` is used.
-In our example the division is "Auckland", which conveniently or confusingly is both a province of New Zealand and a city.
+In our example the division is "Auckland", which conveniently (or confusingly) is both a province of New Zealand and a city.
 
 **Column 10: `region_exposure`**
 
@@ -121,7 +121,7 @@ Currently we have multiple values in the dataset, including "Human", "Canine", "
 
 Numeric age of the patient from whom the sample was collected.
 We round to an integer value.
-This will show up in auspice when clicking on the tip in the tree which brings up an info box and 
+This will show up in auspice when clicking on the tip in the tree which brings up an info box.
 
 **Column 17: `sex`**
 
@@ -151,10 +151,9 @@ For most SARS-CoV-2 data this is [https://www.gisaid.org](https://www.gisaid.org
 
 **Column 22: `title`**
 
-The URL, if available, of the publication announcing these genomes. 
+The URL, if available, of the publication announcing these genomes.
 
 **Column 23: `date_submitted`**
 
 Date the genome was submitted to a public database (most often GISAID).
 In `YYYY-MM-DD` format (see `date` for more information on this formatting).
-

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,8 +1,8 @@
 ### Running a SARS-CoV-2 analysis
 
-The pipeline described in this repo is designed primarily to run the phylogeographic analyses of SARS-CoV-2 data which are displayed on nexstrain.org, for instance [the global analysis](https://nextstrain.org/ncov/global), the [European subsampled build](https://nextstrain.org/ncov/europe), the [North American Build](https://nextstrain.org/ncov/north-america) etc.
+The pipeline described in this repo is designed primarily to run the phylogeographic analyses of SARS-CoV-2 data which are displayed on nexstrain.org, for instance [the global analysis](https://nextstrain.org/ncov/global), the [European subsampled build](https://nextstrain.org/ncov/europe), the [North American build](https://nextstrain.org/ncov/north-america) etc.
 
-It is also possible to run your own data through the analysis here.
+It is also possible to run your own data through the same analysis pipeline.
 Because Nextstrain is open-source, you may modify the analysis to suit your particular needs.
 
 #### A few points before we dive in:
@@ -32,24 +32,23 @@ We will write guidance for subsampling in a future page, but you can investigate
 
 #### Global data
 
-For the nextstrain.org analyses we use data obtained through [GISAID](https//gisaid.org).
-Please see there for how you may obtain those genomic data for your own analysis as the terms of data sharing prevent us making the sequence data publicly available.
-Included in this repository is [a curated list of metadata](../data/metadata.tsv) associated with those sequences.
+For the nextstrain.org analyses, we use data obtained through [GISAID](https//gisaid.org).
+Please see there for how to obtain that genomic data for your own analysis. The terms of data sharing prevent us making the sequence data publicly available. [A curated list of metadata](../data/metadata.tsv) included in this repository is associated with those sequences.
 
 #### Your own data
 
 This should consist of
-- a FASTA file with the (unaligned) genomes and the name must not contain characters such as spaces, or `()[]{}|#><` (except for the `>` character which starts each entry in a FASTA file).
-- the metadata corresponding to each of those genomes.  Please see the [metadata documentation](./metadata.md) for details of the format of this metadata.
+- a FASTA file with the (unaligned) genomes. Sequence names must not contain characters such as spaces, or `()[]{}|#><` (except for the `>` character which starts each entry in a FASTA file).
+- the metadata corresponding to each of your genomes.  Please see [metadata documentation](./metadata.md) for details on the format of this metadata.
 
 
 #### Combining the data
 
-Let's assume you have now have four files:
+Let's assume you now have four files:
 1. `data/global_sequences.fasta` - genomes of worldwide data to provide phylogenetic context
-2. `data/global_metadata.tsv` - Metadata of these (global) genomes. This could well be a copy of the `data/metadata.tsv` that's included with this repo.
+2. `data/global_metadata.tsv` - Metadata of these (global) genomes. This could be a copy of the `data/metadata.tsv` that's included in this repo.
 3. `data/our_sequences.fasta` - Your own sequences, in FASTA format.
-4. `data/our_metadata.tsv` - metadata of your genomes. Let's assume this follows the [same format](./metadata.md) as (2).
+4. `data/our_metadata.tsv` - metadata of your genomes. We'll assume this follows the [same format](./metadata.md) as (2).
 
 We can combine the two sets of genomes simply via
 ```bash
@@ -60,7 +59,7 @@ And, as long as the metadata formats are the same, then we can add our metadata 
 cp ./data/global_metadata.tsv ./data/metadata.tsv
 tail +2 ./data/our_metadata.tsv >> ./data/metadata.tsv
 ```
-(Please double check the columns in this new metadata TSV match up. It's not a problem if there are more entries in the metadata than there are genomes.)
+(Please double check that the columns in this new, merged metadata TSV match up. It's not a problem if there are more entries (rows) in the metadata than the total number of genomes.)
 
 
 
@@ -79,11 +78,11 @@ auspice view --datasetDir auspice
 ## Understanding the parts of the analysis
 
 The Snakemake analysis here consists of a number of rules, which are displayed below.
-Not all of the rules here are essential, or may even be desirable for your analysis.
-We maintain this snakefile primarily for our analyses, and thus your build may be able to be made a lot simpler!
-The aim of this tutorial is to walk you through the rules in this basic analysis run by Nextstrain and give you the ability to change it to suit your needs.
+Not all of the rules included are essential, or may even be desirable for your analysis.
+We maintain this snakefile primarily for our own analyses, and thus your build may be able to be made a lot simpler!
+The aim of this tutorial is to walk you through the rules in the basic analysis run by Nextstrain and to give you the ability to change it to suit your needs.
 
-> Note: this repo contains a few different Snakefiles, as we use them to automate a number of analyses, some of which are beyond the scope of this tutorial. 
+> Note: this repo contains a few different Snakefiles, as we use them to automate a number of analyses, some of which are beyond the scope of this tutorial.
 This tutorial follows the main `Snakefile`.
 
 
@@ -99,7 +98,7 @@ Please inspect the `Snakefile` to see what each rule is doing in more detail and
 
 #### My country / division does not show up on the map
 
-This is most often a result of the country / division not being present in [the file defining the latitude & longitdue of each deme](../config/lat_longs.tsv).
+This is most often a result of the country / division not being present in [the file defining the latitude & longitude of each deme](../config/lat_longs.tsv).
 Adding it to that file (and rerunning the Snakemake rules downstream of this) should fix this.
 You can rerun the appropriate parts of the build via:
 


### PR DESCRIPTION
Hi @jameshadfield, I've added a few edits for clarity and readability to  `docs/metadata.md` and `docs/running.md`. 

Overall, I thought the docs made sense and were easy to follow. I have only a few comments on `running.md`, which are not addressed in the PR:
* Under "Running the default build," the fact that only one json is outputted for ncov while two json's  are outputted for the Zika tutorial might be confusing. A statement along the lines of "Don't worry", explaining why there's only one json could be useful.

* "Debugging common issues" should include a link to another location with more fleshed out Nextstrain troubleshooting help (maybe the augur docs?). Running the pipeline seems simple enough, but a lot of errors could come up (likely related to package version control). For example, I got IQ Tree errors for awhile, and I had to solicit troubleshooting help on how to force conda to install the right version.

* At the top (maybe under "A few points before we dive in") include a link for how to install Nextstrain. For example: "This tutorial assumes Nextstrain is installed locally. If Nextstrain is not already installed, please do so at LINK before continuing on.."