### PR TITLE
Provide an explicit max date for tip frequencies

### DIFF
--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -1,5 +1,30 @@
 """Small, shared functions used to generate inputs and parameters.
 """
+import datetime
+
+
+def numeric_date(dt=None):
+    """
+    Convert datetime object to the numeric date.
+    The numeric date format is YYYY.F, where F is the fraction of the year passed
+    Parameters
+    ----------
+     dt:  datetime.datetime, None
+        date of to be converted. if None, assume today
+    """
+    from calendar import isleap
+
+    if dt is None:
+        dt = datetime.datetime.now()
+
+    days_in_year = 366 if isleap(dt.year) else 365
+    try:
+        res = dt.year + (dt.timetuple().tm_yday-0.5) / days_in_year
+    except:
+        res = None
+
+    return res
+
 def _get_subsampling_scheme_by_build_name(build_name):
     return config["builds"][build_name].get("subsampling_scheme", build_name)
 
@@ -44,3 +69,9 @@ def _get_sampling_bias_correction_for_wildcards(wildcards):
         return config["traits"][wildcards.build_name]["sampling_bias_correction"]
     else:
         return config["traits"]["default"]["sampling_bias_correction"]
+
+def _get_max_date_for_frequencies(wildcards):
+    if "frequencies" in config and "max_date" in config["frequencies"]:
+        return config["frequencies"]["max_date"]
+    else:
+        return numeric_date(date.today())

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -811,6 +811,7 @@ rule tip_frequencies:
         "logs/tip_frequencies_{build_name}.txt"
     params:
         min_date = config["frequencies"]["min_date"],
+        max_date = _get_max_date_for_frequencies,
         pivot_interval = config["frequencies"]["pivot_interval"],
         narrow_bandwidth = config["frequencies"]["narrow_bandwidth"],
         proportion_wide = config["frequencies"]["proportion_wide"]
@@ -822,6 +823,7 @@ rule tip_frequencies:
             --metadata {input.metadata} \
             --tree {input.tree} \
             --min-date {params.min_date} \
+            --max-date {params.max_date} \
             --pivot-interval {params.pivot_interval} \
             --narrow-bandwidth {params.narrow_bandwidth} \
             --proportion-wide {params.proportion_wide} \


### PR DESCRIPTION
## Description of changes

Prevent tip frequency pivots from extending too far into the future when no maximum date is provided by providing an explicit max date. Users can define the `max_date` in the frequencies section of the configuration (as with `min_date`) or leave this field empty. When the `max_date` is not defined by the user, it defaults to today's date.

This commit copies the `numeric_date` utility from TreeTime into the common functions for the workflow. The cost of duplicating this code is worth the benefit of not requiring Augur or TreeTime to be installed in the user's environment when they run Snakemake. This allows users to run the workflow with `--use-conda` from an environment without anything but Snakemake installed.

## Testing

Tested by with the getting started profile, to make sure that the correct date is used as an argument and that the frequency pivots do not extend beyond the maximum date.