### PR TITLE
Add rule to estimate nucleotide mutation frequencies

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -93,6 +93,11 @@ frequencies:
   narrow_bandwidth: 0.05
   proportion_wide: 0.0
 
+  # Diffusion frequency settings
+  minimal_frequency: 0.01
+  stiffness: 20
+  inertia: 0.2
+
 #
 # Region-specific settings
 #

--- a/rules/builds.smk
+++ b/rules/builds.smk
@@ -789,6 +789,37 @@ rule tip_frequencies:
             --output {output.tip_frequencies_json} 2>&1 | tee {log}
         """
 
+rule nucleotide_mutation_frequencies:
+    message: "Estimate nucleotide mutation frequencies"
+    input:
+        alignment = rules.combine_samples.output.alignment,
+        metadata = _get_metadata_by_wildcards
+    output:
+        frequencies = "results/{build_name}/nucleotide_mutation_frequencies.json"
+    log:
+        "logs/nucleotide_mutation_frequencies_{build_name}.txt"
+    params:
+        min_date = config["frequencies"]["min_date"],
+        minimal_frequency = config["frequencies"]["minimal_frequency"],
+        pivot_interval = config["frequencies"]["pivot_interval"],
+        stiffness = config["frequencies"]["stiffness"],
+        inertia = config["frequencies"]["inertia"]
+    conda: config["conda_environment"]
+    shell:
+        """
+        augur frequencies \
+            --method diffusion \
+            --alignments {input.alignment} \
+            --gene-names nuc \
+            --metadata {input.metadata} \
+            --min-date {params.min_date} \
+            --minimal-frequency {params.minimal_frequency} \
+            --pivot-interval {params.pivot_interval} \
+            --stiffness {params.stiffness} \
+            --inertia {params.inertia} \
+            --output {output.frequencies} 2>&1 | tee {log}
+        """
+
 def export_title(wildcards):
     # TODO: maybe we could replace this with a config entry for full/human-readable build name?
     location_name = wildcards.build_name

--- a/rules/nextstrain_exports.smk
+++ b/rules/nextstrain_exports.smk
@@ -69,6 +69,9 @@ rule export_all_regions:
             --latlong {input.lat_longs}
         """
 
+rule all_mutation_frequencies:
+    input: expand("results/{build_name}/nucleotide_mutation_frequencies.json", build_name=BUILD_NAMES)
+
 #
 # Rules for custom auspice exports for the Nextstrain team.
 #


### PR DESCRIPTION
Estimates frequencies of nucleotide mutations that reach at least 1% frequency
per build. Also, adds settings specific to the diffusion frequency method to the
config file and uses existing settings from the tip frequencies configuration as
much as possible.

Note, these frequencies are never requested by the `all` rule, so the user need
to know they can be calculated and explicitly request them. If these frequencies
work as expected, they can be added as default outputs of the builds.