### PR TITLE
Prevent workflow from trying to adjust global metadata

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -41,6 +41,9 @@ rule clean:
     shell:
         "rm -rfv {params}"
 
+# Include small, shared functions that help build inputs and parameters.
+include: "rules/common.smk"
+
 # Include rules to handle primary build logic from multiple sequence alignment
 # to output of auspice JSONs for a default build.
 include: "rules/builds.smk"

--- a/rules/builds.smk
+++ b/rules/builds.smk
@@ -326,12 +326,6 @@ rule tree:
             --nthreads {threads} 2>&1 | tee {log}
         """
 
-def _get_metadata_by_wildcards(wildcards):
-    if wildcards.region == "global":
-        return rules.download.output.metadata
-    else:
-        return rules.adjust_metadata_regions.output.metadata
-
 rule refine:
     message:
         """

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -1,0 +1,19 @@
+"""Small, shared functions used to generate inputs and parameters.
+"""
+def _get_metadata_by_region(region):
+    """Returns a path associated with the metadata for the given region.
+
+    The path can include wildcards that must be provided by the caller through
+    the Snakemake `expand` function or through string formatting with `.format`.
+    """
+    if region == "global":
+        return rules.download.output.metadata
+    else:
+        return rules.adjust_metadata_regions.output.metadata
+
+def _get_metadata_by_wildcards(wildcards):
+    """Returns a metadata path based on the given wildcards object.
+
+    This function is designed to be used as an input function.
+    """
+    return _get_metadata_by_region(wildcards.region)

--- a/rules/nextstrain_exports.smk
+++ b/rules/nextstrain_exports.smk
@@ -58,7 +58,7 @@ rule export_all_regions:
         colors_file = expand("config/colors_{region}.tsv", region=REGIONS),
         auspice_json = expand(REGION_PATH + "ncov_with_accessions.json", region=REGIONS),
         lat_longs = config["files"]["lat_longs"],
-        metadata = expand(REGION_PATH + "metadata_adjusted.tsv", region=REGIONS),
+        metadata = [_get_metadata_by_region(region).format(region=region) for region in REGIONS],
         colors = expand("config/colors_{region}.tsv", region=REGIONS),
     conda: config["conda_environment"]
     shell:


### PR DESCRIPTION
Previously, the `export_all_regions` rule tried to expand the adjusted metadata
path for all regions including the global build. The global build does not have
an adjusted metadata file, though; it uses the original metadata file instead.

This commit fixes the problem by introducing a more generic function to get the
correct metadata file conditional on the region and using this function as a
base for an input function (the original `_get_metadata_by_wildcards`) and in a
list comprehension in the `export_all_regions` rule inputs. These functions live
in a new Snakemake file for shared functions, `common.smk`, following the
guidelines recommended by the Snakemake authors [1].

[1] https://github.com/snakemake-workflows/dna-seq-gatk-variant-calling/blob/master/rules/common.smk

### Testing

I tested this code with the following steps:

1. attach a recent AWS Build
2. try to run the `export_all_regions` rule as is (without the changes in this PR) and confirm that the global build produces the original error when trying to adjust metadata.
3. apply changes in this PR to the attached build, re-run `clean_export_regions`, re-run `export_all_regions`, and confirm that the `check_missing_locations.py` script runs as expected and no errors occur