### PR TITLE
produce an unsampled, non-temporal build

### DIFF
--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -86,7 +86,7 @@
   ],
   "display_defaults": {
     "color_by": "country",
-    "distance_measure": "num_date",
+    "distance_measure": "div",
     "geo_resolution": "country",
     "map_triplicate": true,
     "branch_label": "none"

--- a/config/config_non-subsampled.yaml
+++ b/config/config_non-subsampled.yaml
@@ -1,0 +1,6 @@
+
+filter:
+  exclude_where: "host=rat" # using a meaningless query to avoid modifying the actual rule
+  sequences_per_group: 10000000
+subsample_focus:
+  seq_per_group_global: 10000000

--- a/rules/builds.smk
+++ b/rules/builds.smk
@@ -316,13 +316,16 @@ rule tree:
         # Multiple sequence alignments can use up to 40 times their disk size in
         # memory, especially for larger alignments.
         # Note that Snakemake >5.10.0 supports input.size_mb to avoid converting from bytes to MB.
-        mem_mb=lambda wildcards, input: 40 * int(input.size / 1024 / 1024)
+        mem_mb=lambda wildcards, input: 40 * int(input.size / 1024 / 1024),
+    params:
+        mem_gb=lambda wildcards, resources: int(resources.mem_mb / 1024)-1,
     conda: config["conda_environment"]
     shell:
         """
         augur tree \
             --alignment {input.alignment} \
             --output {output.tree} \
+            --tree-builder-args="-mem {params.mem_gb}G" \
             --nthreads {threads} 2>&1 | tee {log}
         """
 

--- a/rules/builds.smk
+++ b/rules/builds.smk
@@ -311,7 +311,7 @@ rule tree:
         "logs/tree_{region}.txt"
     benchmark:
         "benchmarks/tree_{region}.txt"
-    threads: 4
+    threads: 8
     resources:
         # Multiple sequence alignments can use up to 40 times their disk size in
         # memory, especially for larger alignments.
@@ -368,16 +368,7 @@ rule refine:
             --metadata {input.metadata} \
             --output-tree {output.tree} \
             --output-node-data {output.node_data} \
-            --root {params.root} \
-            --timetree \
-            --clock-rate {params.clock_rate} \
-            --clock-std-dev {params.clock_std_dev} \
-            --coalescent {params.coalescent} \
-            --date-inference {params.date_inference} \
-            --divergence-unit {params.divergence_unit} \
-            --date-confidence \
-            --no-covariance \
-            --clock-filter-iqd {params.clock_filter_iqd} 2>&1 | tee {log}
+            --root {params.root}
         """
 
 rule ancestral:
@@ -584,7 +575,6 @@ rule export:
         branch_lengths = rules.refine.output.node_data,
         nt_muts = rules.ancestral.output.node_data,
         aa_muts = rules.translate.output.node_data,
-        traits = rules.traits.output.node_data,
         auspice_config = config["files"]["auspice_config"],
         colors = rules.colors.output.colors,
         lat_longs = config["files"]["lat_longs"],
@@ -603,7 +593,7 @@ rule export:
         augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \
-            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.traits} {input.clades} {input.recency} \
+            --node-data {input.branch_lengths} {input.nt_muts} {input.aa_muts} {input.clades} {input.recency} \
             --auspice-config {input.auspice_config} \
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \

--- a/scripts/modify-tree-according-to-exposure.py
+++ b/scripts/modify-tree-according-to-exposure.py
@@ -36,11 +36,12 @@ def modify(node):
         "name": node["name"]+"_travel_history",
         "node_attrs": {
             "div": node["node_attrs"]["div"],
-            "num_date": node["node_attrs"]["num_date"],
             EXPOSURE_TRAIT: node["node_attrs"][EXPOSURE_TRAIT]
         },
         "children": [node]
     }
+    if "num_date" in node["node_attrs"]:
+      n["node_attrs"]["num_date"] = node["node_attrs"]["num_date"]
 
     # Store a backup of the original exposure, to put back in later
     node["node_attrs"]["exposure_backup"] = node["node_attrs"][EXPOSURE_TRAIT]


### PR DESCRIPTION
@huddlej @rneher and others -- here is the branch I'm using to produce non-subsampled builds. As you can see there are a few modifications i'm making to the snakemake file. Are there ways we can streamline this? I could think of a couple but am unsure the best practices here:
* A `config["refine"]["infer_temporal_structure"]` (bool) could be defined, and the snakemake rule `refine` calls `augur refine` with the appropriate parameters. 
* A `config["refine"]["traits"]["run"]` (bool) could be set and the `export` rule updated to dynamically use the appropriate node-data JSONs
* The change to `scripts/modify-tree-according-to-exposure.py` should probably be in master

Are there cleverer ways to accomplish this? (I'm also happy keeping a parallel branch, but it gets tedious...)