### PR TITLE
Allow an optional split between S3 source and destination buckets

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -19,6 +19,12 @@ reference_node_name: "USA/WA1/2020"
 # all steps can run locally without using any S3 buckets.
 S3_BUCKET: "your_S3_bucket_here"
 
+# Set these instead to download from a source (SRC) bucket and upload to a
+# different destination (DST) bucket.  If either is empty/undefined, then the
+# value of S3_BUCKET is used instead.
+S3_SRC_BUCKET: ""
+S3_DST_BUCKET: ""
+
 # Preprocess steps involve the creation and storage of intermediate files
 # (alignments etc). These steps are opt-in, and are not run by default.
 # These settings define the compression/decompression settings for these files

--- a/nextstrain_profiles/nextstrain/download_preprocessed.smk
+++ b/nextstrain_profiles/nextstrain/download_preprocessed.smk
@@ -17,7 +17,7 @@ rule download_aligned:
     params:
         compression = config['preprocess']['compression'],
         deflate = config['preprocess']['deflate'],
-        s3_bucket = config["S3_BUCKET"]
+        s3_bucket = _get_first(config, "S3_SRC_BUCKET", "S3_BUCKET")
     shell:
         """
         aws s3 cp s3://{params.s3_bucket}/aligned.fasta.{params.compression} - | {params.deflate} > {output.sequences:q}
@@ -33,7 +33,7 @@ rule download_diagnostic:
     params:
         compression = config['preprocess']['compression'],
         deflate = config['preprocess']['deflate'],
-        s3_bucket = config["S3_BUCKET"]
+        s3_bucket = _get_first(config, "S3_SRC_BUCKET", "S3_BUCKET")
     shell:
         """
         aws s3 cp s3://{params.s3_bucket}/sequence-diagnostics.tsv.{params.compression} - | {params.deflate} > {output.diagnostics:q}
@@ -49,7 +49,7 @@ rule download_refiltered:
     params:
         compression = config['preprocess']['compression'],
         deflate = config['preprocess']['deflate'],
-        s3_bucket = config["S3_BUCKET"]
+        s3_bucket = _get_first(config, "S3_SRC_BUCKET", "S3_BUCKET")
     shell:
         """
         aws s3 cp s3://{params.s3_bucket}/aligned-filtered.fasta.{params.compression} - | {params.deflate} > {output.sequences:q}
@@ -64,7 +64,7 @@ rule download_masked:
     params:
         compression = config['preprocess']['compression'],
         deflate = config['preprocess']['deflate'],
-        s3_bucket = config["S3_BUCKET"]
+        s3_bucket = _get_first(config, "S3_SRC_BUCKET", "S3_BUCKET")
     shell:
         """
         aws s3 cp s3://{params.s3_bucket}/masked.fasta.{params.compression} - | {params.deflate} > {output.sequences:q}
@@ -79,7 +79,7 @@ rule download_filtered:
     params:
         compression = config['preprocess']['compression'],
         deflate = config['preprocess']['deflate'],
-        s3_bucket = config["S3_BUCKET"]
+        s3_bucket = _get_first(config, "S3_SRC_BUCKET", "S3_BUCKET")
     shell:
         """
         aws s3 cp s3://{params.s3_bucket}/filtered.fasta.{params.compression} - | {params.deflate} > {output.sequences:q}

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -75,3 +75,16 @@ def _get_max_date_for_frequencies(wildcards):
         return config["frequencies"]["max_date"]
     else:
         return numeric_date(date.today())
+
+def _get_first(config, *keys):
+    """
+    Get the value of the first key in *keys* that exists in *config* and has a
+    non-empty value.
+
+    Raises a :class:`KeyError` if none of the *keys* exist with a suitable
+    value.
+    """
+    for key in keys:
+        if config.get(key) not in {"", None}:
+            return config[key]
+    raise KeyError(str(keys))

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -133,7 +133,7 @@ rule upload:
         "results/flagged-sequences.tsv",
         "results/to-exclude.txt"
     params:
-        s3_bucket = config["S3_BUCKET"],
+        s3_bucket = _get_first(config, "S3_DST_BUCKET", "S3_BUCKET"),
         compression = config["preprocess"]["compression"]
     log:
         "logs/upload.txt"

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -4,7 +4,7 @@ rule download_sequences:
         sequences = config["sequences"]
     conda: config["conda_environment"]
     params:
-        s3_bucket = config["S3_BUCKET"]
+        s3_bucket = _get_first(config, "S3_SRC_BUCKET", "S3_BUCKET")
     shell:
         """
         aws s3 cp s3://{params.s3_bucket}/sequences.fasta.gz - | gunzip -cq > {output.sequences:q}
@@ -16,7 +16,7 @@ rule download_metadata:
         metadata = config["metadata"]
     conda: config["conda_environment"]
     params:
-        s3_bucket = config["S3_BUCKET"]
+        s3_bucket = _get_first(config, "S3_SRC_BUCKET", "S3_BUCKET")
     shell:
         """
         aws s3 cp s3://{params.s3_bucket}/metadata.tsv.gz - | gunzip -cq >{output.metadata:q}


### PR DESCRIPTION
This lets trial runs pull the latest data from the production bucket but
upload back into non-production buckets so as not to affect our
production runs.
