### PR TITLE
Change SARS-CoV-2 tutorial heading level

### DIFF
--- a/docs/orientation-files.md
+++ b/docs/orientation-files.md
@@ -1,5 +1,5 @@
 
-## Overview of this repository (i.e., what do these files do?)
+# Overview of this repository (i.e., what do these files do?)
 
 The files in this repository fall into one of these categories:  
 * Input files  


### PR DESCRIPTION
This fixes a bug where this page would render as many sidebar headings [1] instead of just one in the docs.nextstrain.org read the docs build. 

[1] see https://docs.nextstrain.org/en/migrate-ncov-tutorial/tutorials/SARS-CoV-2/index.html ; note the extra headings when compared with https://nextstrain.github.io/ncov/.