### PR TITLE
Add 'snakemake=5.26.1' to nextstrain.yaml

### DIFF
--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -21,3 +21,4 @@ dependencies:
   - nextstrain-augur==10.3.0
   - nextstrain-cli==1.16.5
   - rethinkdb==2.3.0.post6
+  - snakemake==5.26.1


### PR DESCRIPTION
### Description of proposed changes    
Install Snakemake into conda environment by appending it to workflow/envs/nextstrain.yaml.

### Related issue(s)  
No related issues.

### Testing
Conda environment creation has been tested, locally by:
* `$ conda env update --prefix ./env --file workflow/envs/nextstrain.yaml  --prune`

Conda environment has been installed by:
* `conda env create --prefix ./env --file workflow/envs/nextstrain.yaml` (using the old version of nextstrain.yaml)

### Thank you for contributing to Nextstrain!
