### PR TITLE
Fix nnz scipy issue with proximity_score job

### DIFF
--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -11,7 +11,6 @@ dependencies:
 - pandas
 - psutil
 - python=3.7*
-- scipy=1.6.0
 - nodejs=10
 - raxml
 - vcftools

--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -10,7 +10,8 @@ dependencies:
 - mafft=7.471
 - pandas
 - psutil
-- python=3.6*
+- python=3.7*
+- scipy=1.6.0
 - nodejs=10
 - raxml
 - vcftools


### PR DESCRIPTION
### Description of proposed changes    
Fixes Issue with running proximity_score job on latest pull from GISAID of ~425000 sequences. Fix was identified from issue on scipy repo https://github.com/scipy/scipy/issues/12495. Increasing python version to 3.7.* in env ensures that scipy 1.6.0 is installed instead of 1.5.4.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #512 

### Testing
What steps should be taken to test the changes you've proposed?  

* conda env create --prefix ./env --file workflow/envs/nextstrain.yaml

If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

### Thank you for contributing to Nextstrain!
