### PR TITLE
Min max data subsampling

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -360,8 +360,8 @@ rule subsample:
          - group by: {params.group_by}
          - sequences per group: {params.sequences_per_group}
          - subsample max sequences: {params.subsample_max_sequences}
-         - date-min: {params.date_max}
-         - date-max: {params.date_min}
+         - min-date: {params.max_date}
+         - max-date: {params.min_date}
          - exclude: {params.exclude_argument}
          - include: {params.include_argument}
          - query: {params.query_argument}
@@ -381,8 +381,8 @@ rule subsample:
         exclude_argument = _get_specific_subsampling_setting("exclude", optional=True),
         include_argument = _get_specific_subsampling_setting("include", optional=True),
         query_argument = _get_specific_subsampling_setting("query", optional=True),
-        date_min = _get_specific_subsampling_setting("date_min", optional=True),
-        date_max = _get_specific_subsampling_setting("date_max", optional=True),
+        min_date = _get_specific_subsampling_setting("min_date", optional=True),
+        max_date = _get_specific_subsampling_setting("max_date", optional=True),
         priority_argument = get_priority_argument
     conda: config["conda_environment"]
     shell:
@@ -391,8 +391,8 @@ rule subsample:
             --sequences {input.sequences} \
             --metadata {input.metadata} \
             --include {input.include} \
-            {params.date_min} \
-            {params.date_max} \
+            {params.min_date} \
+            {params.max_date} \
             {params.exclude_argument} \
             {params.include_argument} \
             {params.query_argument} \

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -360,6 +360,8 @@ rule subsample:
          - group by: {params.group_by}
          - sequences per group: {params.sequences_per_group}
          - subsample max sequences: {params.subsample_max_sequences}
+         - date-min: {params.date_max}
+         - date-max: {params.date_min}
          - exclude: {params.exclude_argument}
          - include: {params.include_argument}
          - query: {params.query_argument}
@@ -379,6 +381,8 @@ rule subsample:
         exclude_argument = _get_specific_subsampling_setting("exclude", optional=True),
         include_argument = _get_specific_subsampling_setting("include", optional=True),
         query_argument = _get_specific_subsampling_setting("query", optional=True),
+        date_min = _get_specific_subsampling_setting("date_min", optional=True),
+        date_max = _get_specific_subsampling_setting("date_max", optional=True),
         priority_argument = get_priority_argument
     conda: config["conda_environment"]
     shell:
@@ -387,6 +391,8 @@ rule subsample:
             --sequences {input.sequences} \
             --metadata {input.metadata} \
             --include {input.include} \
+            {params.date_min} \
+            {params.date_max} \
             {params.exclude_argument} \
             {params.include_argument} \
             {params.query_argument} \


### PR DESCRIPTION
### Description of proposed changes    
Allow producing subsamples specific to date ranges. 

This PR introduces `max/min-date` fields for the subsampling rules. The envisioned use-case is tailoring sampling density to specific time slices. One might for example want a sparse sampling of the first half of the pandemic and a denser focus on the last few months. 

For Europe, this could look like this:

OLD:
![image](https://user-images.githubusercontent.com/8379168/94583557-e02ac900-027d-11eb-8627-7d9c8edb96fc.png)

NEW:
![image](https://user-images.githubusercontent.com/8379168/94583604-f0db3f00-027d-11eb-8542-4ca5c9217657.png)

Note that this is completely optional, just exposing some additional flags. 
