### PR TITLE
Notify Slack when new automated builds start

### DIFF
--- a/rules/nextstrain_exports.smk
+++ b/rules/nextstrain_exports.smk
@@ -277,6 +277,19 @@ rule deploy_to_staging:
         fi
         """
 
+onstart:
+    slack_message = f"Build {deploy_origin} started."
+
+    if SLACK_TOKEN and SLACK_CHANNEL:
+        shell(f"""
+            curl https://slack.com/api/chat.postMessage \
+                --header "Authorization: Bearer $SLACK_TOKEN" \
+                --form-string channel="$SLACK_CHANNEL" \
+                --form-string text={{slack_message:q}} \
+                --fail --silent --show-error \
+                --include
+        """)
+
 onerror:
     slack_message = f"Build {deploy_origin} failed."
 


### PR DESCRIPTION
Handy for noticing if submitted builds (which ncov-ingest messages
about) never start or if there's a significant delay introduced by the
scheduler.
