### PR TITLE
Allow non-region 'focal' geographies

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -65,6 +65,9 @@ mask:
   # 13402, 24389 and 24390 are restricted to Belgian samples
   mask_sites: "13402 24389 24390"
 
+adjust_metadata_regions:
+  focal_resolution: "region"
+
 tree:
   tree-builder-args: "'-ninit 10 -n 4'"
 

--- a/rules/builds.smk
+++ b/rules/builds.smk
@@ -421,14 +421,16 @@ rule adjust_metadata_regions:
     output:
         metadata = "results/{build_name}/metadata_adjusted.tsv"
     params:
-        region = lambda wildcards: config["builds"][wildcards.build_name]["region"]
+        focal_resolution = config["adjust_metadata_regions"]["focal_resolution"],
+        focal_label = lambda wildcards: config["builds"][wildcards.build_name][config["adjust_metadata_regions"]["focal_resolution"]]
     log:
         "logs/adjust_metadata_regions_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """
         {python:q} scripts/adjust_regional_meta.py \
-            --region {params.region:q} \
+            --focal-resolution {params.focal_resolution:q} \
+            --focal-label {params.focal_label:q} \
             --metadata {input.metadata} \
             --output {output.metadata} 2>&1 | tee {log}
         """


### PR DESCRIPTION
### Description of proposed changes    

In the current behavior `adjust_regional_meta.py` takes a focal region, say "North America" and flattens country, division and location for all samples where region != "North America". 

This commit changes the flags in adjust_regional_meta to allow `--focal-resolution` and `--focal-label`. This allows focal resolution of "division" and focal label of "Washington". Doing this will additionally flatten county, division, location for samples from North America that don't belong to Washington. This allows for coloring of Washington locations that doesn't get swamped by locations from other regions in North America.

I believe this should be generally useful for geographically-focused builds.

### Testing

I've tested this with `snakemake --profile profiles/nextstrain` and `snakemake`. Things seem to be in order. 


