### PR TITLE
Update mask sites

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -59,12 +59,13 @@ partition_sequences:
 mask:
   # Number of bases to mask from the beginning and end of the alignment. These regions of the genome
   # are difficult to sequence accurately.
-  mask_from_beginning: 130
+  mask_from_beginning: 100
   mask_from_end: 50
 
   # Specific sites to mask in the reference genome's coordinates.
   # These are 1-indexed coordinates of sites that have been identified as prone to sequencing errors.
-  mask_sites: "18529 29849 29851 29853"
+  # Need to provide something here for the script to not crash, using "1" in this case
+  mask_sites: "1"
 
 # TreeTime settings
 refine:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,8 +64,8 @@ mask:
 
   # Specific sites to mask in the reference genome's coordinates.
   # These are 1-indexed coordinates of sites that have been identified as prone to sequencing errors.
-  # Need to provide something here for the script to not crash, using "1" in this case
-  mask_sites: "1"
+  # 13402, 24389 and 24390 are restricted to Belgian samples
+  mask_sites: "13402 24389 24390"
 
 # TreeTime settings
 refine:


### PR DESCRIPTION
The original list of masked sites were chosen to mitigate against specific sequencing issues in early Wuhan samples. This is now longer the case. This PR removes these sites. Additionally, I walked through sites listed here http://virological.org/t/issues-with-sars-cov-2-sequencing-data/473, and could reproduce the noted homoplasies. However, I didn't see any that I was concerned were actually harming phylogenetic reconstruction (the homoplasies are scattered across the tree).