### PR TITLE
Reconstruct division trait for North America and Oceania

### DIFF
--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -70,7 +70,12 @@
     },
     {
       "key": "country_exposure",
-      "title": "Exposure History",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
       "type": "categorical"
     }
   ],

--- a/config/auspice_config_gisaid.json
+++ b/config/auspice_config_gisaid.json
@@ -65,7 +65,12 @@
     },
     {
       "key": "country_exposure",
-      "title": "Exposure History",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
       "type": "categorical"
     }
   ],

--- a/config/auspice_config_zh.json
+++ b/config/auspice_config_zh.json
@@ -70,7 +70,12 @@
     },
     {
       "key": "country_exposure",
-      "title": "Exposure History",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
       "type": "categorical"
     }
   ],

--- a/rules/builds.smk
+++ b/rules/builds.smk
@@ -446,11 +446,11 @@ rule translate:
         """
 
 def _get_sampling_trait_for_wildcards(wildcards):
-    mapping = {"north-america": "country", "oceania": "country"} # TODO: switch to "division"
+    mapping = {"north-america": "division", "oceania": "division"}
     return mapping[wildcards.region] if wildcards.region in mapping else "country"
 
 def _get_exposure_trait_for_wildcards(wildcards):
-    mapping = {"north-america": "country_exposure", "oceania": "country_exposure"} # TODO: switch to "division_exposure"
+    mapping = {"north-america": "division_exposure", "oceania": "division_exposure"}
     return mapping[wildcards.region] if wildcards.region in mapping else "country_exposure"
 
 rule traits:

--- a/scripts/adjust_regional_meta.py
+++ b/scripts/adjust_regional_meta.py
@@ -41,5 +41,7 @@ if __name__ == '__main__':
     metadata.loc[metadata.region != focal_region, 'country_exposure'] = metadata.region_exposure
     metadata.loc[(metadata.region == focal_region) & (metadata.region_exposure != focal_region), 'division_exposure'] = metadata.region_exposure
     metadata.loc[(metadata.region == focal_region) & (metadata.region_exposure != focal_region), 'country_exposure'] = metadata.region_exposure
+    metadata.loc[(metadata.region == focal_region) & (metadata.division_exposure.isna()), 'division_exposure'] = metadata.division
+    metadata.loc[(metadata.region == focal_region) & (metadata.country_exposure.isna()), 'country_exposure'] = metadata.country
 
     metadata.to_csv(args.output, index=False, sep="\t")


### PR DESCRIPTION
North America and Oceania are not very interesting at the country scale. This switches trait reconstruction to be at the division level. At this point given how `modify-tree-according-to-exposure` works, it's non-trivial to reconstruct multiple traits (this should probably get attention at some point), but thought it better to reconstruct the more useful / interesting trait.

I've tested this with a condensed local build and things seemed to work alright.

This required two fixes to make it work:
1. Guarantee that `division_exposure` is actually present in metadata
2. Make sure that `division_exposure` is exported into the auspice JSON by including it as a coloring

(2) is non-ideal, but this is a persistent issue with how we handle metadata. There's no way for something to be present as an attr and not be a coloring.