### PR TITLE
Make Europe Build Sample by Country, not Division

### DIFF
--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -78,7 +78,7 @@ rule subsample_focus:
     output:
         sequences = "results/subsample_focus{region}.fasta"
     params:
-        group_by = "division year month",
+        #group_by = "division year month",
         seq_per_group_global = 40, # i.e. if not regional build
         seq_per_group_regional = 260
     shell:
@@ -89,12 +89,22 @@ rule subsample_focus:
         if [ "$rgn" = "_global" ]; then
             seq_per_group={params.seq_per_group_global}
             regionarg="--exclude-where region="
+            grouparg="division year month"
             region="frog"   #I don't know! It wouldn't work without something!
             echo "Filtering for a global run - $seq_per_group per division"
+        elif [ "$rgn" = "_europe" ]; then
+            seq_per_group={params.seq_per_group_regional}
+            region="${{rgn//[_y]/}}"
+            region="${{region//[-y]/ }}"
+            grouparg="country year month"
+            echo "Filtering for a focal run on $region - $seq_per_group per country"
+            regionarg="--exclude-where region!="
+            echo "   This is passed to augur as $regionarg'$region'"
         else
             seq_per_group={params.seq_per_group_regional}
             region="${{rgn//[_y]/}}"
             region="${{region//[-y]/ }}"
+            grouparg="division year month"
             echo "Filtering for a focal run on $region - $seq_per_group per division"
             regionarg="--exclude-where region!="
             echo "   This is passed to augur as $regionarg'$region'"
@@ -105,7 +115,7 @@ rule subsample_focus:
             --metadata {input.metadata} \
             --include {input.include} \
             $regionarg"$region" \
-            --group-by {params.group_by} \
+            --group-by "$grouparg" \
             --sequences-per-group $seq_per_group \
             --output {output.sequences} \
 

--- a/Snakefile_Regions
+++ b/Snakefile_Regions
@@ -97,6 +97,7 @@ rule subsample_focus:
             region="${{rgn//[_y]/}}"
             region="${{region//[-y]/ }}"
             grouparg="country year month"
+            echo "Filtering by these groups '$grouparg'"
             echo "Filtering for a focal run on $region - $seq_per_group per country"
             regionarg="--exclude-where region!="
             echo "   This is passed to augur as $regionarg'$region'"
@@ -115,7 +116,7 @@ rule subsample_focus:
             --metadata {input.metadata} \
             --include {input.include} \
             $regionarg"$region" \
-            --group-by "$grouparg" \
+            --group-by $grouparg \
             --sequences-per-group $seq_per_group \
             --output {output.sequences} \
 


### PR DESCRIPTION
### Description of proposed changes    
Europe build is currently over 5000 sequences and takes the longest to do `tree` and `refine` when running. It is also the regional build that likely has the most overall (un-sub-sampled) sequences. This PR change sampling for 'Europe' to to by `country month year` instead of `division month year` as it is for the other regions. Just implemented in shell for now, as this will be superseceded by #375 - but this change should be integrated there too, prior to merging. 


### Testing
Ran a full Europe build locally, looks good, reduces the number of sequences to 4000. We can further reduce sampling by reducing the number per country/division (for all regional builds) or by introducing a different number of 'number samples per' for Europe vs other regions.

### Thank you for contributing to Nextstrain!
