### PR TITLE
New Nextstrain Sampling Scheme - Using `max_sequences`

### DIFF
--- a/nextstrain_profiles/nextstrain/builds.yaml
+++ b/nextstrain_profiles/nextstrain/builds.yaml
@@ -109,12 +109,12 @@ subsampling:
     # Focal samples for region
     region:
       group_by: "division year month"
-      seq_per_group: 32
+      max_sequences: 2500
       exclude: "--exclude-where 'region!={region}'"
     # Contextual samples for region from the rest of the world
     global:
       group_by: "country year month"
-      seq_per_group: 4
+      max_sequences: 1500
       exclude: "--exclude-where 'region={region}'"
       priorities:
         type: "proximity"
@@ -122,9 +122,30 @@ subsampling:
 
   # Custom subsampling logic for global region.
   nextstrain_region_global:
-    global:
+    africa:
       group_by: "country year month"
-      seq_per_group: 16
+      max_sequences: 600
+      exclude: "--exclude-where 'region!=Africa'"
+    asia:
+      group_by: "country year month"
+      max_sequences: 700
+      exclude: "--exclude-where 'region!=Asia'"
+    europe:
+      group_by: "country year month"
+      max_sequences: 800
+      exclude: "--exclude-where 'region!=Europe'"
+    north_america:
+      group_by: "division year month"
+      max_sequences: 800
+      exclude: "--exclude-where 'region!=North America'"
+    south_america:
+      group_by: "country year month"
+      max_sequences: 600
+      exclude: "--exclude-where 'region!=South America'"
+    oceania:
+      group_by: "division year month"
+      max_sequences: 500
+      exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling for regions like Europe where grouping by country
   # is the smallest resolution requied
@@ -132,12 +153,12 @@ subsampling:
     # Focal samples for region
     region:
       group_by: "country year month"
-      seq_per_group: 44
+      max_sequences: 2500
       exclude: "--exclude-where 'region!={region}'"
     # Contextual samples for region from the rest of the world
     global:
       group_by: "country year month"
-      seq_per_group: 5
+      max_sequences: 1500
       exclude: "--exclude-where 'region={region}'"
       priorities:
         type: "proximity"


### PR DESCRIPTION
Two purposes to this PR:
1. Switching to using `max_sequences` will keep build size stable, meaning we can stop worrying about 'slow creep' as the dataset gets larger, thus having to regularly adjust subsampling
2. Differences in country size & whether samples should be taken by division vs by country are leading to some unbalance datasets.

This PR primarily switches all three subsampling schema used by `nextstrain_profile` to using `max_sequences` to help keep build size stable. 

## Regional Builds
For the regional builds this allows more focus to be put on the region itself, without having to adjust parameters across regions with vastly different sample sizes & distributions.

All regional builds are now set to have 2,500 focal sequences (sampled by country for Europe and by division for all other regions) and 1,500 context sequences (sampled by country), giving a final build size of ~4,000 sequences.

Comparisons below:
Europe [current](https://nextstrain.org/ncov/europe) [new](https://nextstrain.org/staging/ncov/europe-newsample)
N America [current](https://nextstrain.org/ncov/north-america) [new](https://nextstrain.org/staging/ncov/north-america-newsample)
Africa  [current](https://nextstrain.org/ncov/africa) [new](https://nextstrain.org/staging/ncov/africa-newsample)
Asia [current](https://nextstrain.org/ncov/asia) [new](https://nextstrain.org/staging/ncov/asia-newsample)
Oceania [current](https://nextstrain.org/ncov/oceania) [new](https://nextstrain.org/staging/ncov/oceania-newsample)
S America [current](https://nextstrain.org/ncov/south-america) [new](https://nextstrain.org/staging/ncov/south-america-newsample)

Regions with fewer samples show the greatest difference here - there is a noticeable increase in the number of samples from that region. However, I think this is possibly a good thing - the regions with fewest samples are also those where we have few (if any) more focused builds being run, so may be the only way people can get a 'closer look' at their country in that region. 


## Global Build
Our global build is currently pretty skewed in sampling, because we sample by country only - this doesn't work out favourably for North America or Oceania. This made it basically impossible, for example, to even start to look at links between Europe & America.
Here's a comparison of the 'actual # sequences', the current numbers in the global build, and my proposed sampling:
```
Region  Real    Current Proposed
Africa  2442    505     600
Asia    9096    1337    700
Europe  60894   1952    800
N Amer  30810   412     800
Oceania 7682    221     500
S Amer  1932    427     600
```
[Current](https://nextstrain.org/ncov/global)   [New](https://nextstrain.org/staging/ncov/global-newsample)

Here, I switched to using `max_sequences`, but also away from having just one sampling scheme for the whole world, but rather, one for each region. This way N America & Oceania can be sampled by division instead of country, giving a much more balanced view (N America still coming a little shorter than expected in the above example, unsure why - but still much better than previously). The one downside of this approach is that the number of samples per region has to be manually set - and may need reassessing from time to time. I originally tried to be more even in the sampling, but this ends up with big clumps in some places, for lack of samples, and really underrepresenting places where we have a lot of samples. The above sampling is after a few tries, and I hope strikes the balance between being fairly equitable but also ending up with a tree that seems at least somewhat representative of the samples we have. Because `max_sequences` is used, we also don't have to worry about build-size creep.


------

Hoping we can move to this scheme soon - to alleviate the extreme unbalance of the global build, and get our build size down - forever!