### PR TITLE
Enable subsample filtering with augur filter's query argument

### DIFF
--- a/docs/customizing-analysis.md
+++ b/docs/customizing-analysis.md
@@ -113,9 +113,22 @@ lac-leman:
 
 All entries above canton level (the 'contextual' samples) specify priorities.
 Currently, we have only implemented one type of priority called `proximity`.
-It attempts to selected sequences as close as possible to the focal samples
-specified as `focus: division`.
+It attempts to selected sequences as close as possible to the focal samples specified as `focus: division`.
 The argument of the latter has to match the name of one of the other subsamples.
+
+In addition to the `exclude` filter, you can also specify strains to keep by providing a `query`.
+The `query` field uses augur filter's `--query` argument (introduced in version 8.0.0) and supports [pandas-style logical operators](https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#indexing-query).
+For example, the following exclusionary filter,
+
+```yaml
+exclude: "--exclude-where 'region!={region}' 'country!={country}' 'division!={division}'"
+```
+
+can also be written as an inclusionary filter like so:
+
+```yaml
+query: --query "(region == {region}) & (country == {country}) & (division == '{division}')"
+```
 
 If you need parameters in a way that isn't represented by the configuration file, [create a new issue in the ncov repository](https://github.com/nextstrain/ncov/issues/new) to let us know.
 

--- a/my_profiles/example/builds.yaml
+++ b/my_profiles/example/builds.yaml
@@ -16,7 +16,7 @@ builds:
   # with a build name that will produce the following URL fragment on Nextstrain/auspice:
   # /ncov/north-america/usa/washington/king-county
   north-america_usa_washington_king-county: # name of the build; this can be anything
-    subsampling_scheme: location # what subsampling method to use (see parameters.yaml)
+    subsampling_scheme: county
     region: North America
     country: USA
     division: Washington
@@ -29,7 +29,7 @@ builds:
   # with a build name that will produce the following URL fragment on Nextstrain/auspice:
   # /ncov/north-america/usa/washington
   north-america_usa_washington:
-    subsampling_scheme: division # we named the subsampling scheme meant for divisions accordingly; you can rename these whatever you'd like
+    subsampling_scheme: division
     region: North America
     country: USA
     division: Washington
@@ -57,6 +57,32 @@ builds:
   global:
     subsampling_scheme: region_global
     region: global
+
+# Define custom subsampling logic for county-level builds.
+subsampling:
+  county:
+    # Focal samples for location
+    focal:
+      group_by: "year month"
+      seq_per_group: 300
+      # Use augur filter's query argument to filter strains with pandas-style logic expressions.
+      # This can be easier to read than the corresponding filter by exclusion.
+      query: --query "(country == '{country}') & (division == '{division}') & (location == '{location}')"
+
+    # Samples that are genetically related to the focal samples
+    related:
+      group_by: "country year month"
+      seq_per_group: 20
+      exclude: "--exclude-where 'location={location}'"
+      priorities:
+        type: "proximity"
+        focus: "focal"
+
+    # Contextual samples from the rest of the world
+    contextual:
+      group_by: "country year month"
+      seq_per_group: 10
+      exclude: "--exclude-where 'location={location}'"
 
 # Here, you can specify what type of auspice_config you want to use
 # and what description you want. These will apply to all the above builds.

--- a/my_profiles/example/builds.yaml
+++ b/my_profiles/example/builds.yaml
@@ -16,12 +16,12 @@ builds:
   # with a build name that will produce the following URL fragment on Nextstrain/auspice:
   # /ncov/north-america/usa/washington/king-county
   north-america_usa_washington_king-county: # name of the build; this can be anything
-    subsampling_scheme: county
+    subsampling_scheme: county # use a custom subsampling scheme defined below
     region: North America
     country: USA
     division: Washington
     location: King County
-    # Whatever your lowest geographic area is (here, 'location' since we are doing a county in the USA)
+    # Whatever your finest geographic scale is (here, 'location' since we are doing a county in the USA)
     # list 'up' from here the geographic area that location is in.
     # Here, King County is in Washington state, is in USA, is in North America.
 
@@ -29,7 +29,7 @@ builds:
   # with a build name that will produce the following URL fragment on Nextstrain/auspice:
   # /ncov/north-america/usa/washington
   north-america_usa_washington:
-    subsampling_scheme: division
+    subsampling_scheme: division # use a default subsampling scheme defined in defaults/parameters.yaml
     region: North America
     country: USA
     division: Washington

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -345,6 +345,7 @@ rule subsample:
         sequences_per_group = _get_specific_subsampling_setting("seq_per_group"),
         exclude_argument = _get_specific_subsampling_setting("exclude", optional=True),
         include_argument = _get_specific_subsampling_setting("include", optional=True),
+        query_argument = _get_specific_subsampling_setting("query", optional=True),
         priority_argument = get_priority_argument
     conda: config["conda_environment"]
     shell:
@@ -355,6 +356,7 @@ rule subsample:
             --include {input.include} \
             {params.exclude_argument} \
             {params.include_argument} \
+            {params.query_argument} \
             {params.priority_argument} \
             --group-by {params.group_by} \
             --sequences-per-group {params.sequences_per_group} \


### PR DESCRIPTION
Adds support for a `query` key to individual subsampling definitions, allowing
users to filter strains by specifying the attribute values needed to retain
strains. This approach can make subsampling filters easier to read than the
corresponding exclusionary filters with `--exclude-where`.

Also adds an example of how to use the new `query` key in a county-level build
for King County in Washington State.

Note that the `--query` argument is only available in augur versions 8.0.0 and
later, so this PR also updates the required version of augur in the conda
environment file.