### PR TITLE
Use compressed metadata and sequences files

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -76,8 +76,8 @@ rule download:
         metadata = config["metadata"]
     shell:
         """
-        aws s3 cp s3://nextstrain-ncov-private/metadata.tsv {output.metadata:q}
-        aws s3 cp s3://nextstrain-ncov-private/sequences.fasta {output.sequences:q}
+        aws s3 cp s3://nextstrain-ncov-private/metadata.tsv.gz - | gunzip -cq > {output.metadata:q}
+        aws s3 cp s3://nextstrain-ncov-private/sequences.fasta.gz - | gunzip -cq > {output.sequences:q}
         """
 
 rule filter:


### PR DESCRIPTION
Use the newly available, compressed, `metadata.tsv.gz` and
`sequences.fasta.gz` files to reduce network transfer time.

Depends on https://github.com/nextstrain/ncov-ingest/pull/41 

### Related issue(s)  
https://github.com/nextstrain/ncov-ingest/issues/34