### PR TITLE
Filter out samples pre-screened for S dropout

### DIFF
--- a/nextstrain_profiles/nextstrain/builds.yaml
+++ b/nextstrain_profiles/nextstrain/builds.yaml
@@ -40,6 +40,10 @@ builds:
     region: South America
     auspice_config: "nextstrain_profiles/nextstrain/south-america_auspice_config.json"
 
+# remove S dropout sequences and sequences without division label in US
+filter:
+  exclude_where: "division='USA' purpose_of_sequencing='S dropout'"
+
 # if different exposure traits should be used for some builds, specify here
 # otherwise the default exposure in defaults/parameters.yaml will used
 exposure:


### PR DESCRIPTION
### Description of proposed changes    
Including "S dropout" samples biases prevalence of B.1.1.7 upwards. Labeling of samples in GISAID seems to be happening best in the US, but I think helpful to have this included in general.

This additional filtering is included in the Nextstrain profile rather than the default parameters because I imagine other groups will want to look specifically at trees of B.1.1.7.

Here, we see that prior to this change, we are listing 501Y.V1 in the US at 9% frequency at the most recent pivot:

<img width="1178" alt="uncorrected" src="https://user-images.githubusercontent.com/1176109/106022720-ffdecc00-607a-11eb-8a40-66fad6cba879.png">

while with this change, we list 501Y.V1 in the US at 6% frequency:

<img width="1178" alt="corrected" src="https://user-images.githubusercontent.com/1176109/106022799-11c06f00-607b-11eb-8b1e-7ede53f398b3.png">

So, not a huge effect, but a simple step in the right direction.

### Testing
I did a full build locally via `snakemake` with this change in place.
