### PR TITLE
Updates message on min/max date for rule subsample

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -360,8 +360,8 @@ rule subsample:
          - group by: {params.group_by}
          - sequences per group: {params.sequences_per_group}
          - subsample max sequences: {params.subsample_max_sequences}
-         - min-date: {params.max_date}
-         - max-date: {params.min_date}
+         - min-date: {params.min_date}
+         - max-date: {params.max_date}
          - exclude: {params.exclude_argument}
          - include: {params.include_argument}
          - query: {params.query_argument}


### PR DESCRIPTION
### Description of proposed changes    
`{params.min_date}`& `{params.max_date}` are swapped in the message for `rule subsample`. This PR just fixes that typo :)

Thanks for adding the flag. It's a super useful feature for me!