### PR TITLE
WIP: Use metadata-only filtering in subsample jobs

### DIFF
--- a/nextstrain_profiles/nextstrain/builds.yaml
+++ b/nextstrain_profiles/nextstrain/builds.yaml
@@ -31,7 +31,7 @@ inputs:
     # sequences: "s3://nextstrain-ncov-private/sequences_gisaid.fasta.gz"
     # aligned: "s3://nextstrain-ncov-private/aligned_gisaid.fasta.xz"
     # to-exclude: "s3://nextstrain-ncov-private/to-exclude_gisaid.txt.xz"
-    # masked: "s3://nextstrain-ncov-private/masked_gisaid.fasta.fasta.xz"
+    # masked: "s3://nextstrain-ncov-private/masked_gisaid.fasta.xz"
     # filtered: "s3://nextstrain-ncov-private/filtered_gisaid.fasta.xz"
 
 # Define locations for which builds should be created.

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -355,14 +355,12 @@ rule subsample:
          - priority: {params.priority_argument}
         """
     input:
-        sequences = _get_unified_alignment,
         metadata = _get_unified_metadata,
         sequence_index = rules.index_sequences.output.sequence_index,
         include = config["files"]["include"],
         priorities = get_priorities,
         exclude = config["files"]["exclude"]
     output:
-        sequences = "results/{build_name}/sample-{subsample}.fasta",
         strains="results/{build_name}/sample-{subsample}.txt",
     log:
         "logs/subsample_{build_name}_{subsample}.txt"
@@ -387,7 +385,6 @@ rule subsample:
     shell:
         """
         augur filter \
-            --sequences {input.sequences} \
             --metadata {input.metadata} \
             --sequence-index {input.sequence_index} \
             --include {input.include} \
@@ -403,7 +400,6 @@ rule subsample:
             {params.sequences_per_group} \
             {params.subsample_max_sequences} \
             {params.sampling_scheme} \
-            --output {output.sequences} \
             --output-strains {output.strains} 2>&1 | tee {log}
         """
 
@@ -468,10 +464,6 @@ def _get_subsampled_files(wildcards):
     ]
 
 rule combine_samples:
-    message:
-        """
-        Combine and deduplicate FASTAs
-        """
     input:
         sequences=_get_unified_alignment,
         sequence_index=rules.index_sequences.output.sequence_index,

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -132,18 +132,6 @@ def _collect_exclusion_files(wildcards):
         exclude_files.append(_get_path_for_input("to-exclude", wildcards.origin))
     return exclude_files
 
-rule exclude_file:
-    input:
-        _collect_exclusion_files
-    output:
-        "results/exclude{origin}.txt"
-    benchmark:
-        "benchmarks/exclude_file{origin}.txt"
-    shell:
-        """
-        cat {input} > {output}
-        """
-
 rule mask:
     message:
         """
@@ -189,7 +177,7 @@ rule filter:
         metadata = lambda wildcards: _get_path_for_input("metadata", wildcards.origin),
         # TODO - currently the include / exclude files are not input (origin) specific, but this is possible if we want
         include = config["files"]["include"],
-        exclude = rules.exclude_file.output
+        exclude = _collect_exclusion_files
     output:
         sequences = "results/filtered{origin}.fasta"
     log:


### PR DESCRIPTION
### Description of proposed changes
Minimize inspection of large FASTA files by subsampling only with metadata and a sequence index and outputting only strain names for each subsample rule. Uses the new metadata-only filter interface proposed for Augur to collect the resulting subsampled strains and output a single FASTA file of all distinct strains.

As noted in 3216c5f, some subsample jobs require priority scores for another subsampled set and these score calculations require subsampled sequences. That same commit as a rule to extract only the subsampled sequences for a specific set as needed.

Although the goal of metadata-only filtering is to dramatically speed up this workflow, this PR does not address a major bottleneck in the current workflow which is the amount of time required by augur filter to write sequences to disk.

### Related issue(s)
Related to https://github.com/nextstrain/augur/pull/679

### Testing
I've tested this workflow with the Nextstrain Europe build and also the multiple inputs example data.

CI tests will fail because this PR requires an Augur development branch (code that is not available in the Docker image). To test this PR locally, run Snakemake with the conda mode like so:

```
snakemake --use-conda --cores 4 --profile nextstrain_profiles/nextstrain --config active_builds=europe
```