### PR TITLE
Print failed logs

### DIFF
--- a/my_profiles/example/config.yaml
+++ b/my_profiles/example/config.yaml
@@ -19,3 +19,6 @@ cores: 2
 
 # Always print the commands that will be run to the screen for debugging.
 printshellcmds: True
+
+# Print log files of failed jobs
+show-failed-logs: True

--- a/my_profiles/example_advanced_customization/config.yaml
+++ b/my_profiles/example_advanced_customization/config.yaml
@@ -5,6 +5,7 @@ configfile:
 
 keep-going: True
 printshellcmds: True
+show-failed-logs: True
 stats: stats.json
 
 # Wait a fixed number of seconds for missing files since the cluster file system

--- a/my_profiles/getting_started/config.yaml
+++ b/my_profiles/getting_started/config.yaml
@@ -19,3 +19,6 @@ cores: 1
 
 # Always print the commands that will be run to the screen for debugging.
 printshellcmds: True
+
+# Always print log files of failed jobs to the screen.
+show-failed-logs: True

--- a/nextstrain_profiles/nextstrain-rhino/config.yaml
+++ b/nextstrain_profiles/nextstrain-rhino/config.yaml
@@ -5,6 +5,7 @@ configfile:
 cores: 20
 keep-going: True
 printshellcmds: True
+show-failed-logs: True
 reason: True
 stats: stats.json
 

--- a/nextstrain_profiles/nextstrain-scicore/config.yaml
+++ b/nextstrain_profiles/nextstrain-scicore/config.yaml
@@ -5,6 +5,7 @@ configfile:
 
 keep-going: True
 printshellcmds: True
+show-failed-logs: True
 stats: stats.json
 
 # Wait a fixed number of seconds for missing files since the cluster file system

--- a/nextstrain_profiles/nextstrain/config.yaml
+++ b/nextstrain_profiles/nextstrain/config.yaml
@@ -5,6 +5,7 @@ configfile:
 cores: 8
 keep-going: True
 printshellcmds: True
+show-failed-logs: True
 reason: True
 restart-times: 1
 stats: stats.json


### PR DESCRIPTION
Adds Snakemake's `show-failed-logs` option to Nextstrain and example config files. This flag will automatically print log files of any failed jobs to the screen for easier debugging.