### PR TITLE
Use an absolute path to the conda environment

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,5 +1,6 @@
 import copy
 from datetime import date
+import os
 from os import environ
 from socket import getfqdn
 from getpass import getuser
@@ -63,6 +64,13 @@ if "builds" not in config:
     }
 
 BUILD_NAMES = list(config["builds"].keys())
+
+# Construct the correct absolute path to the conda environment based on the
+# top-level Snakefile's directory and a path defined in the Snakemake config
+# that is relative to that top-level directory.
+SNAKEMAKE_DIR = os.path.dirname(workflow.snakefile)
+CONDA_ENV_PATH = os.path.join(SNAKEMAKE_DIR, config["conda_environment"])
+config["conda_environment"] = CONDA_ENV_PATH
 
 # Define patterns we expect for wildcards.
 wildcard_constraints:

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -4,7 +4,8 @@
 # or --configfile options.
 ---
 # conda environment file to use by default
-conda_environment: "../envs/nextstrain.yaml"
+# This must be a relative path to the top-level Snakefile directory (e.g., `ncov/`).
+conda_environment: "workflow/envs/nextstrain.yaml"
 
 # These are the two main starting files for the run.
 # If they do not exist, we will attempt to fetch them from a S3 bucket (see below)


### PR DESCRIPTION
Updates the expected format of the `conda_environment` config parameter to be a path relative to the top-level Snakefile instead of a path relative to the main workflow files in `workflow/snakemake_rules/`. This change fixes a bug where user-defined workflow rules in profiles (e.g., `wa_profile/download_preprocessed.smk`) are nested in a different directory structure than the main workflow rules and cannot find the conda environment based on a relative path.

This commit explicitly defines the `conda_environment` path as relative to the top-level directory and then builds an absolute path from that relative path such that all rules will reference the same file regardless of their directory structure.