### PR TITLE
Use python3 executable instead of system executable

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -6,11 +6,6 @@ from snakemake.utils import validate
 configfile: "defaults/parameters.yaml"
 validate(config, schema="workflow/schemas/config.schema.yaml")
 
-# In our shell rules, we try to use the same Python executable running
-# Snakemake, if known, by interpolating {python:q}.  The aim is to prevent
-# issues with multiple Python versions or symlinks for python vs. python3.
-python = sys.executable or "python3"
-
 # default build if none specified in config
 if "builds" not in config:
     config["builds"] = {

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -63,7 +63,7 @@ rule export_all_regions:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} ./scripts/check_missing_locations.py \
+        python3 ./scripts/check_missing_locations.py \
             --metadata {input.metadata} \
             --colors {input.colors} \
             --latlong {input.lat_longs}
@@ -158,7 +158,7 @@ rule incorporate_travel_history_gisaid:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} ./scripts/modify-tree-according-to-exposure.py \
+        python3 ./scripts/modify-tree-according-to-exposure.py \
             --input {input.auspice_json} \
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \
@@ -183,7 +183,7 @@ rule incorporate_travel_history_zh:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} ./scripts/modify-tree-according-to-exposure.py \
+        python3 ./scripts/modify-tree-according-to-exposure.py \
             --input {input.auspice_json} \
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \
@@ -203,7 +203,7 @@ rule fix_colorings_gisaid:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/fix-colorings.py \
+        python3 scripts/fix-colorings.py \
             --input {input.auspice_json} \
             --output {output.auspice_json} 2>&1 | tee {log}
         """
@@ -219,7 +219,7 @@ rule fix_colorings_zh:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/fix-colorings.py \
+        python3 scripts/fix-colorings.py \
             --input {input.auspice_json} \
             --output {output.auspice_json} 2>&1 | tee {log}
         """

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -113,7 +113,7 @@ rule diagnose_excluded:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/diagnostic.py \
+        python3 scripts/diagnostic.py \
             --alignment {input.alignment} \
             --metadata {input.metadata} \
             --reference {input.reference} \
@@ -137,7 +137,7 @@ checkpoint partition_sequences:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/partition-sequences.py \
+        python3 scripts/partition-sequences.py \
             --sequences {input.sequences} \
             --sequences-per-group {params.sequences_per_group} \
             --output-dir {output.split_sequences} 2>&1 | tee {log}
@@ -208,7 +208,7 @@ rule diagnostic:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/diagnostic.py \
+        python3 scripts/diagnostic.py \
             --alignment {input.alignment} \
             --metadata {input.metadata} \
             --reference {input.reference} \
@@ -264,7 +264,7 @@ rule mask:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/mask-alignment.py \
+        python3 scripts/mask-alignment.py \
             --alignment {input.alignment} \
             --mask-from-beginning {params.mask_from_beginning} \
             --mask-from-end {params.mask_from_end} \
@@ -383,7 +383,7 @@ rule proximity_score:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/priorities.py --alignment {input.alignment} \
+        python3 scripts/priorities.py --alignment {input.alignment} \
             --metadata {input.metadata} \
             --reference {input.reference} \
             --focal-alignment {input.focal_alignment} \
@@ -412,7 +412,7 @@ rule combine_samples:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/combine-and-dedup-fastas.py \
+        python3 scripts/combine-and-dedup-fastas.py \
             --input {input} \
             --output {output} 2>&1 | tee {log}
         """
@@ -434,7 +434,7 @@ rule adjust_metadata_regions:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/adjust_regional_meta.py \
+        python3 scripts/adjust_regional_meta.py \
             --region {params.region:q} \
             --metadata {input.metadata} \
             --output {output.metadata} 2>&1 | tee {log}
@@ -562,7 +562,7 @@ rule haplotype_status:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/annotate-haplotype-status.py \
+        python3 scripts/annotate-haplotype-status.py \
             --ancestral-sequences {input.nt_muts} \
             --reference-node-name {params.reference_node_name:q} \
             --output {output.node_data} 2>&1 | tee {log}
@@ -647,7 +647,7 @@ rule pangolin:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/add_pangolin_lineages.py \
+        python3 scripts/add_pangolin_lineages.py \
             --tree {input.tree} \
             --output {output.clade_data}
         """
@@ -743,7 +743,7 @@ rule colors:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/assign-colors.py \
+        python3 scripts/assign-colors.py \
             --ordering {input.ordering} \
             --color-schemes {input.color_schemes} \
             --output {output.colors} \
@@ -761,7 +761,7 @@ rule recency:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/construct-recency-from-submission-date.py \
+        python3 scripts/construct-recency-from-submission-date.py \
             --metadata {input.metadata} \
             --output {output} 2>&1 | tee {log}
         """
@@ -912,7 +912,7 @@ rule incorporate_travel_history:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} ./scripts/modify-tree-according-to-exposure.py \
+        python3 ./scripts/modify-tree-according-to-exposure.py \
             --input {input.auspice_json} \
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \
@@ -934,7 +934,7 @@ rule finalize:
     conda: config["conda_environment"]
     shell:
         """
-        {python:q} scripts/fix-colorings.py \
+        python3 scripts/fix-colorings.py \
             --input {input.auspice_json} \
             --output {output.auspice_json} 2>&1 | tee {log} &&
         cp {input.frequencies} {output.tip_frequency_json}


### PR DESCRIPTION
Allows Snakemake rules to use the most appropriate Python 3 executable currently available in the environment instead of preferring the system executable. This distinction is most important when users run Snakemake with the `--use-conda` flag and expect to have access to Python modules installed in the corresponding conda environment for each rule. When the system executable was preferred, it would be possible for the rule to run with a Python executable that did not have access to the same environment as the user's requested conda environment.

Minimal steps to recreate the original problem described in #442 and to test this PR:

```bash
# Create and activate a minimal Python 3 environment.
conda create -n ncov python=3.6
conda activate ncov

# Install Snakemake.
python3 -m pip install snakemake

# Run the "getting started" analysis with --use-conda.
snakemake --use-conda --profile my_profiles/getting_started/
```

This last step produces several errors when the system executable Python (from the outer `ncov` environment) does not have access to pandas, augur, etc. This issue is resolved by running all Python scripts with `python3`.

This PR also removes a dependency on TreeTime in the main workflow. This dependency causes an error in the minimal example above where the user will not necessarily have TreeTime installed in their current environment.

Resolves #442