### PR TITLE
Add Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ install:
 script:
   - gunzip data/example_sequences.fasta.gz
   - nextstrain build . all_regions -j 2 --profile nextstrain_profiles/nextstrain --config sequences=data/example_sequences.fasta metadata=data/example_metadata.tsv active_builds=global
-  - augur validate export-v2 auspice/ncov_global.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+os: linux
+dist: xenial
+services:
+  - docker
+language: python
+python:
+  - "3.6"
+install:
+  - pip3 install git+https://github.com/nextstrain/cli
+  - nextstrain version
+  - nextstrain check-setup
+  - nextstrain update
+script:
+  - gunzip data/example_sequences.fasta.gz
+  - nextstrain build . all_regions -j 2 --profile nextstrain_profiles/nextstrain --config sequences=data/example_sequences.fasta metadata=data/example_metadata.tsv active_builds=global
+  - augur validate export-v2 auspice/ncov_global.json

--- a/Snakefile
+++ b/Snakefile
@@ -62,7 +62,11 @@ if "builds" not in config:
         }
     }
 
-BUILD_NAMES = list(config["builds"].keys())
+# Allow users to specify a list of active builds from the command line.
+if config.get("active_builds"):
+    BUILD_NAMES = config["active_builds"].split(",")
+else:
+    BUILD_NAMES = list(config["builds"].keys())
 
 # Define patterns we expect for wildcards.
 wildcard_constraints:


### PR DESCRIPTION
### Description of proposed changes    

This PR adds Travis CI tests that run a minimal Nextstrain global build (with the "example" dataset) in the Nextstrain Docker container based on @trvrb's pattern from [the avian flu repository](https://github.com/nextstrain/avian-flu/blob/master/.travis.yml). These tests should help us catch bugs in new workflow features by automating a previously manual process.

To implement a minimal global build that creates all of the many various outputs from a standard Nextstrain build, this PR also introduces a new configuration parameter, `active_builds`, that allows users to control which builds will be run from the command line with a comma-delimited list of build names.

The tests current take ~8 minutes to complete. The build itself takes ~6 minutes with what is already minimal data and 2 cores. I imagine we'd only want to run CI checks on new branches and PRs but not for minor changes pushed directly to `master`.

### Related issue(s)  

Related to #297 

### Testing

Tested by Travis CI.