### PR TITLE
Reduce inputs to augur refine with a conditional input function

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -242,6 +242,15 @@ rule tree:
             --nthreads {threads}
         """
 
+def _get_alignments_for_tree(wildcards):
+    """Global builds use the complete alignment of sequences while regional builds
+    use a subsampled set of sequences.
+    """
+    if wildcards.region == "":
+        return rules.mask.output.alignment
+    else:
+        return rules.subsample_regions.output.alignment
+
 rule refine:
     message:
         """
@@ -252,7 +261,7 @@ rule refine:
         """
     input:
         tree = rules.tree.output.tree,
-        alignment = rules.mask.output,
+        alignment = _get_alignments_for_tree,
         metadata = "results/metadata_adjusted{region}.tsv"
     output:
         tree = "results/tree{region}.nwk",
@@ -294,7 +303,7 @@ rule ancestral:
         """
     input:
         tree = "results/tree{region}.nwk",
-        alignment = rules.mask.output
+        alignment = _get_alignments_for_tree
     output:
         node_data = "results/nt_muts{region}.json"
     params:

--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -193,7 +193,7 @@ rule subsample_regions:
         rules.subsample_focus.output.sequences,
         rules.subsample_context.output.sequences
     output:
-        "results/subsampled_alignment{region}.fasta"
+        alignment = "results/subsampled_alignment{region}.fasta"
     shell:
         """
         python3 scripts/combine-and-dedup-fastas.py \

--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -198,7 +198,7 @@ rule subsample_regions:
         """
         python3 scripts/combine-and-dedup-fastas.py \
             --input {input} \
-            --output {output}
+            --output {output.alignment}
         """
 
 rule adjust_metadata_regions:


### PR DESCRIPTION
Checks whether the current region is empty (the default build) or one of the
specific regions and only returns the full multiple sequence alignment as input
to augur refine in the default case. This should reduce the size of inputs to
augur refine for regional builds to just those sequences in the subsampled
alignment and reduce the amount of memory required for the refine step.