### PR TITLE
Keep gaps

### DIFF
--- a/rules/builds.smk
+++ b/rules/builds.smk
@@ -89,8 +89,7 @@ rule align:
             --reference-sequence {input.reference} \
             --output {output.alignment} \
             --nthreads {threads} \
-            --remove-reference \
-            --fill-gaps 2>&1 | tee {log}
+            --remove-reference 2>&1 | tee {log}
         """
 
 def _get_alignments(wildcards):
@@ -138,6 +137,7 @@ rule mask:
             --mask-from-beginning {params.mask_from_beginning} \
             --mask-from-end {params.mask_from_end} \
             --mask-sites {params.mask_sites} \
+            --mask-terminal-gaps \
             --output {output.alignment} 2>&1 | tee {log}
         """
 

--- a/scripts/mask-alignment.py
+++ b/scripts/mask-alignment.py
@@ -11,7 +11,7 @@ def mask_terminal_gaps(seq):
     seq_trimmed = seq.lstrip('-')
     left_gaps = L - len(seq_trimmed)
     seq_trimmed = seq_trimmed.rstrip('-')
-    right_gaps = L - len(seq_trimmed) + left_gaps
+    right_gaps = L - len(seq_trimmed) - left_gaps
     return "N"*left_gaps + seq_trimmed + "N"*right_gaps 
 
 

--- a/scripts/mask-alignment.py
+++ b/scripts/mask-alignment.py
@@ -6,6 +6,14 @@ import Bio
 import Bio.SeqIO
 from Bio.Seq import Seq
 
+def mask_terminal_gaps(seq):
+    L = len(seq)
+    seq_trimmed = seq.lstrip('-')
+    left_gaps = L - len(seq_trimmed)
+    seq_trimmed = seq_trimmed.rstrip('-')
+    right_gaps = L - len(seq_trimmed) + left_gaps
+    return "N"*left_gaps + seq_trimmed + "N"*right_gaps 
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -13,6 +21,7 @@ if __name__ == '__main__':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument("--alignment", required=True, help="FASTA file of alignment")
+    parser.add_argument("--mask-terminal-gaps", action='store_true', help="fill all terminal gaps with N as they likely represent missing data")
     parser.add_argument("--mask-from-beginning", type = int, required=True, help="number of bases to mask from start")
     parser.add_argument("--mask-from-end", type = int, help="number of bases to mask from end")
     parser.add_argument("--mask-sites", nargs='+', type = int,  help="list of sites to mask")
@@ -29,6 +38,9 @@ if __name__ == '__main__':
     with open(args.output, 'w') as outfile:
         for record in Bio.SeqIO.parse(args.alignment, 'fasta'):
             seq = str(record.seq)
+            if args.mask_terminal_gaps:
+                seq = mask_terminal_gaps(seq)
+
             start = "N" * begin_length
             middle = seq[begin_length:-end_length]
             end = "N" * end_length


### PR DESCRIPTION
### Description of proposed changes    
SARS-CoV-2 has meaningful deletions. We currently fill these with `N`s which makes them invisible in auspice.  This was motivated initially by spurious gaps and uncertainty about their veracity. but multiple deletions have been confirmed and observed repeatedly. This PR reinstantiates gaps. 

 * remove `--fill-gaps` flag from the alignment step
 * explicitly fill terminal gaps with `N`s in the mask step. 

### Testing
I'll post a link to staging once its done....
