### PR TITLE
Revise tutorial quickstart and setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ If you were running customized builds before this, these changes may cause some 
 
 **We've written a comprehensive guide to get you up and running in <1 hr. Click on the below links to follow it. It covers:**
 
-0. [**Introduction and quickstart**](https://nextstrain.github.io/ncov/index) _(Start here)_
-1. [**Preparing your data**](https://nextstrain.github.io/ncov/data-prep)
-2. [**Setup and installation**](https://nextstrain.github.io/ncov/setup.md)
+0. [**Introduction**](https://nextstrain.github.io/ncov/index) _(Start here)_
+1. [**Setup and installation**](https://nextstrain.github.io/ncov/setup.md)
+2. [**Preparing your data**](https://nextstrain.github.io/ncov/data-prep)
 3. [**Orientation: analysis workflow**](https://nextstrain.github.io/ncov/orientation-workflow)
 4. [**Orientation: which files should I touch?**](https://nextstrain.github.io/ncov/orientation-files)
 5. [**Running & troubleshooting**](https://nextstrain.github.io/ncov/running)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you were running customized builds before this, these changes may cause some 
 **We've written a comprehensive guide to get you up and running in <1 hr. Click on the below links to follow it. It covers:**
 
 0. [**Introduction**](https://nextstrain.github.io/ncov/index) _(Start here)_
-1. [**Setup and installation**](https://nextstrain.github.io/ncov/setup.md)
+1. [**Setup and installation**](https://nextstrain.github.io/ncov/setup)
 2. [**Preparing your data**](https://nextstrain.github.io/ncov/data-prep)
 3. [**Orientation: analysis workflow**](https://nextstrain.github.io/ncov/orientation-workflow)
 4. [**Orientation: which files should I touch?**](https://nextstrain.github.io/ncov/orientation-files)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ If you were running customized builds before this, these changes may cause some 
 9. [**Interpreting your results**](https://nextstrain.github.io/ncov/interpretation)
 10. [**Writing a narrative to highlight key findings**](https://nextstrain.github.io/ncov/narratives)
 
-
 ### Download formatted datasets
 
 The hCoV-19 / SARS-CoV-2 genomes were generously shared via GISAID. We gratefully acknowledge the Authors, Originating and Submitting laboratories of the genetic sequence and metadata made available through GISAID on which this research is based.

--- a/docs/data-prep.md
+++ b/docs/data-prep.md
@@ -46,7 +46,8 @@ NewZealand/01/2020  ncov   EPI_ISL_413490  ?                   2020-02-27  Ocean
 In total there are 23 columns of metadata for each genome; see the last section of this page for an in-depth walkthrough.
 
 #### Required metadata
-**A valid metadata file must include the following fields:**
+
+A valid metadata file must include the following fields:
 
 | Field | Example value | Description | Formatting |
 |---|---|---|---|
@@ -239,5 +240,5 @@ Date the genome was submitted to a public database (most often GISAID).
 In `YYYY-MM-DD` format (see `date` for more information on this formatting).
 
 
-## [Previous Section: Setup and Installation](setup.md)
+## [Previous Section: Setup and installation](setup.md)
 ## [Next Section: Orientation: workflow](orientation-workflow.md)

--- a/docs/data-prep.md
+++ b/docs/data-prep.md
@@ -239,4 +239,5 @@ Date the genome was submitted to a public database (most often GISAID).
 In `YYYY-MM-DD` format (see `date` for more information on this formatting).
 
 
-## [Next Section: Setup and Installation](setup.md)
+## [Previous Section: Setup and Installation](setup.md)
+## [Next Section: Orientation: workflow](orientation-workflow.md)

--- a/docs/data-prep.md
+++ b/docs/data-prep.md
@@ -8,9 +8,7 @@ To use Nextstrain to analyze your own data, you'll need to prepare two files:
 1. A `fasta` file with viral genomic sequences
 2. A corresponding `tsv` file with metadata describing each sequence
 
-
 We've created an example dataset in the `data` directory. This consists of a fasta file with viral genomes sourced from Genbank, and a corresponding TSV with metadata describing these sequences.
-
 
 ### Formatting your sequence data
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,59 +4,30 @@ This template and tutorial will walk you through the process of running a basic 
 We've created these resources with the goal of enabling Departments of Public Health to start using Nextstrain to understand their SARS-CoV-2 genomic data within 1-2 hours.
 In addition to the phylogenetic analysis described here, you can use our "drag-and-drop" tool for a clade assignment, mutations calling, and basic sequence quality checks at [clades.nextstrain.org](https://clades.nextstrain.org/).
 
-## Overview: complete walkthrough
-### Getting started with analysis
-_The starting point for this section is a FASTA file with sequence data + a TSV file with metadata. You can alternately use our example data to start._
-
-[1. Setup and installation](setup.md)
-[2. Preparing your data](data-prep.md)
-[3. Orientation: analysis workflow](orientation-workflow.md)
-[4. Orientation: which files should I touch?](orientation-files.md)
-[5. Running & troubleshooting](running.md)
-[6. Customizing your analysis](customizing-analysis.md)
-[7. Customizing your visualization](customizing-visualization.md)
-
-### Getting started with visualization & interpretation
-_The starting point for this section is a JSON file. You can alternately use our examples to start._
-
-[8. Options for visualizing and sharing results](sharing.md)
-[9. Interpreting your results](interpretation.md)
-[10. Writing a narrative to highlight key findings](narratives.md)
-_11. Case studies: interpreting your data (coming soon!)_
-
-## Quickstart
-
-If you'd prefer, you can also start by running a basic analysis on the provided example data and/or visualizing the output with the [auspice.us](auspice.us) drag-and-drop viewer. If you get stuck at any point, you can find more detailed instructions in the full tutorial outlined above.
-
 We also recommend [this 1-hour video overview](https://youtu.be/m4_F2tG58Pc) by Heather Blankenship on how to deploy Nextstrain for a Public Health lab.
 
-#### 1. Clone this repository
-```
-git clone https://github.com/nextstrain/ncov.git
-```
+## Overview: complete walkthrough
 
-#### 2. Install augur and auspice for bioinformatics and visualization, respectively
-_Note: this assumes you have conda installed. If this doesn't work for you, see our full installation instructions [here](https://nextstrain.org/docs/getting-started/local-installation)._
-```
-curl http://data.nextstrain.org/nextstrain.yml --compressed -o nextstrain.yml
-conda env create -f nextstrain.yml
-conda activate nextstrain
-npm install --global auspice
-```
+### Getting started with analysis
 
-#### 3. Run basic analysis on example data
-```
-ncov$ conda activate nextstrain
-ncov$ snakemake --profile ./my_profiles/example
-```
+The starting point for this section is a FASTA file with sequence data + a TSV file with metadata. You can alternately use our example data to start.
 
+  1. [Setup and installation](setup.md)
+  2. [Preparing your data](data-prep.md)
+  3. [Orientation: analysis workflow](orientation-workflow.md)
+  4. [Orientation: which files should I touch?](orientation-files.md)
+  5. [Running & troubleshooting](running.md)
+  6. [Customizing your analysis](customizing-analysis.md)
+  7. [Customizing your visualization](customizing-visualization.md)
 
-#### 4. Visualize your results (or our example output)
-Go to `https://auspice.us` in your browser.
-Drag and drop any of the JSON files from `./auspice/*.json` anywhere on the screen.
+### Getting started with visualization & interpretation
 
-Voila!
+The starting point for this section is a JSON file. You can alternately use our examples to start.
 
+  8. [Options for visualizing and sharing results](sharing.md)
+  9. [Interpreting your results](interpretation.md)
+  10. [Writing a narrative to highlight key findings](narratives.md)
+  11. _Case studies: interpreting your data (coming soon!)_
 
 ## Help
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,8 @@ In addition to the phylogenetic analysis described here, you can use our "drag-a
 ### Getting started with analysis
 _The starting point for this section is a FASTA file with sequence data + a TSV file with metadata. You can alternately use our example data to start._
 
-[1. Preparing your data](data-prep.md)
-[2. Set up and installation](setup.md)
+[1. Setup and installation](setup.md)
+[2. Preparing your data](data-prep.md)
 [3. Orientation: analysis workflow](orientation-workflow.md)
 [4. Orientation: which files should I touch?](orientation-files.md)
 [5. Running & troubleshooting](running.md)

--- a/docs/orientation-workflow.md
+++ b/docs/orientation-workflow.md
@@ -42,5 +42,5 @@ The components in this diagram **constitute a Nextstrain "build" -- i.e., a set 
 
 Builds are particularly important if you frequently want to run several different analysis workflows or datasets. For example, if you wanted to run one analysis on just your data and another analysis that incorporates background / contextual sequences, you could configure two different _builds_ (one for each of these workflows). We'll cover this in more detail in the [basic build configuration](running.md) section.
 
-## [Previous Section: Setup and installation](setup.md)
+## [Previous Section: Preparing your data](data-prep.md)
 ## [Next Section: Orientation: which files should I touch?](orientation-files.md)

--- a/docs/running.md
+++ b/docs/running.md
@@ -51,7 +51,9 @@ To adapt this for your own analyses:
 
   1. copy `my_profiles/example` to `my_profiles/<my-new-name>`
   1. open and modify the `builds.yaml` file in this directory to include your geographic area(s) of interest and remove any builds that are not relevant to your work
-  1. open and modify the `config.yaml` file in this directory such that it references the path to your new custom `builds.yaml` instead of the example builds file
+  1. open and modify the `config.yaml` file in this directory such that it references:
+    - the path to your new custom `builds.yaml` instead of the example builds file
+    - the path to your own sequences and metadata instead of the example data
 
 ## Step 3: Run the workflow
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -23,6 +23,7 @@ Let's start with defining a build in `./my_profiles/example/builds.yaml`.
 **We use the `builds.yaml` file to define what geographic areas of the world we want to focus on. Each block in this file will produce a separate output JSON for visualization**.
 
 The first block of the provided `./my_profiles/example/builds.yaml` file looks like this:
+
 ```
 builds:
   # Focus on King County (location) in Washington State (division) in the USA (country)
@@ -38,17 +39,19 @@ builds:
     # list 'up' from here the geographic area that location is in.
     # Here, King County is in Washington state, is in USA, is in North America.
 ```
+
 Looking at this example, we can see that each build has a:
+
 - `build_name`, which is used for naming output files
 - `subsampling_scheme`, which specifies how sequences are selected. Default schemes exist for `region`, `country`, and `division`. Custom schemes [can be defined](customizing-analysis.md).
 - `region`, `country`, `division`, `location`: specify geographic attributes of the sample used for subsampling
 
 The rest of the builds defined in this file serve as examples for division-, country- or region-focused analyses.
+To adapt this for your own analyses:
 
-**To adapt this for your own analyses, copy `my_profiles/example` to `my_profiles/<my-new-name>` and open the `builds.yaml`
-file in this directory.**
-
-Go ahead and **swap out the values in this file with the geographic area of interest to you.** You can add, disable (comment out), or remove as many of these build definitions as you'd like.
+  1. copy `my_profiles/example` to `my_profiles/<my-new-name>`
+  1. open and modify the `builds.yaml` file in this directory to include your geographic area(s) of interest and remove any builds that are not relevant to your work
+  1. open and modify the `config.yaml` file in this directory such that it references the path to your new custom `builds.yaml` instead of the example builds file
 
 ## Step 3: Run the workflow
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -52,8 +52,8 @@ To adapt this for your own analyses:
   1. copy `my_profiles/example` to `my_profiles/<my-new-name>`
   1. open and modify the `builds.yaml` file in this directory to include your geographic area(s) of interest and remove any builds that are not relevant to your work
   1. open and modify the `config.yaml` file in this directory such that it references:
-    - the path to your new custom `builds.yaml` instead of the example builds file
-    - the path to your own sequences and metadata instead of the example data
+     - the path to your new custom `builds.yaml` instead of the example builds file
+     - the path to your own sequences and metadata instead of the example data
 
 ## Step 3: Run the workflow
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,20 +1,19 @@
-# Setup  
+# Setup
 
-For this tutorial, there are three components to set up. Depending on what you'd like to do, you may need one, two, or all of these components.  
+For this tutorial, there are three components to set up. Depending on what you'd like to do, you may need one, two, or all of these components.
 
-
-## 1. Make a copy of this tutorial [required for all]  
+## 1. Make a copy of this tutorial [required for all]
 
 There are two ways to do this:
-* [Recommended] If you're familiar with git, clone this repository either via the web interface, a GUI such as gitkraken, or the command line:  
-```bash  
+* [Recommended] If you're familiar with git, clone this repository either via the web interface, a GUI such as gitkraken, or the command line:
+```bash
 git clone https://github.com/nextstrain/ncov.git
 ```
 
 * [Alternative] If you're not familiar with git, you can also download a copy of these files via the buttons on the left.
 
 
-## 2. Install augur [required for running analysis]  
+## 2. Install augur [required for running analysis]
 
 You can find instructions for installing augur [here](https://nextstrain.org/docs/getting-started/introduction).
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,11 +32,11 @@ Run a basic workflow on example data, to confirm that your Nextstrain environmen
 
 ```
 conda activate nextstrain
-snakemake --cores 3 --profile ./my_profiles/getting_started
+snakemake --cores 4 --profile ./my_profiles/getting_started
 ```
 
 The `getting_started` profile produces a minimal global phylogeny for visualization in auspice.
-This workflow should complete in XX minutes on a MacBook Pro with three cores.
+This workflow should complete in about 5 minutes on a MacBook Pro (2.7 GHz Intel Core i5) with four cores.
 
 ## 4. Visualize the phylogeny for example data
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,33 +5,33 @@ The following steps will prepare you to run complete analyses of SARS-CoV-2 data
 ## 1. Make a copy of this tutorial
 
 There are two ways to do this:
-* [Recommended] If you're familiar with git, clone this repository either via the web interface, a GUI such as gitkraken, or the command line:
+
+  * [Recommended] If you're familiar with git, clone this repository either via the web interface, a GUI such as [GitKraken](https://www.gitkraken.com/), or the command line:
 
 ```bash
 git clone https://github.com/nextstrain/ncov.git
 ```
 
-* [Alternative] If you're not familiar with git, you can also download a copy of these files via the buttons on the left.
+  * [Alternative] If you're not familiar with git, you can also download a copy of these files via the buttons on the left.
 
-## 2. Install augur and auspice for bioinformatics and visualization, respectively
+## 2. Setup your Nextstrain environment
 
 Create a Nextstrain conda environment with augur and auspice installed.
 If you do not have conda installed already, [see our full installation instructions for more details](https://nextstrain.org/docs/getting-started/local-installation).
-If you are running Windows, we recommend working through Windows Subsystem for Linux (WSL) - you can find out how to set this up [here](https://nextstrain.org/docs/getting-started/windows-help).
+If you are running Windows, [see our documentation about setting up the Windows Subsystem for Linux (WSL)](https://nextstrain.org/docs/getting-started/windows-help).
 
-```
+```bash
 curl http://data.nextstrain.org/nextstrain.yml --compressed -o nextstrain.yml
 conda env create -f nextstrain.yml
 conda activate nextstrain
 npm install --global auspice
 ```
 
-## 3. Run a basic analysis on example data
+## 3. Run a basic analysis with example data
 
-Run a basic workflow on example data, to confirm that your Nextstrain environment is properly configured.
+Run a basic workflow with example data, to confirm that your Nextstrain environment is properly configured.
 
-```
-conda activate nextstrain
+```bash
 snakemake --cores 4 --profile ./my_profiles/getting_started
 ```
 
@@ -41,7 +41,7 @@ This workflow should complete in about 5 minutes on a MacBook Pro (2.7 GHz Intel
 ## 4. Visualize the phylogeny for example data
 
 Go to [https://auspice.us](https://auspice.us) in your browser.
-Drag and drop any of the JSON files from `./auspice/*.json` anywhere on the screen.
+Drag and drop the JSON file `auspice/ncov_global.json` anywhere on the [https://auspice.us](https://auspice.us) landing page, to visualize the resulting phylogeny.
 
 ## Advanced reading: considerations for keeping a 'Location Build' up-to-date
 
@@ -75,7 +75,7 @@ For the [`south-usa-sarscov2`](https://github.com/emmahodcroft/south-usa-sarscov
 To run this, one would call the following from within `ncov`:
 
 ```bash
-ncov$ snakemake --cores 1 --profile ../south-usa-sarscov2/profiles/south-central/
+snakemake --cores 1 --profile ../south-usa-sarscov2/profiles/south-central/
 ```
 
 ## [Next Section: Preparing your data](data-prep.md)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,32 +1,47 @@
-# Setup
+# Setup and installation
 
-For this tutorial, there are three components to set up. Depending on what you'd like to do, you may need one, two, or all of these components.
+The following steps will prepare you to run complete analyses of SARS-CoV-2 data by installing required software and running a simple example workflow.
 
-## 1. Make a copy of this tutorial [required for all]
+## 1. Make a copy of this tutorial
 
 There are two ways to do this:
 * [Recommended] If you're familiar with git, clone this repository either via the web interface, a GUI such as gitkraken, or the command line:
+
 ```bash
 git clone https://github.com/nextstrain/ncov.git
 ```
 
 * [Alternative] If you're not familiar with git, you can also download a copy of these files via the buttons on the left.
 
+## 2. Install augur and auspice for bioinformatics and visualization, respectively
 
-## 2. Install augur [required for running analysis]
-
-You can find instructions for installing augur [here](https://nextstrain.org/docs/getting-started/introduction).
-
-Note there are many options for installing augur, including local installations from `conda`, `pip`, and from source, and container installation - take a minute to look at which may be best for you.
-
+Create a Nextstrain conda environment with augur and auspice installed.
+If you do not have conda installed already, [see our full installation instructions for more details](https://nextstrain.org/docs/getting-started/local-installation).
 If you are running Windows, we recommend working through Windows Subsystem for Linux (WSL) - you can find out how to set this up [here](https://nextstrain.org/docs/getting-started/windows-help).
 
+```
+curl http://data.nextstrain.org/nextstrain.yml --compressed -o nextstrain.yml
+conda env create -f nextstrain.yml
+conda activate nextstrain
+npm install --global auspice
+```
 
-## 3. Install auspice [required only for local visualization; web-based, no-install options available]
+## 3. Run a basic analysis on example data
 
-You can find instructions for installing auspice [here](https://nextstrain.github.io/auspice/introduction/install).
+Run a basic workflow on example data, to confirm that your Nextstrain environment is properly configured.
 
----
+```
+conda activate nextstrain
+snakemake --cores 3 --profile ./my_profiles/getting_started
+```
+
+The `getting_started` profile produces a minimal global phylogeny for visualization in auspice.
+This workflow should complete in XX minutes on a MacBook Pro with three cores.
+
+## 4. Visualize the phylogeny for example data
+
+Go to [https://auspice.us](https://auspice.us) in your browser.
+Drag and drop any of the JSON files from `./auspice/*.json` anywhere on the screen.
 
 ## Advanced reading: considerations for keeping a 'Location Build' up-to-date
 
@@ -63,5 +78,4 @@ To run this, one would call the following from within `ncov`:
 ncov$ snakemake --cores 1 --profile ../south-usa-sarscov2/profiles/south-central/
 ```
 
-## [Previous Section: Preparing your data](data-prep.md)
-## [Next Section: Orientation: workflow](orientation-workflow.md)
+## [Next Section: Preparing your data](data-prep.md)

--- a/my_profiles/getting_started/builds.yaml
+++ b/my_profiles/getting_started/builds.yaml
@@ -1,0 +1,26 @@
+# This is where we define which builds we'd like to run.
+# This example includes one minimal global build.
+
+# Each build needs a name, a defined subsampling process, and geographic attributes used for subsampling.
+# Geography is specified by build attributes (e.g., `region`, `country`, `division`, `location`) that are referenced from subsampling schemes.
+
+# The default config file, `./defaults/parameters.yaml` has reasonable default subsampling methods for each geographic resolution.
+# These subsample primarily from the area of interest ("focus"), and add in background ("contextual") sequences from the rest of the world.
+# Contextual sequences that are genetically similar to (hamming distance) and geographically near the focal sequences are heavily prioritized.
+
+# In this example, we use these default methods. See other templates for examples of how to customize this subsampling scheme.
+builds:
+  # This build samples evenly from the globe
+  # with a build name that will produce the following URL fragment on Nextstrain/auspice:
+  # /ncov/global
+  global:
+    subsampling_scheme: region_global
+    region: global
+
+# Here, you can specify what type of auspice_config you want to use
+# and what description you want. These will apply to all the above builds.
+# If you want to specify specific files for each build - you can!
+# See the 'example_advanced_customization' builds.yaml
+files:
+  auspice_config: "my_profiles/example/my_auspice_config.json"
+  description: "my_profiles/example/my_description.md"

--- a/my_profiles/getting_started/config.yaml
+++ b/my_profiles/getting_started/config.yaml
@@ -11,8 +11,8 @@ configfile:
   - my_profiles/getting_started/builds.yaml # Pull in our list of desired builds
 
 config:
-  - sequences=data/minimal_example_sequences.fasta
-  - metadata=data/minimal_example_metadata.tsv
+  - sequences=data/example_sequences.fasta
+  - metadata=data/example_metadata.tsv
 
 # Set the maximum number of cores you want Snakemake to use for this pipeline.
 cores: 1

--- a/my_profiles/getting_started/config.yaml
+++ b/my_profiles/getting_started/config.yaml
@@ -1,0 +1,21 @@
+#####################################################################################
+#### NOTE: head over to `builds.yaml` to define what builds you'd like to run. ####
+#### (i.e., datasets and subsampling schemas)  ####
+#####################################################################################
+
+# This analysis-specific config file overrides the settings in the default config file.
+# If a parameter is not defined here, it will fall back to the default value.
+
+configfile:
+  - defaults/parameters.yaml # Pull in the default values
+  - my_profiles/getting_started/builds.yaml # Pull in our list of desired builds
+
+config:
+  - sequences=data/minimal_example_sequences.fasta
+  - metadata=data/minimal_example_metadata.tsv
+
+# Set the maximum number of cores you want Snakemake to use for this pipeline.
+cores: 1
+
+# Always print the commands that will be run to the screen for debugging.
+printshellcmds: True


### PR DESCRIPTION
### Description of proposed changes

This PR attempts to minimize the number of entry points for users to the tutorial content. This issue is fully described in #456. This PR moves much of the quickstart content into the setup/installation guide and removes the quickstart such that there is only a single entry point to the documentation for users.

This PR also reorders the setup/installation instructions to precede the "preparing data" section, so users have a working Nextstrain environment before they embark on the rest of the tutorial. The installation instructions are copied from the quickstart and along with the proper link to full installation instructions in the Nextstrain docs.

### Related issue(s)

Fixes #456 

### Testing

I have visually confirmed that edits appear as intended through GitHub's markdown rendered. Whether edits appear properly after Jekyll rendering has not been tested.