### PR TITLE
Do not rely on TreeTime when augur filter supports ISO 8601 dates

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,3 +1,4 @@
+from datetime import date
 from os import environ
 from socket import getfqdn
 from getpass import getuser

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -10,9 +10,6 @@ rule download:
         aws s3 cp s3://nextstrain-ncov-private/sequences.fasta.gz - | gunzip -cq > {output.sequences:q}
         """
 
-from datetime import date
-from treetime.utils import numeric_date
-
 rule filter:
     message:
         """
@@ -31,7 +28,7 @@ rule filter:
     params:
         min_length = config["filter"]["min_length"],
         exclude_where = config["filter"]["exclude_where"],
-        date = numeric_date(date.today())
+        date = date.today().strftime("%Y-%m-%d")
     conda: config["conda_environment"]
     shell:
         """


### PR DESCRIPTION
The user's environment will not necessarily have TreeTime installed globally, leading to an error when running the basic workflow. This commit takes advantage of the fact that augur filter supports ISO 8601 dates as of v9.0.0 to avoid a call to TreeTime's numeric_date function.

This PR splits out a commit that was original part of #473. While that PR's change to the Python 3 executable should be mostly transparent to users (except for those using `--use-conda`, for whom it will make life better), this PR makes a backwards-incompatible change to the workflow that relies on augur version 9.0.0 and later.