### PR TITLE
Start collecting benchmark information for the proximity_score rule

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -431,6 +431,8 @@ rule proximity_score:
         priorities = "results/{build_name}/proximity_{focus}.tsv"
     log:
         "logs/subsampling_priorities_{build_name}_{focus}.txt"
+    benchmark:
+        "benchmarks/proximity_score_{build_name}_{focus}.txt"
     resources:
         mem_mb = 4000
     conda: config["conda_environment"]


### PR DESCRIPTION
This will let us see how much memory the step actually uses, so we have
some additional insight into adjusting the mem_mb resource declaration.

See also <https://github.com/nextstrain/ncov/issues/546>.
