### PR TITLE
update date exclusions

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,7 +42,7 @@ filter:
   min_length: 25000
 
   # Omit sequences with incomplete date annotations.
-  exclude_where: "date='2020' date='2020-01-XX' date='2020-02-XX' date='2020-03-XX' date='2020-04-XX' date='2020-01' date='2020-02' date='2020-03' date='2020-04'"
+  exclude_where: "date='2020' date='2020-01-XX' date='2020-02-XX' date='2020-03-XX' date='2020-04-XX' date='2020-05-XX' date='2020-06-XX' date='2020-01' date='2020-02' date='2020-03' date='2020-04' date='2020-05' date='2020-06'"
 
   # Select a subset of sequences per unique geographic and temporal group.
   # This limits the number of sequences in the base build to prevent long runtimes.


### PR DESCRIPTION
Updates the initial filtering to remove ambiguous dates for May & June 2020. 

Running (without group-by filtering) indicates that there are no offending sequences, but these filtering criteria are good to have nonetheless
```
636 sequences were dropped during filtering
        238 of these were dropped because they were in config/exclude.txt
        99 of these were dropped because of 'date=2020'
        6 of these were dropped because of 'date=2020-01-XX'
        13 of these were dropped because of 'date=2020-02-XX'
        0 of these were dropped because of 'date=2020-03-XX'
        0 of these were dropped because of 'date=2020-04-XX'
        0 of these were dropped because of 'date=2020-05-XX'
        0 of these were dropped because of 'date=2020-06-XX'
        2 of these were dropped because of 'date=2020-01'
        3 of these were dropped because of 'date=2020-02'
        135 of these were dropped because of 'date=2020-03'
        15 of these were dropped because of 'date=2020-04'
        0 of these were dropped because of 'date=2020-05'
        0 of these were dropped because of 'date=2020-06'
        125 of these were dropped because they were shorter than minimum length of 25000bp
        0 of these were dropped because of subsampling criteria

        0 sequences were added back because they were in config/include.txt
26864 sequences have been written out to results/filtered.fasta
```
