### PR TITLE
Write subsampling log output to a file

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -374,6 +374,8 @@ rule subsample:
         priorities = get_priorities
     output:
         sequences = "results/{build_name}/sample-{subsample}.fasta"
+    log:
+        "logs/subsample_{build_name}_{subsample}.txt"
     params:
         group_by = _get_specific_subsampling_setting("group_by"),
         sequences_per_group = _get_specific_subsampling_setting("seq_per_group", optional=True),


### PR DESCRIPTION
When I added support for logging output from all primary rules to files in a `logs/` directory, I forgot to add a `log` directive to the subsampling rule. This oversight causes logging output to be written to the screen only and [prevents users from easily debugging issues with subsampling](https://discussion.nextstrain.org/t/diagnosing-error-filtering-issues/149/5). This PR addresses this issue by adding a `log` directive to the subsampling rule.

I have tested this change with the following commands:

```bash
# Run "getting started" workflow up through subsampling.
snakemake --profile my_profiles/getting_started --use-conda -j 4 results/global/sample-global.fasta

# Confirm subsampling log output exists and is not empty.
cat logs/subsample_global_global.txt
```

The output of the last command should be:

```
-2 sequences were dropped during filtering
	0 of these were dropped because of subsampling criteria

	2 sequences were added back because they were in defaults/include.txt
4 sequences have been written out to results/global/sample-global.fasta
```
