### PR TITLE
Set weeks as pivot interval

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -97,6 +97,9 @@ frequencies:
   # Number of months between pivots
   pivot_interval: 1
 
+  # Measure pivots in weeks rather than months
+  pivot_interval_units: "weeks"
+
   # KDE bandwidths in proportion of a year to use per strain.
   narrow_bandwidth: 0.05
   proportion_wide: 0.0

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -813,6 +813,7 @@ rule tip_frequencies:
         min_date = config["frequencies"]["min_date"],
         max_date = _get_max_date_for_frequencies,
         pivot_interval = config["frequencies"]["pivot_interval"],
+        pivot_interval_units = config["frequencies"]["pivot_interval_units"],
         narrow_bandwidth = config["frequencies"]["narrow_bandwidth"],
         proportion_wide = config["frequencies"]["proportion_wide"]
     conda: config["conda_environment"]
@@ -825,6 +826,7 @@ rule tip_frequencies:
             --min-date {params.min_date} \
             --max-date {params.max_date} \
             --pivot-interval {params.pivot_interval} \
+            --pivot-interval-units {params.pivot_interval_units} \
             --narrow-bandwidth {params.narrow_bandwidth} \
             --proportion-wide {params.proportion_wide} \
             --output {output.tip_frequencies_json} 2>&1 | tee {log}


### PR DESCRIPTION
### Description of proposed changes    

This PR updates `augur frequencies` with `--pivot-interval-units weeks` to give finer resolution pivots. Merging this should wait on the merge of Augur PR https://github.com/nextstrain/augur/pull/660 and the release of a new Augur version (so that AWS Batch has Augur change available).