### PR TITLE
Allow filtering by PANGO lineage

### DIFF
--- a/nextstrain_profiles/nextstrain/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/africa_auspice_config.json
@@ -121,7 +121,7 @@
     "division",
     "location",
     "host",
-    "author"
+    "pangolin_lineage"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/asia_auspice_config.json
@@ -121,7 +121,7 @@
     "division",
     "location",
     "host",
-    "author"
+    "pangolin_lineage"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/europe_auspice_config.json
@@ -121,7 +121,7 @@
     "division",
     "location",
     "host",
-    "author"
+    "pangolin_lineage"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/global_auspice_config.json
@@ -121,7 +121,7 @@
     "division",
     "location",
     "host",
-    "author"
+    "pangolin_lineage"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/north-america_auspice_config.json
@@ -121,7 +121,7 @@
     "division",
     "location",
     "host",
-    "author"
+    "pangolin_lineage"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/oceania_auspice_config.json
@@ -121,7 +121,7 @@
     "division",
     "location",
     "host",
-    "author"
+    "pangolin_lineage"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/south-america_auspice_config.json
@@ -121,7 +121,7 @@
     "division",
     "location",
     "host",
-    "author"
+    "pangolin_lineage"
   ],
   "panels": [
     "tree",


### PR DESCRIPTION
### Description of proposed changes    
This is a simple swap from `authors` to `pangolin_lineage` in the Nextstrain profile filters. I've found it increasingly common to want to point people to trees highlighting B.1.525, etc... and this accomplishes this easily. 

I've chosen to swap out `authors` rather than just add `pangolin_lineage` just because the page footer was seeming over verbose. If folks think that `authors` is required we should keep it in. We'll still have originating lab, submitting lab and authors in the tooltip.

### Testing
I applied this on top of the latest build artifacts from AWS and it worked just fine. (There's not much there to break)
