### PR TITLE
Set memory resources required for the tree and refine rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Files created by the pipeline, which we want to keep out of git
 # (or at least out of _this_ git repo).
+benchmarks/
 results/
 build/
 auspice/

--- a/Snakefile
+++ b/Snakefile
@@ -233,7 +233,14 @@ rule tree:
         alignment = "results/subsampled_alignment{region}.fasta"
     output:
         tree = "results/tree_raw{region}.nwk"
+    benchmark:
+        "benchmarks/tree{region}.txt"
     threads: 4
+    resources:
+        # Multiple sequence alignments can use up to 40 times their disk size in
+        # memory, especially for larger alignments.
+        # Note that Snakemake >5.10.0 supports input.size_mb to avoid converting from bytes to MB.
+        mem_mb=lambda wildcards, input: 40 * int(input.size / 1024 / 1024)
     shell:
         """
         augur tree \
@@ -266,7 +273,14 @@ rule refine:
     output:
         tree = "results/tree{region}.nwk",
         node_data = "results/branch_lengths{region}.json"
+    benchmark:
+        "benchmarks/refine{region}.txt"
     threads: 1
+    resources:
+        # Multiple sequence alignments can use up to 15 times their disk size in
+        # memory.
+        # Note that Snakemake >5.10.0 supports input.size_mb to avoid converting from bytes to MB.
+        mem_mb=lambda wildcards, input: 15 * int(input.size / 1024 / 1024)
     params:
         root = "Wuhan-Hu-1/2019 Wuhan/WH01/2019",
         clock_rate = 0.0008,


### PR DESCRIPTION
Defines the amount of memory required in MB for the tree and refine rules using
rule resources [1] as a function of the size of its inputs on disk (the `size`
attribute [2]). This approach allows Snakemake to dynamically adjust the memory
resources required for global and regional builds, since these builds require ~3
GB and ~300 MB of memory for the refine rule, respectively. They require ~12 GB
and ~550 MB of memory for the tree rule, respectively, too.

If Snakemake is executed with the `--resources` flag such that it knows how much
memory is available, this new resource definition will prevent Snakemake from
trying to run too many refine jobs in parallel if doing so would exceed
available memory.

This commit also adds the benchmark parameters for the tree and refine rules
that I used to determine memory usage. These benchmarks will allow us to
continually track resource usage across builds and potentially adjust the values
added in this commit.

Note that when augur supports snakemake >5.10.0, we will be able to refer to
input sizes in MB [3] instead of bytes and will save some additional code like
this commit adds to convert from bytes to MB.

[1] https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#resources
[2] https://snakemake.readthedocs.io/en/stable/api_reference/internal/snakemake.html#snakemake.io.InputFiles.size
[3] https://snakemake.readthedocs.io/en/stable/api_reference/internal/snakemake.html#snakemake.io.InputFiles.size_mb