### PR TITLE
Allow config-defined multiple sequence & metadata files

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -7,6 +7,7 @@
 conda_environment: "../envs/nextstrain.yaml"
 
 # These are the two main starting files for the run
+# Each can take an array (and the files will be merged appropriately) or a string.
 sequences: "data/sequences.fasta"
 metadata: "data/metadata.tsv"
 

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -7,7 +7,7 @@
 conda_environment: "../envs/nextstrain.yaml"
 
 # These are the two main starting files for the run
-# Each can take an array (and the files will be merged appropriately) or a string.
+# Each can take either a string (file path) or a dict of input "origins", each specifying a filepath
 sequences: "data/sequences.fasta"
 metadata: "data/metadata.tsv"
 
@@ -47,6 +47,12 @@ filter:
 # The number of sequences per group determines the run time of a single alignment job.
 partition_sequences:
   sequences_per_group: 150
+
+# Diagnostic settings
+# You can opt-out of running diagnostics for certain inputs (be careful!)
+# diagnostic:
+#   skip:
+#     - "origin_name_here"
 
 # Mask settings determine how the multiple sequence alignment is masked prior to phylogenetic inference.
 mask:

--- a/scripts/combine_metadata.py
+++ b/scripts/combine_metadata.py
@@ -1,0 +1,80 @@
+import argparse
+from augur.utils import read_metadata
+from Bio import SeqIO
+import csv
+
+EMPTY = ''
+
+# This script was written in preparation for a future augur where commands
+# may take multiple metadata files, thus making this script unnecessary!
+#
+# Merging logic:
+# - Order of supplied TSVs matters
+# - All columns are included (i.e. union of all columns present)
+# - The last non-empty value read (from different TSVs) is used. I.e. values are overwritten.
+# - Missing data is represented by an empty string
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Custom script to combine metadata files",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('--input', required=True, nargs='+', metavar="TSV", help="Metadata files")
+    parser.add_argument('--output', required=True, metavar="TSV", help="output (merged) metadata")
+    args = parser.parse_args()
+    return args
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    if len(args.input)==1:
+        import sys
+        from shutil import copyfile
+        copyfile(args.input[0], args.output)
+        sys.exit(0)
+
+    metadata = []
+    for fname in args.input:
+        data, columns = read_metadata(fname)
+        metadata.append({'name': fname, 'data': data, 'columns': columns})
+    
+    # SUMMARISE
+    print(f"Parsed {len(metadata)} metadata TSVs")
+    for m in metadata:
+        print(f"\t{m['name']}: {len(m['data'].keys())} strains x {len(m['columns'])} columns")
+
+    # BUILD UP COLUMN NAMES TO PRESERVE ORDER
+    combined_columns = []
+    for m in metadata:
+        combined_columns.extend([c for c in m['columns'] if c not in combined_columns])
+
+    # ADD IN VALUES ONE BY ONE, OVERWRITING AS NECESSARY
+    combined_data = metadata[0]['data']
+    for strain in combined_data:
+        for column in combined_columns:
+            if column not in combined_data[strain]:
+                combined_data[strain][column] = EMPTY
+
+    for m in metadata[1:]:
+        for strain, row in m['data'].items():
+            if strain not in combined_data:
+                combined_data[strain] = {c:EMPTY for c in combined_columns}
+            for column in combined_columns:
+                if column in row:
+                    existing_value = combined_data[strain][column]
+                    new_value = row[column]
+                    # overwrite _ANY_ existing value if the overwriting value is non empty (and different)!
+                    if new_value != EMPTY and new_value != existing_value:
+                        if existing_value != EMPTY:
+                            print(f"[{strain}::{column}] Overwriting {combined_data[strain][column]} with {new_value}")
+                        combined_data[strain][column] = new_value
+
+    print(f"Combined metadata: {len(combined_data.keys())} strains x {len(combined_columns)} columns")
+
+
+    with open(args.output, 'w') as fh:
+        tsv_writer = csv.writer(fh, delimiter='\t')
+        tsv_writer.writerow(combined_columns)
+        for row in combined_data.values():
+            tsv_writer.writerow([row[column] for column in combined_columns])
+

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -3,6 +3,24 @@
 def _get_subsampling_scheme_by_build_name(build_name):
     return config["builds"][build_name].get("subsampling_scheme", build_name)
 
+def _get_main_metadata(wildcards):
+    """Returns the appropriate metadata file for all analysis steps"""
+    if isinstance(config["metadata"], str):
+        return config["metadata"]
+    elif len(config["metadata"])==1:
+        return config["metadata"][0]
+    else:
+        return "results/combined_metadata.tsv"
+
+def _get_main_sequences(wildcards):
+    """Returns the appropriate sequences file (FASTA) for all analysis steps"""
+    if isinstance(config["sequences"], str):
+        return config["sequences"]
+    elif len(config["sequences"])==1:
+        return config["sequences"][0]
+    else:
+        return "results/combined_sequences.fasta"
+
 def _get_metadata_by_build_name(build_name):
     """Returns a path associated with the metadata for the given build name.
 
@@ -10,7 +28,7 @@ def _get_metadata_by_build_name(build_name):
     the Snakemake `expand` function or through string formatting with `.format`.
     """
     if build_name == "global" or "region" not in config["builds"][build_name]:
-        return rules.download.output.metadata
+        return _get_main_metadata({})
     else:
         return rules.adjust_metadata_regions.output.metadata
 


### PR DESCRIPTION
A common use case is the desire to start from multiple sequence / metadata files. For instance, a build starting with the GISAID data and a set of new (non-public) sequences.

~This extends the workflow to allow `config["metadata"]` and `config["sequences"]` to be an array. If so, then an additional rule (`combine_input_metadata` and `combine_input_sequences`, respectively) are run before analysis steps.~

This PR extends the workflow logic to be able to take a number of inputs (matched TSVs + FASTAs) by allowing `config["sequences"]` and `config["metadata"]` to be a dictionary (see examples below). Each input, if there are multiple, is referred to as an "origin" (via wildcards). Each origin has it's own separate filter / align /  diagnostic / mask steps (see DAGs below). This is by design as it will allow us to maintain pre-computed alignments / masked-alignments of S3 (gisaid) data and then replace the appropriate local computation steps, whilst still allowing seaparate (private) sequence / metadata inputs.

Note that metadata is combined via `scripts/combine_metadata.py` which respects the order of metadata files supplied, and thus will overwrite conflicting (non-empty) fields, such that the last file supplied takes precedence.

### Example: multiple inputs

The following input config will produce the following DAG

```yaml
sequences: 
  gisaid: "data/sequences.fasta"
  private: "data/example_sequences.fasta"
metadata:
  gisaid: "data/metadata.tsv"
  private: "data/example_metadata.tsv"
```

![image](https://user-images.githubusercontent.com/8350992/100961538-797ca100-3587-11eb-99a9-48c3e6d434b3.png)

### Future: use pre-computed masked alignment

In the future, this workflow will be able to be converted to use the pre-computed files in #516, using a DAG along the lines of

![image](https://user-images.githubusercontent.com/8350992/100961718-ce201c00-3587-11eb-80fe-a4d1b53d259b.png)


### Bug - cannot overwrite string value of `config["metadata"]` with a dict?

Ideally, the former syntax for defining starting files (e.g. `sequences: "data/sequences.fasta"`) would remain in `defaults/parameters.yaml` and custom profiles could overwrite this with a dict, as needed. This would maintain backwards compatibility with the many builds out there. However it seems you cannot overwrite a string value with a dict:

```
TypeError in line 32 of /Users/naboo/projects/nCoV/nz/ncov/Snakefile:
'str' object does not support item assignment
  File "/Users/naboo/projects/nCoV/nz/ncov/Snakefile", line 32, in <module>
```

### Todo - commented out rules

The rules `excluded_sequences`, `align_excluded`, and `diagnose_excluded` have been commented out here as I am unsure how they are used. If someone could comment on how they use them then I'll add the appropriate wildcards and restore this functionality. (The `--min-length 50000` argument in `rule excluded_sequences` makes me think these rules aren't being used!)

### Todo - potentially unnecessary `combine_masked` step

In the case where there is a single sequence input, the logic in this PR adds a `collect_masked` step between `mask` and the subsampling steps. I believe this could be skipped in this case. (Were the config inputs to always be dicts this would be simple.)

### Feature - Custom filtering options for each input origin

The `config["filter"]` options now allow a dictionary of values specific to the origin. Using the above example,
```yaml
filter:
  min_length: 27000
  private:
    min_length: 20000
```
Would allow the private dataset to include shorter sequences, which may be important for certain scenarios where you want to see lower-quality sequences.

### Feature - ability to skip diagnostic step for certain input origin

Adding the following to the config YAML
```yaml
diagnostic:
  skip:
     - "private"
```
Will skip the QC filtering steps (rules `diagnostic` and `refilter`) for the "private" input sequences only. Similar to custom filtering, this can be important to allow lower-quality sequences which are of interest to be included. 


### Note
The longer-term plan is for augur to natively allow multiple metadata/sequence inputs, which would simplify this logic and remove a couple of rules.

