### PR TITLE
Add a "dump_config" rule to spew the final, merged config to stdout

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -99,6 +99,11 @@ rule clean:
     shell:
         "rm -rfv {params}"
 
+rule dump_config:
+    run:
+        import yaml, sys
+        yaml.dump(config, sys.stdout, explicit_start = True, explicit_end = True)
+
 # Include small, shared functions that help build inputs and parameters.
 include: "workflow/snakemake_rules/common.smk"
 


### PR DESCRIPTION
Helpful for development, testing, and debugging of config settings when
layers of profiles/config files and command-line options are involved.

yaml is PyYAML, which is a transitive dep through Snakemake.

Even in --quiet mode, Snakemake prints cruft to stdout, so the explicit
start and end markers for the YAML document help delineate it.

