### PR TITLE
Update interface to read_sequences in combine and dedup sequences

### DIFF
--- a/scripts/combine-and-dedup-fastas.py
+++ b/scripts/combine-and-dedup-fastas.py
@@ -13,6 +13,11 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Read sequences with augur to benefit from additional checks for duplicates.
-    sequences = list(read_sequences(*args.input).values())
+    sequences = read_sequences(*args.input)
+
+    # Convert dictionary of sequences by id to a list, for compatibility with
+    # augur versions <9.0.0.
+    if isinstance(sequences, dict):
+        sequences = list(sequences.values())
 
     SeqIO.write(sequences, args.output, 'fasta')


### PR DESCRIPTION
Updates the interface for the `read_sequences` function for compatibility with
augur version 9.0.0 and later while also maintaining backwards compatibility
with earlier augur versions. This commit should prevent broken workflows when
users upgrade augur while supporting older versions.