### PR TITLE
Use a Snakemake profile for Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - nextstrain update
 script:
   - gunzip data/example_sequences.fasta.gz
-  - nextstrain build . all_regions -j 2 --profile nextstrain_profiles/nextstrain --config sequences=data/example_sequences.fasta metadata=data/example_metadata.tsv active_builds=global inputs=
+  - nextstrain build . all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci

--- a/Snakefile
+++ b/Snakefile
@@ -37,7 +37,7 @@ configfile: "defaults/parameters.yaml"
 # Check config file for errors
 validate(config, schema="workflow/schemas/config.schema.yaml")
 # Convert inputs (YAML array) into an OrderedDict with keys of "name" for use by the pipeline. String values are ignored.
-if isinstance(config.get("inputs", ""), list):
+if isinstance(config.get("inputs"), list):
     config["inputs"] = OrderedDict((v["name"], v) for v in config["inputs"])
 
 # Check for overlapping subsampling schemes in user and default

--- a/nextstrain_profiles/nextstrain-ci/builds.yaml
+++ b/nextstrain_profiles/nextstrain-ci/builds.yaml
@@ -1,0 +1,8 @@
+# Only use one build for CI.
+active_builds: europe
+
+# Override full GISAID data with example data for a faster build.
+inputs:
+  - name: gisaid
+    metadata: "data/example_metadata.tsv"
+    sequences: "data/example_sequences.fasta"

--- a/nextstrain_profiles/nextstrain-ci/config.yaml
+++ b/nextstrain_profiles/nextstrain-ci/config.yaml
@@ -1,0 +1,4 @@
+configfile:
+  - defaults/parameters.yaml
+  - nextstrain_profiles/nextstrain/builds.yaml
+  - nextstrain_profiles/nextstrain-ci/builds.yaml

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -12,7 +12,6 @@ properties:
   inputs:
     type:
       - array
-      - string # string values will be ignored, but this can be useful for cmd-line overrides
     minItems: 1
     items:
       type: object


### PR DESCRIPTION
The current CI tests override the default Nextstrain data with the example data by passing arguments to the Snakemake config. However, we recently deprecated the top-level `sequences` and `metadata` keys and recent versions of Snakemake no longer allow empty values to be passed for config keys (e.g., `input=`), so whenever we upgrade Snakemake in the Nextstrain Docker image, the current CI tests would start to fail.

Since there is no interface in Snakemake to override nested config keys from the command line, this PR moves the logic to override sequence data into a Snakemake profile that inherits all of the other Nextstrain build settings. This PR also changes the test build from "global" to "europe" to make sure CI tests a path through proximity-based subsampling.