### PR TITLE
Stream combined sequences to disk instead of loading into memory

### DIFF
--- a/scripts/combine-and-dedup-fastas.py
+++ b/scripts/combine-and-dedup-fastas.py
@@ -1,6 +1,9 @@
-from Bio import SeqIO
 import argparse
-from augur.align import read_sequences
+from Bio import SeqIO
+import hashlib
+import sys
+import textwrap
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -12,12 +15,29 @@ if __name__ == '__main__':
     parser.add_argument('--output', type=str, metavar="FASTA", required=True, help="output FASTA")
     args = parser.parse_args()
 
-    # Read sequences with augur to benefit from additional checks for duplicates.
-    sequences = read_sequences(*args.input)
+    sequence_hash_by_name = {}
+    duplicate_strains = set()
 
-    # Convert dictionary of sequences by id to a list, for compatibility with
-    # augur versions <9.0.0.
-    if isinstance(sequences, dict):
-        sequences = list(sequences.values())
+    counter = 0
+    with open(args.output, "w") as output_handle:
+        for filename in args.input:
+            for record in SeqIO.parse(filename, 'fasta'):
+                counter += 1
+                if counter % 10000 == 0:
+                    print(f"Processed {counter} records")
 
-    SeqIO.write(sequences, args.output, 'fasta')
+                sequence_hash = hashlib.sha256(str(record.seq).encode("utf-8")).hexdigest()
+                if record.name in sequence_hash_by_name and sequence_hash_by_name.get(record.name) != sequence_hash:
+                    duplicate_strains.add(record.name)
+                    continue
+
+                sequence_hash_by_name[record.name] = sequence_hash
+                SeqIO.write(record, output_handle, 'fasta')
+
+    if len(duplicate_strains) > 0:
+        print(
+            "WARNING: Detected the following duplicate input strains with different sequences:",
+            file=sys.stderr
+        )
+        for strain in duplicate_strains:
+            print(textwrap.indent(strain, "    "), file=sys.stderr)

--- a/scripts/combine-and-dedup-fastas.py
+++ b/scripts/combine-and-dedup-fastas.py
@@ -20,15 +20,28 @@ if __name__ == '__main__':
 
     counter = 0
     with open(args.output, "w") as output_handle:
+        # Stream sequences from all input files into a single output file,
+        # skipping duplicate records (same strain and sequence) and noting
+        # mismatched sequences for the same strain name.
         for filename in args.input:
             for record in SeqIO.parse(filename, 'fasta'):
                 counter += 1
                 if counter % 10000 == 0:
                     print(f"Processed {counter} records")
 
+                # Hash each sequence and check whether another sequence with the
+                # same name already exists and if the hash is different.
                 sequence_hash = hashlib.sha256(str(record.seq).encode("utf-8")).hexdigest()
-                if record.name in sequence_hash_by_name and sequence_hash_by_name.get(record.name) != sequence_hash:
-                    duplicate_strains.add(record.name)
+                if record.name in sequence_hash_by_name:
+                    # If the hashes differ (multiple entries with the same
+                    # strain name but different sequences), we keep the first
+                    # sequence and add the strain to a list of duplicates to
+                    # report at the end.
+                    if sequence_hash_by_name.get(record.name) != sequence_hash:
+                        duplicate_strains.add(record.name)
+
+                    # If the current strain has been seen before, don't write
+                    # out its sequence again.
                     continue
 
                 sequence_hash_by_name[record.name] = sequence_hash
@@ -36,8 +49,10 @@ if __name__ == '__main__':
 
     if len(duplicate_strains) > 0:
         print(
-            "WARNING: Detected the following duplicate input strains with different sequences:",
+            "ERROR: Detected the following duplicate input strains with different sequences:",
             file=sys.stderr
         )
         for strain in duplicate_strains:
             print(textwrap.indent(strain, "    "), file=sys.stderr)
+
+        sys.exit(1)


### PR DESCRIPTION
### Description of proposed changes

Instead of reading all sequences into memory to identify duplicates and then write out to disk, stream sequences from the multiple input files to disk and check for duplicates on the fly with a hash of the sequence content indexed by strain name. Hashes require far less memory than the actual sequences, so we are able to output a full list of duplicate sequences to stderr instead of the first duplicate.

Mismatched duplicates are treated as errors. All of such strains are reported at the end and an error is thrown.

### Related issue(s)  
Related to #571 (this commit content is copied from work done in that PR)

### Testing

```bash
# Combine and dedup the same file. This should write out a single copy of each strain sequence.
$ python3 scripts/combine-and-dedup-fastas.py \
  --input data/example_sequences_aus.fasta data/example_sequences_aus.fasta \
  --output test.fasta

# Confirm that both inputs and the output have the same number of records.
$ grep "^>" data/example_sequences_aus.fasta | wc -l
91
$ grep "^>" test.fasta | wc -l
91

# Make a modified copy of the original input sequences.
sed 's/AAGGNNNN/AAGGAAAA/' data/example_sequences_aus.fasta > example_sequences_aus_modified.fasta

# Combine and dedup the original and modified inputs.
# This should output the mismatches sequences and return a non-zero error code.
$ python3 scripts/combine-and-dedup-fastas.py \
  --input data/example_sequences_aus.fasta example_sequences_aus_modified.fasta \
  --output test.fasta
ERROR: Detected the following duplicate input strains with different sequences:
    Australia/VIC330/2020
    Australia/VIC969/2020
    Australia/VIC1045/2020
    Australia/VIC431/2020
    Australia/VIC329/2020
    Australia/VIC987/2020
    Australia/VIC05/2020
    Australia/VIC187/2020
    Australia/VIC970/2020
    Australia/VIC1120/2020
    Australia/VIC962/2020
    Australia/VIC1175/2020
$ echo $?
1
```