### PR TITLE
Allow parameters to define ambiguous date exclusion criteria

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -50,7 +50,8 @@ filter:
   min_length: 27000
 
   # Omit sequences with incomplete date annotations, and USA seqs without a state.
-  exclude_where: "division='USA' date='2020' date='2020-01-XX' date='2020-02-XX' date='2020-03-XX' date='2020-04-XX' date='2020-05-XX' date='2020-06-XX' date='2020-07-XX' date='2020-08-XX' date='2020-09-XX' date='2020-10-XX' date='2020-11-XX' date='2020-12-XX' date='2020-01' date='2020-02' date='2020-03' date='2020-04' date='2020-05' date='2020-06' date='2020-07' date='2020-08' date='2020-09' date='2020-10' date='2020-11' date='2020-12'"
+  exclude_where: "division='USA'"
+  exclude_ambiguous_dates_by: "any"
 
   # Exclude sequences which are from before late 2019 (likely date mix-ups)
   min_date: 2019.74

--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -18,6 +18,6 @@ dependencies:
 - pip
 - pip:
   - awscli==1.18.45
-  - nextstrain-augur==10.1.1
+  - nextstrain-augur==10.2.0
   - nextstrain-cli==1.16.5
   - rethinkdb==2.3.0.post6

--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -18,6 +18,6 @@ dependencies:
 - pip
 - pip:
   - awscli==1.18.45
-  - nextstrain-augur==10.0.2
+  - nextstrain-augur==10.1.1
   - nextstrain-cli==1.16.5
   - rethinkdb==2.3.0.post6

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -259,6 +259,7 @@ rule filter:
         min_length = config["filter"]["min_length"],
         exclude_where = config["filter"]["exclude_where"],
         min_date = config["filter"]["min_date"],
+        ambiguous = lambda wildcards: f"--exclude-ambiguous-dates-by {config['filter']['exclude_ambiguous_dates_by']}" if "exclude_ambiguous_dates_by" in config["filter"] else "",
         date = date.today().strftime("%Y-%m-%d")
     conda: config["conda_environment"]
     shell:
@@ -269,6 +270,7 @@ rule filter:
             --include {input.include} \
             --max-date {params.date} \
             --min-date {params.min_date} \
+            {params.ambiguous} \
             --exclude {input.exclude} \
             --exclude-where {params.exclude_where}\
             --min-length {params.min_length} \
@@ -332,6 +334,8 @@ def _get_specific_subsampling_setting(setting, optional=False):
             # build's region, country, division, etc. as needed for subsampling.
             build = config["builds"][wildcards.build_name]
             value = value.format(**build)
+            if value !="" and setting == 'exclude_ambiguous_dates_by':
+                value = f"--exclude-ambiguous-dates-by {value}"
         elif value is not None:
             # If is 'seq_per_group' or 'max_sequences' build subsampling setting,
             # need to return the 'argument' for augur
@@ -362,6 +366,7 @@ rule subsample:
          - subsample max sequences: {params.subsample_max_sequences}
          - min-date: {params.min_date}
          - max-date: {params.max_date}
+         - {params.exclude_ambiguous_dates_argument}
          - exclude: {params.exclude_argument}
          - include: {params.include_argument}
          - query: {params.query_argument}
@@ -384,6 +389,7 @@ rule subsample:
         exclude_argument = _get_specific_subsampling_setting("exclude", optional=True),
         include_argument = _get_specific_subsampling_setting("include", optional=True),
         query_argument = _get_specific_subsampling_setting("query", optional=True),
+        exclude_ambiguous_dates_argument = _get_specific_subsampling_setting("exclude_ambiguous_dates_by", optional=True),
         min_date = _get_specific_subsampling_setting("min_date", optional=True),
         max_date = _get_specific_subsampling_setting("max_date", optional=True),
         priority_argument = get_priority_argument
@@ -400,6 +406,7 @@ rule subsample:
             {params.exclude_argument} \
             {params.include_argument} \
             {params.query_argument} \
+            {params.exclude_ambiguous_dates_argument} \
             {params.priority_argument} \
             --group-by {params.group_by} \
             {params.sequences_per_group} \


### PR DESCRIPTION
This allows both the main filtering step as well as individual subsampling schemes to define if ambiguous dates are to be excluded, and if so, what level of ambiguity is to be excluded.

By having this in the subsampling steps, we allow flexibility so that (e.g.) we can allow ambiguous sequences for a particular subset of (important) samples.

NOTE: requires augur version `10.1.0` or higher