### PR TITLE
Regional builds should not display the map in triplicate

### DIFF
--- a/nextstrain_profiles/nextstrain/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/africa_auspice_config.json
@@ -109,7 +109,7 @@
     "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "country",
-    "map_triplicate": true,
+    "map_triplicate": false,
     "branch_label": "clade",
     "transmission_lines": false
   },

--- a/nextstrain_profiles/nextstrain/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/asia_auspice_config.json
@@ -109,7 +109,7 @@
     "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "country",
-    "map_triplicate": true,
+    "map_triplicate": false,
     "branch_label": "clade",
     "transmission_lines": false
   },

--- a/nextstrain_profiles/nextstrain/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/europe_auspice_config.json
@@ -109,7 +109,7 @@
     "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "country",
-    "map_triplicate": true,
+    "map_triplicate": false,
     "branch_label": "clade",
     "transmission_lines": false
   },

--- a/nextstrain_profiles/nextstrain/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/north-america_auspice_config.json
@@ -109,7 +109,7 @@
     "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "division",
-    "map_triplicate": true,
+    "map_triplicate": false,
     "branch_label": "clade",
     "transmission_lines": false
   },

--- a/nextstrain_profiles/nextstrain/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/oceania_auspice_config.json
@@ -109,7 +109,7 @@
     "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "division",
-    "map_triplicate": true,
+    "map_triplicate": false,
     "branch_label": "clade",
     "transmission_lines": false
   },

--- a/nextstrain_profiles/nextstrain/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/south-america_auspice_config.json
@@ -109,7 +109,7 @@
     "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "country",
-    "map_triplicate": true,
+    "map_triplicate": false,
     "branch_label": "clade",
     "transmission_lines": false
   },


### PR DESCRIPTION
The map-triplicate functionality is useful for interpreting sequential transmissions which involve the entire world, however this comes at a performance cost (more elements in the DOM, and larger arrays for the map logic to loop through) as well as producing default map-bounds which nearly always show the entire world (although the default views are by no means perfect with the changes in this PR).

For regional nCoV builds, the focus is on an individual location (region) and thus it's not necessary to display the map in triplicate.


Current master (triplicate):

![image](https://user-images.githubusercontent.com/8350992/89235774-f54ef700-d642-11ea-9dab-1a35917e1fd6.png)

This PR (not triplicate):

![image](https://user-images.githubusercontent.com/8350992/89235795-039d1300-d643-11ea-8ce3-fb6ea283f705.png)
