### PR TITLE
Allow numbers in build names

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -133,7 +133,7 @@ config["conda_environment"] = CONDA_ENV_PATH
 wildcard_constraints:
     # Allow build names to contain alpha characters, underscores, and hyphens
     # but not special strings used for Nextstrain builds.
-    build_name = r'(?:[_a-zA-Z-](?!(tip-frequencies)))+',
+    build_name = r'(?:[a-zA-Z0-9-_](?!(tip-frequencies)))+',
     date = r"[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]",
     origin = r"[a-zA-Z0-9-_]+"
 

--- a/Snakefile
+++ b/Snakefile
@@ -131,11 +131,11 @@ config["conda_environment"] = CONDA_ENV_PATH
 
 # Define patterns we expect for wildcards.
 wildcard_constraints:
-    # Allow build names to contain alpha characters, underscores, and hyphens
+    # Allow build names to contain alphanumeric characters, underscores, and hyphens
     # but not special strings used for Nextstrain builds.
-    build_name = r'(?:[a-zA-Z0-9-_](?!(tip-frequencies)))+',
+    build_name = r'(?:[a-zA-Z0-9_-](?!(tip-frequencies)))+',
     date = r"[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]",
-    origin = r"[a-zA-Z0-9-_]+"
+    origin = r"[a-zA-Z0-9_-]+"
 
 localrules: clean
 

--- a/Snakefile
+++ b/Snakefile
@@ -133,9 +133,9 @@ config["conda_environment"] = CONDA_ENV_PATH
 wildcard_constraints:
     # Allow build names to contain alphanumeric characters, underscores, and hyphens
     # but not special strings used for Nextstrain builds.
-    build_name = r'(?:[a-zA-Z0-9_-](?!(tip-frequencies)))+',
-    date = r"[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]",
-    origin = r"[a-zA-Z0-9_-]+"
+    build_name = r'(?:[-a-zA-Z0-9_](?!(tip-frequencies)))+',
+    date = r"\d{4}-\d{2}-\d{2}",
+    origin = r"[-a-zA-Z0-9_]+"
 
 localrules: clean
 

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,10 +5,11 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
-- 11 February 2022: Add colors to default Auspice config for Nextclade quality control columns and a filter for overall Nextclade QC status. [PR #861](https://github.com/nextstrain/ncov/pull/861).
-- 8 Mar 2022: Support disabling clock filters in the refine step by setting `clock_filter_iqd: 0` in the `refine` section. [PR #884](https://github.com/nextstrain/ncov/pull/884), [Issue #852](https://github.com/nextstrain/ncov/issues/852).
-- 17 March 2022: Add `Nextclade_pango` column to metadata [PR 892](https://github.com/nextstrain/ncov/pull/892)
+- 12 April 2022: Add support for numbers in build names. [PR 524](https://github.com/nextstrain/ncov/pull/524)
 - 11 April 2022: Update clade definitions to be robust to presence of lineage BA.4 and BA.5 viruses. [PR #913](https://github.com/nextstrain/ncov/pull/913)
+- 17 March 2022: Add `Nextclade_pango` column to metadata [PR 892](https://github.com/nextstrain/ncov/pull/892)
+- 8 Mar 2022: Support disabling clock filters in the refine step by setting `clock_filter_iqd: 0` in the `refine` section. [PR #884](https://github.com/nextstrain/ncov/pull/884), [Issue #852](https://github.com/nextstrain/ncov/issues/852).
+- 11 February 2022: Add colors to default Auspice config for Nextclade quality control columns and a filter for overall Nextclade QC status. [PR #861](https://github.com/nextstrain/ncov/pull/861).
 
 ## v11 (3 February 2022)
 

--- a/docs/src/reference/configuration.rst
+++ b/docs/src/reference/configuration.rst
@@ -98,12 +98,11 @@ builds
 
 .. warning::
 
-   Build names currently only allow alpha characters, underscores, and hyphens (``A-Z``, ``a-z``, ``_``, ``-``), but must not contain ``tip-frequencies`` as it is a special string used for Nextstrain builds.
+   Build names only allow alphanumeric characters, underscores, and hyphens (``A-Z``, ``a-z``, ``0-9``, ``_``, ``-``), but must not contain ``tip-frequencies`` as it is a special string used for Nextstrain builds.
 
    Note that these are not allowed:
 
    - Periods (``.``)
-   - Digits (``0-9``)
 
 -  examples:
 

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -42,7 +42,7 @@ properties:
       # Allow build names to contain alphanumeric characters, underscores, and hyphens
       # but not special strings used for Nextstrain builds.  Also used in the
       # workflow's wildcard_constraints.
-      pattern: "^(?:[a-zA-Z0-9_-](?!(tip-frequencies)))+$"
+      pattern: "^(?:[-a-zA-Z0-9_](?!(tip-frequencies)))+$"
 
   S3_DST_COMPRESSION:
     type: string

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -39,10 +39,10 @@ properties:
     type: object
     minProperties: 1
     propertyNames:
-      # Allow build names to contain alpha characters, underscores, and hyphens
+      # Allow build names to contain alphanumeric characters, underscores, and hyphens
       # but not special strings used for Nextstrain builds.  Also used in the
       # workflow's wildcard_constraints.
-      pattern: "^(?:[_a-zA-Z-](?!(tip-frequencies)))+$"
+      pattern: "^(?:[a-zA-Z0-9_-](?!(tip-frequencies)))+$"
 
   S3_DST_COMPRESSION:
     type: string

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -26,7 +26,7 @@ def numeric_date(dt=None):
     return res
 
 def _get_subsampling_scheme_by_build_name(build_name):
-    return config["builds"][build_name].get("subsampling_scheme", build_name)
+    return config["builds"].get(build_name, {}).get("subsampling_scheme", build_name)
 
 def _get_skipped_inputs_for_diagnostic(wildcards):
     """Build an argument for the diagnostic script with a list of inputs to skip.

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -23,6 +23,8 @@ import requests
 import json
 from workflow.lib.persistent_dict import PersistentDict, NoSuchEntryError
 
+ruleorder: dated_json > finalize
+
 def get_todays_date():
     from datetime import datetime
     date = datetime.today().strftime('%Y-%m-%d')
@@ -135,6 +137,11 @@ rule dated_json:
         dated_tip_frequencies_json = "auspice/{prefix}_{build_name}_{date}_tip-frequencies.json"
     benchmark:
         "benchmarks/dated_json_{prefix}_{build_name}_{date}.txt"
+    wildcard_constraints:
+        # Allow build names to contain alphanumeric characters, underscores, and hyphens
+        # but not special strings used for Nextstrain builds.
+        build_name = r'(?:[a-zA-Z0-9-_](?!(tip-frequencies|\d{4}-\d{2}-\d{2})))+',
+        date = r"[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"
     conda: config["conda_environment"]
     shell:
         """

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -140,8 +140,8 @@ rule dated_json:
     wildcard_constraints:
         # Allow build names to contain alphanumeric characters, underscores, and hyphens
         # but not special strings used for Nextstrain builds.
-        build_name = r'(?:[a-zA-Z0-9-_](?!(tip-frequencies|\d{4}-\d{2}-\d{2})))+',
-        date = r"[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"
+        build_name = r'(?:[-a-zA-Z0-9_](?!(tip-frequencies|\d{4}-\d{2}-\d{2})))+',
+        date = r"\d{4}-\d{2}-\d{2}"
     conda: config["conda_environment"]
     shell:
         """

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1010,7 +1010,7 @@ rule traits:
         """
 
 def _get_clade_files(wildcards):
-    if "subclades" in config["builds"][wildcards.build_name]:
+    if "subclades" in config["builds"].get(wildcards.build_name, {}):
         return [config["files"]["clades"], config["builds"][wildcards.build_name]["subclades"]]
     else:
         return config["files"]["clades"]
@@ -1346,7 +1346,7 @@ def _get_node_data_by_wildcards(wildcards):
 rule build_description:
     message: "Templating build description for Auspice"
     input:
-        description = lambda w: config["builds"][w.build_name]["description"] if "description" in config["builds"][w.build_name] else config["files"]["description"]
+        description = lambda w: config["builds"][w.build_name]["description"] if "description" in config["builds"].get(w.build_name, {}) else config["files"]["description"]
     output:
         description = "results/{build_name}/description.md"
     log:
@@ -1366,8 +1366,8 @@ rule export:
         tree = rules.refine.output.tree,
         metadata="results/{build_name}/metadata_adjusted.tsv.xz",
         node_data = _get_node_data_by_wildcards,
-        auspice_config = lambda w: config["builds"][w.build_name]["auspice_config"] if "auspice_config" in config["builds"][w.build_name] else config["files"]["auspice_config"],
-        colors = lambda w: config["builds"][w.build_name]["colors"] if "colors" in config["builds"][w.build_name] else ( config["files"]["colors"] if "colors" in config["files"] else rules.colors.output.colors.format(**w) ),
+        auspice_config = lambda w: config["builds"][w.build_name]["auspice_config"] if "auspice_config" in config["builds"].get(w.build_name, {}) else config["files"]["auspice_config"],
+        colors = lambda w: config["builds"][w.build_name]["colors"] if "colors" in config["builds"].get(w.build_name, {}) else ( config["files"]["colors"] if "colors" in config["files"] else rules.colors.output.colors.format(**w) ),
         lat_longs = config["files"]["lat_longs"],
         description = rules.build_description.output.description
     output:


### PR DESCRIPTION
This is a second attempt to add support for numbers in build names after #522 unexpectedly broke the Nextstrain team's builds. This PR reduces the constraints on build names for most builds and adds rule-specific wildcard constraints to Nextstrain-dated builds. These constraints prevent dates from being in Nextstrain build names so the standard Nextstrain builds can be saved as dated copies. To prevent ambiguity between the dated JSONs rule and the main workflow's finalize rule, this commit also specifies a preferred rule order for the Nextstrain builds.

(**Updated on November 24, 2021**)
I tested this new code with the following build config (`builds.yaml`):

```yaml
inputs:
  - name: example-data
    metadata: data/example_metadata.tsv
    sequences: data/example_sequences.fasta.gz

default_build_name: my-build-2021-11-24
```

And then the following command:

```bash
snakemake --configfile builds.yaml -p -j 1
```

I also confirmed that the Nextstrain profile's dryrun worked as expected:

```
snakemake --profile nextstrain_profiles/nextstrain-gisaid all_regions -np
```

These changes should allow people to name their builds nearly anything they like including dates (e.g., `global-2020-12-22`) without breaking the existing Nextstrain naming scheme for dated builds.

- [x] Tested with CI
- [ ] [Tested with full Nextstrain open build](https://github.com/nextstrain/ncov/runs/4621236854)

Resolves #482 