### PR TITLE
#225 link to ingest from ncov tutorial

### DIFF
--- a/docs/data-prep.md
+++ b/docs/data-prep.md
@@ -114,6 +114,8 @@ This should be decompressed and saved as `data/global_sequences.fasta`.
 
 You can concatenate these files with your own; make sure the TSV fields are in the same order.
 
+The Nextstrain team uses this pipeline to include the latest sequences and metadata from GISAID in our builds: [nextstrain/ncov-ingest](https://github.com/nextstrain/ncov-ingest).
+
 ### Subsampling
 
 We've outlined several methods for subsampling, including builds with a focus area + genetically similar contextual sequences, in the [next section](running.md).


### PR DESCRIPTION
Addressing question about where metadata comes from by linking to ncov-ingest pipeline. cc @trvrb let me know if this language is what you were looking for. I left out this part since it's in the ncov-ingest README.md's first line:
> This is open source, but we are not intending to support this to be used by outside groups.

