### PR TITLE
Add frequencies panel to Auspice config

### DIFF
--- a/nextstrain_profiles/nextstrain/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/africa_auspice_config.json
@@ -130,6 +130,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }

--- a/nextstrain_profiles/nextstrain/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/asia_auspice_config.json
@@ -130,6 +130,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }

--- a/nextstrain_profiles/nextstrain/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/europe_auspice_config.json
@@ -130,6 +130,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }

--- a/nextstrain_profiles/nextstrain/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/global_auspice_config.json
@@ -130,6 +130,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }

--- a/nextstrain_profiles/nextstrain/nextstrain_auspice_config_gisaid.json
+++ b/nextstrain_profiles/nextstrain/nextstrain_auspice_config_gisaid.json
@@ -119,6 +119,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }

--- a/nextstrain_profiles/nextstrain/nextstrain_auspice_config_zh.json
+++ b/nextstrain_profiles/nextstrain/nextstrain_auspice_config_zh.json
@@ -124,6 +124,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }

--- a/nextstrain_profiles/nextstrain/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/north-america_auspice_config.json
@@ -130,6 +130,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }

--- a/nextstrain_profiles/nextstrain/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/oceania_auspice_config.json
@@ -130,6 +130,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }

--- a/nextstrain_profiles/nextstrain/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/south-america_auspice_config.json
@@ -130,6 +130,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }


### PR DESCRIPTION
### Description of proposed changes    

We have been exporting tip frequencies for all regional ncov builds as _tip-frequencies.json. However, these haven't been shown due to the absence of "frequencies" in the list of "panels" in the Auspice config. We now have enough temporal variation that I think it's warranted to include a frequencies view.

Further discussion on Slack here: https://bedfordlab.slack.com/archives/CSKMU6YUC/p1597861118040000

This does surface issues with geographic over-representation, especially in the global view, where Europe is over-represented:

<img width="1216" alt="ncov_global_frequencies" src="https://user-images.githubusercontent.com/1176109/95692266-6d084780-0bd9-11eb-817c-22dd5e1919e7.png">

but I don't think this should block this PR. We should get regions equilibrated separately with https://github.com/nextstrain/ncov/pull/494.

### Testing
I've rerun `augur export` from latest AWS Batch build and everything looks as it should.
