### PR TITLE
Update latest sitrep in footer (or replace entirely with /ncov-sit-reps

### DIFF
--- a/nextstrain_profiles/nextstrain/nextstrain_description.md
+++ b/nextstrain_profiles/nextstrain/nextstrain_description.md
@@ -1,6 +1,6 @@
 [请点击这里查看中文版本](/ncov/zh)
 
-[Latest Nextstrain COVID-19 situation report in English](https://nextstrain.org/narratives/ncov/sit-rep/2020-05-15) and [in other languages](https://nextstrain.org/narratives/ncov-sit-reps/). Follow [@nextstrain](https://twitter.com/nextstrain) for continual updates to data and analysis.
+[All Nextstrain COVID-19 situation reports](https://nextstrain.org/ncov-sit-reps/) in English and in other languages. Follow [@nextstrain](https://twitter.com/nextstrain) for continual updates to data and analysis.
 
 This phylogeny shows evolutionary relationships of hCoV-19 (or SARS-CoV-2) viruses from the ongoing novel coronavirus COVID-19 pandemic. This phylogeny shows an initial emergence in Wuhan, China, in Nov-Dec 2019 followed by sustained human-to-human transmission leading to sampled infections. Although the genetic relationships among sampled viruses are quite clear, there is considerable uncertainty surrounding estimates of specific transmission dates and in reconstruction of geographic spread. Please be aware that specific inferred transmission patterns are only a hypothesis.
 

--- a/nextstrain_profiles/nextstrain/nextstrain_description.md
+++ b/nextstrain_profiles/nextstrain/nextstrain_description.md
@@ -1,6 +1,6 @@
 [请点击这里查看中文版本](/ncov/zh)
 
-[Latest Nextstrain COVID-19 situation report in English](https://nextstrain.org/narratives/ncov/sit-rep/2020-04-17) and [in other languages](https://nextstrain.org/narratives/ncov/sit-rep/). Follow [@nextstrain](https://twitter.com/nextstrain) for continual updates to data and analysis.
+[Latest Nextstrain COVID-19 situation report in English](https://nextstrain.org/narratives/ncov/sit-rep/2020-05-15) and [in other languages](https://nextstrain.org/narratives/ncov-sit-reps/). Follow [@nextstrain](https://twitter.com/nextstrain) for continual updates to data and analysis.
 
 This phylogeny shows evolutionary relationships of hCoV-19 (or SARS-CoV-2) viruses from the ongoing novel coronavirus COVID-19 pandemic. This phylogeny shows an initial emergence in Wuhan, China, in Nov-Dec 2019 followed by sustained human-to-human transmission leading to sampled infections. Although the genetic relationships among sampled viruses are quite clear, there is considerable uncertainty surrounding estimates of specific transmission dates and in reconstruction of geographic spread. Please be aware that specific inferred transmission patterns are only a hypothesis.
 

--- a/nextstrain_profiles/nextstrain/nextstrain_description_zh.md
+++ b/nextstrain_profiles/nextstrain/nextstrain_description_zh.md
@@ -1,4 +1,4 @@
-[最新的Nextstrain nCoV中文情况报告](https://nextstrain.org/narratives/ncov/sit-rep/zh/2020-04-17)。
+[最新的Nextstrain nCoV中文情况报告](https://nextstrain.org/narratives/ncov/sit-rep/zh/2020-05-15)。
 
 此系统发生显示新的冠状病毒（nCoV）COVID-19流行病毒的进化关系。 所有样品相对于一个共同祖先与最多八个突变高度相关，表明在2019年11月至12月某个时间共有一个共同祖先。这表明2019年11月至12月初次人类感染，随后持续的人对人传播导致 采样感染。
 

--- a/nextstrain_profiles/nextstrain/nextstrain_description_zh.md
+++ b/nextstrain_profiles/nextstrain/nextstrain_description_zh.md
@@ -1,4 +1,4 @@
-[最新的Nextstrain nCoV中文情况报告](https://nextstrain.org/narratives/ncov/sit-rep/zh/2020-05-15)。
+[最新的Nextstrain nCoV中文情况报告](https://nextstrain.org/ncov-sit-reps/)。
 
 此系统发生显示新的冠状病毒（nCoV）COVID-19流行病毒的进化关系。 所有样品相对于一个共同祖先与最多八个突变高度相关，表明在2019年11月至12月某个时间共有一个共同祖先。这表明2019年11月至12月初次人类感染，随后持续的人对人传播导致 采样感染。
 


### PR DESCRIPTION
I happened to notice that the footer text on nextstrain.org (that comes from this repo `nextstrain_profiles/nextstrain/nextstrain_description{_zh}.md`) currently links to this sit rep:  https://nextstrain.org/narratives/ncov/sit-rep/2020-04-17.

I am assuming with this PR that we would be ok to replace that (in both the english and Chinese versions) with a link to https://nextstrain.org/ncov-sit-reps/ - so that we don't forget to update it again later when we do more sit reps (even though the 05-15 one is
>  our last weekly Situation Report for a while

). Otherwise, I can remove the second commit and go back to the first one on this branch which just updates each of them to https://nextstrain.org/narratives/ncov/sit-rep/2020-05-15.
