### PR TITLE
Use sequence index for augur filter rules

### DIFF
--- a/nextstrain_profiles/nextstrain/builds.yaml
+++ b/nextstrain_profiles/nextstrain/builds.yaml
@@ -26,6 +26,7 @@ inputs:
     # ------------------------------------------------------
     # metadata: "s3://nextstrain-ncov-private/metadata_gisaid.tsv.gz"
     # sequences: "s3://nextstrain-ncov-private/sequences_gisaid.fasta.gz"
+    # sequence_index: "s3://nextstrain-ncov-private/sequence_index_gisaid.tsv"
     # aligned: "s3://nextstrain-ncov-private/aligned_gisaid.fasta.xz"
     # to-exclude: "s3://nextstrain-ncov-private/to-exclude_gisaid.txt.xz"
     # masked: "s3://nextstrain-ncov-private/masked_gisaid.fasta.fasta.xz"

--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -18,6 +18,6 @@ dependencies:
 - pip
 - pip:
   - awscli==1.18.45
-  - nextstrain-augur==10.3.0
+  - nextstrain-augur==11.1.2
   - nextstrain-cli==1.16.5
   - rethinkdb==2.3.0.post6

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -110,6 +110,14 @@ def _get_unified_alignment(wildcards):
         return _get_path_for_input("filtered", "_"+list(config["inputs"].keys())[0])
     return "results/combined_sequences_for_subsampling.fasta",
 
+def _get_unified_sequence_index(wildcards):
+    if not config.get("inputs"):
+        return f"results/sequence_index.tsv"
+    elif len(list(config["inputs"].keys())) == 1:
+        return f"results/sequence_index{wildcards.origin}.tsv"
+
+    return "results/combined_sequence_index.tsv"
+
 def _get_metadata_by_build_name(build_name):
     """Returns a path associated with the metadata for the given build name.
 

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -72,6 +72,8 @@ def _get_path_for_input(stage, origin_wildcard):
         return f"data/downloaded{origin_wildcard}.tsv" if remote else path_or_url
     if stage=="sequences":
         return f"data/downloaded{origin_wildcard}.fasta" if remote else path_or_url
+    if stage=="sequence_index":
+        return f"results/precomputed-sequence_index{origin_wildcard}.tsv" if remote else f"results/sequence_index{origin_wildcard}.tsv"
     if stage=="prefiltered":
         # we don't expose the option to download a prefiltered alignment - it must be computed locally
         return f"results/prefiltered{origin_wildcard}.fasta"
@@ -112,9 +114,9 @@ def _get_unified_alignment(wildcards):
 
 def _get_unified_sequence_index(wildcards):
     if not config.get("inputs"):
-        return f"results/sequence_index.tsv"
+        return "results/sequence_index.tsv"
     elif len(list(config["inputs"].keys())) == 1:
-        return f"results/sequence_index{wildcards.origin}.tsv"
+        return _get_path_for_input("sequence_index", "_"+list(config["inputs"].keys())[0])
 
     return "results/combined_sequence_index.tsv"
 

--- a/workflow/snakemake_rules/download.smk
+++ b/workflow/snakemake_rules/download.smk
@@ -43,6 +43,18 @@ rule download_sequences:
         aws s3 cp {params.address} - | {params.deflate} > {output.sequences:q}
         """
 
+rule download_sequence_index:
+    message: "Downloading sequence index from {params.address} -> {output.sequence_index}"
+    output:
+        sequence_index = "results/precomputed-sequence_index{origin}.tsv"
+    conda: config["conda_environment"]
+    params:
+        address = lambda w: config["inputs"][_trim_origin(w.origin)]["sequence_index"]
+    shell:
+        """
+        aws s3 cp {params.address} - | gunzip -cq >{output.sequence_index:q}
+        """
+
 rule download_metadata:
     message: "Downloading metadata from {params.address} -> {output.metadata}"
     output:

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -127,6 +127,7 @@ rule deploy_to_staging:
 rule upload:
     message: "Uploading intermediate files for specified origins to {params.s3_bucket}"
     input:
+        expand("results/sequence_index_{origin}.tsv", origin=config["S3_DST_ORIGINS"]),         # from `rule index_sequences`
         expand("results/aligned_{origin}.fasta", origin=config["S3_DST_ORIGINS"]),              # from `rule align`
         expand("results/sequence-diagnostics_{origin}.tsv", origin=config["S3_DST_ORIGINS"]),   # from `rule diagnostic`
         expand("results/flagged-sequences_{origin}.tsv", origin=config["S3_DST_ORIGINS"]),      # from `rule diagnostic`

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -46,7 +46,7 @@ rule excluded_sequences:
         """
     input:
         sequences = lambda wildcards: _get_path_for_input("sequences", wildcards.origin),
-        sequence_index = "results/sequence_index{origin.tsv}",
+        sequence_index = "results/sequence_index{origin}.tsv",
         metadata = lambda wildcards: _get_path_for_input("metadata", wildcards.origin),
         include = config["files"]["exclude"]
     output:


### PR DESCRIPTION
Adds a rule to generate an initial sequence index with the new augur index command and updates the workflow's augur filter rules to use this index.

Note that this implementation requires the download of the full sequence set even if the user has requested to start the workflow from the filtered alignment (since subsampling also needs the sequence index). If we chose to recalculate the sequence index for the filtered alignment, the contents of that new index would be different as it would represent a multiple sequence alignment with additional gap sequences.