### PR TITLE
Updates to augur 10.3.0

### DIFF
--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -18,6 +18,6 @@ dependencies:
 - pip
 - pip:
   - awscli==1.18.45
-  - nextstrain-augur==10.2.0
+  - nextstrain-augur==10.3.0
   - nextstrain-cli==1.16.5
   - rethinkdb==2.3.0.post6


### PR DESCRIPTION
Updates `nextstrain.yaml` to specify the latest version of augur. Otherwise augur frequency fails with`use-conda` after weeks as the pivot interval (#533) was merged in.

Noticed this bug and tested it on the WA builds.