### PR TITLE
correct typo in mask-alignment.py

### DIFF
--- a/scripts/mask-alignment.py
+++ b/scripts/mask-alignment.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     parser.add_argument("--output", required=True, help="FASTA file of output alignment")
     args = parser.parse_args()
 
-    being_length = 0
+    begin_length = 0
     if args.mask_from_beginning:
         begin_length = args.mask_from_beginning
     end_length = 0


### PR DESCRIPTION

### Description of proposed changes    
This corrects a typo in `scripts/mask-alignment.py`, replacing one mistpyed instance of `being_length` with the expected variable name, `begin_length`.
