### PR TITLE
Tilt sampling towards focal region

### DIFF
--- a/nextstrain_profiles/nextstrain/builds.yaml
+++ b/nextstrain_profiles/nextstrain/builds.yaml
@@ -143,28 +143,28 @@ subsampling:
     # Focal samples for region
     region_early:
       group_by: "division year month"
-      max_sequences: 800
+      max_sequences: 1050
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region!={region}'"
     # Contextual samples for region from the rest of the world
     global_early:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 350
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region={region}'"
       priorities:
         type: "proximity"
         focus: "region_late"
-
+    # Focal samples for region
     region_late:
       group_by: "division year month"
-      max_sequences: 1700
+      max_sequences: 2100
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region!={region}'"
     # Contextual samples for region from the rest of the world
     global_late:
       group_by: "country year month"
-      max_sequences: 1000
+      max_sequences: 700
       exclude: "--exclude-where 'region={region}'"
       sampling_scheme: "--probabilistic-sampling"
       priorities:
@@ -239,30 +239,30 @@ subsampling:
   # is the smallest resolution requied
   nextstrain_region_grouped_by_country:
     # Focal samples for region
-    region_late:
+    region_early:
       group_by: "country year month"
-      max_sequences: 1700
+      max_sequences: 1050
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region!={region}'"
     # Contextual samples for region from the rest of the world
-    global_late:
+    global_early:
       group_by: "country year month"
-      max_sequences: 1000
+      max_sequences: 350
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region={region}'"
       priorities:
         type: "proximity"
         focus: "region_late"
     # Focal samples for region
-    region_early:
+    region_late:
       group_by: "country year month"
-      max_sequences: 800
+      max_sequences: 2100
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region!={region}'"
     # Contextual samples for region from the rest of the world
-    global_early:
+    global_late:
       group_by: "country year month"
-      max_sequences: 500
+      max_sequences: 700
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region={region}'"
       priorities:

--- a/nextstrain_profiles/nextstrain/builds.yaml
+++ b/nextstrain_profiles/nextstrain/builds.yaml
@@ -143,13 +143,13 @@ subsampling:
     # Focal samples for region
     region_early:
       group_by: "division year month"
-      max_sequences: 1050
+      max_sequences: 700
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region!={region}'"
     # Contextual samples for region from the rest of the world
     global_early:
       group_by: "country year month"
-      max_sequences: 350
+      max_sequences: 700
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region={region}'"
       priorities:
@@ -241,13 +241,13 @@ subsampling:
     # Focal samples for region
     region_early:
       group_by: "country year month"
-      max_sequences: 1050
+      max_sequences: 700
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region!={region}'"
     # Contextual samples for region from the rest of the world
     global_early:
       group_by: "country year month"
-      max_sequences: 350
+      max_sequences: 700
       sampling_scheme: "--probabilistic-sampling"
       exclude: "--exclude-where 'region={region}'"
       priorities:


### PR DESCRIPTION
Existing subsampling aimed at 1.5:1 ratio of regional focal samples vs global contextual samples. This commit tilts this subsampling to be a 3:1 ratio of regional focal samples vs global contextual samples. The 2:1 ratio of late to early samples remains unchanged.

### Existing

Desired subsampling counts

global: 1600
region: 2500
total: 4100
ratio of region to global: 1.56X

### This PR

Desired subsampling counts

global: 1050
region: 3150
total: 4200
ratio of region to global: 3X

Late vs early remains at 2X

### Relative to existing:

Region goes from 2500 to 3150 (1.26X)
Global goes from 1600 to 1050 (0.65X)
Early goes from 1400 to 1400 (1X)
Late goes from 2700 to 2800 (1.04X)

## Example workflow outputs

(This used @tsibley's new automatic branch AWS batch deploys. So cool.)

- Africa: https://nextstrain.org/staging/trial/focal-sampling/ncov/africa
- Asia: https://nextstrain.org/staging/trial/focal-sampling/ncov/asia
- Europe: https://nextstrain.org/staging/trial/focal-sampling/ncov/europe
- North America: https://nextstrain.org/staging/trial/focal-sampling/ncov/north-america
- Oceania: https://nextstrain.org/staging/trial/focal-sampling/ncov/oceania
- South America: https://nextstrain.org/staging/trial/focal-sampling/ncov/south-america

---------------------------------------

I think this is an improvement. The overall tree structure seems okay and the geographic inferences seem comparable to the existing code. However, for looking at emerging clades of interest, this seems preferable. For example:

- B.1.526 in the US
  - Existing: https://nextstrain.org/ncov/north-america?f_country=USA&f_pangolin_lineage=B.1.526 with 2 tips
  - PR: https://nextstrain.org/staging/trial/focal-sampling/ncov/north-america?f_country=USA&f_pangolin_lineage=B.1.526 with 7 tips
- B.1.1.7 in Europe
  - Existing: https://nextstrain.org/ncov/europe?c=country&f_pangolin_lineage=B.1.1.7&f_region=Europe with 270 tips
  - PR: https://nextstrain.org/staging/trial/focal-sampling/ncov/europe?c=country&f_pangolin_lineage=B.1.1.7&f_region=Europe with 366 tips

This isn't a big push, but I think it's in the right direction. Basically this comes from me wanting more resolution to clades / lineages in particular regions and going from ~2500 to ~3100 sequences in a region is decently helpful for this without causing much harm in terms of missing context.

If you think this change is too extreme we could dial back to 2:1 or 2.5:1 ratio of region to global from the PR 3:1 ratio.