### PR TITLE
Default to clades coloring

### DIFF
--- a/nextstrain_profiles/nextstrain/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/africa_auspice_config.json
@@ -106,11 +106,12 @@
     "region"
   ],
   "display_defaults": {
-    "color_by": "country",
+    "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "country",
     "map_triplicate": true,
-    "branch_label": "clade"
+    "branch_label": "clade",
+    "transmission_lines": false
   },
   "filters": [
     "recency",

--- a/nextstrain_profiles/nextstrain/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/asia_auspice_config.json
@@ -106,11 +106,12 @@
     "region"
   ],
   "display_defaults": {
-    "color_by": "country",
+    "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "country",
     "map_triplicate": true,
-    "branch_label": "clade"
+    "branch_label": "clade",
+    "transmission_lines": false    
   },
   "filters": [
     "recency",

--- a/nextstrain_profiles/nextstrain/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/europe_auspice_config.json
@@ -106,11 +106,12 @@
     "region"
   ],
   "display_defaults": {
-    "color_by": "country",
+    "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "country",
     "map_triplicate": true,
-    "branch_label": "clade"
+    "branch_label": "clade",
+    "transmission_lines": false    
   },
   "filters": [
     "recency",

--- a/nextstrain_profiles/nextstrain/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/global_auspice_config.json
@@ -106,11 +106,12 @@
     "region"
   ],
   "display_defaults": {
-    "color_by": "region",
+    "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "country",
     "map_triplicate": true,
-    "branch_label": "clade"
+    "branch_label": "clade",
+    "transmission_lines": false    
   },
   "filters": [
     "recency",

--- a/nextstrain_profiles/nextstrain/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/north-america_auspice_config.json
@@ -106,11 +106,12 @@
     "region"
   ],
   "display_defaults": {
-    "color_by": "division",
+    "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "division",
     "map_triplicate": true,
-    "branch_label": "clade"
+    "branch_label": "clade",
+    "transmission_lines": false    
   },
   "filters": [
     "recency",

--- a/nextstrain_profiles/nextstrain/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/oceania_auspice_config.json
@@ -106,11 +106,12 @@
     "region"
   ],
   "display_defaults": {
-    "color_by": "division",
+    "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "division",
     "map_triplicate": true,
-    "branch_label": "clade"
+    "branch_label": "clade",
+    "transmission_lines": false    
   },
   "filters": [
     "recency",

--- a/nextstrain_profiles/nextstrain/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/south-america_auspice_config.json
@@ -106,11 +106,12 @@
     "region"
   ],
   "display_defaults": {
-    "color_by": "country",
+    "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "country",
     "map_triplicate": true,
-    "branch_label": "clade"
+    "branch_label": "clade",
+    "transmission_lines": false    
   },
   "filters": [
     "recency",


### PR DESCRIPTION
### Description of proposed changes    

This moves default from geographic coloring to clades coloring for global and regional builds. I think this is in order at this point given necessary focus on expanding variants of concern.

### Testing
This was tested locally, but there's not a lot potential for errors.
