### PR TITLE
Remove unconnected word, "either" from naming clades docs.

### DIFF
--- a/docs/naming_clades.md
+++ b/docs/naming_clades.md
@@ -11,7 +11,7 @@ The nomenclature used by Nextstrain to designate clades for SARS-CoV-2 is driven
 
 #### Definition
 
-We name a new major clade when it either reaches a frequency of 20% globally. When calculating these frequencies, care has to be taken to achieve approximately even sampling of sequences in time and space since sequencing effort varies strongly between countries. A clade name consists of the year it emerged and the next available letter in the alphabet. A new clade should be at least 2 mutations away from its parent major clade.
+We name a new major clade when it reaches a frequency of 20% globally. When calculating these frequencies, care has to be taken to achieve approximately even sampling of sequences in time and space since sequencing effort varies strongly between countries. A clade name consists of the year it emerged and the next available letter in the alphabet. A new clade should be at least 2 mutations away from its parent major clade.
 
 #### Naming
 


### PR DESCRIPTION
### Description of proposed changes    
Thanks for publishing this project. I noticed a small mistake in the documentation of how clades are named, so this fixes that. Perhaps you could also consider clarifying the 20% threshold for naming a new clade. Presumably you select a set of samples within some time window, is that easy to describe? Also, our lab was initially confused about how you could have more than five clades if they all had to be over 20% prevalance. We concluded that a clade can later drop below 20%, leaving room for new clades to emerge. If that's right, it might be helpful to be explicit in your description.

Thanks again.