### PR TITLE
Benchmark all rules

### DIFF
--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -51,6 +51,8 @@ rule export_all_regions:
         metadata = [_get_metadata_by_build_name(build_name).format(build_name=build_name)
                     for build_name in BUILD_NAMES],
         colors = expand("results/{build_name}/colors.tsv", build_name=BUILD_NAMES),
+    benchmark:
+        "benchmarks/export_all_regions.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -76,6 +78,8 @@ rule mutation_summary:
         mutation_summary = "results/mutation_summary{origin}.tsv"
     log:
         "logs/mutation_summary{origin}.txt"
+    benchmark:
+        "benchmarks/mutation_summary{origin}.txt"
     params:
         outdir = "results/translations",
         basename = "seqs{origin}"
@@ -105,6 +109,8 @@ rule dated_json:
     output:
         dated_auspice_json = "auspice/ncov_{build_name}_{date}.json",
         dated_tip_frequencies_json = "auspice/ncov_{build_name}_{date}_tip-frequencies.json"
+    benchmark:
+        "benchmarks/dated_json_{build_name}_{date}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -138,6 +144,8 @@ rule deploy_to_staging:
     params:
         slack_message = f"Deployed <https://nextstrain.org/staging/ncov|nextstrain.org/staging/ncov> {deploy_origin}",
         s3_staging_url = config["s3_staging_url"]
+    benchmark:
+        "benchmarks/deploy_to_staging.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -169,6 +177,8 @@ rule upload:
         compression = config["S3_DST_COMPRESSION"]
     log:
         "logs/upload_gisaid.txt"
+    benchmark:
+        "benchmarks/upload_gisaid.txt"
     run:
         for fname in input:
             cmd = f"./scripts/upload-to-s3 {fname} s3://{params.s3_bucket}/{os.path.basename(fname)}.{params.compression} | tee -a {log}"

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -12,6 +12,8 @@ rule combine_input_metadata:
         origins = lambda wildcards: list(config["inputs"].keys())
     log:
         "logs/combine_input_metadata.txt"
+    benchmark:
+        "benchmarks/combine_input_metadata.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -102,6 +104,8 @@ rule diagnostic:
     params:
         mask_from_beginning = config["mask"]["mask_from_beginning"],
         mask_from_end = config["mask"]["mask_from_end"]
+    benchmark:
+        "benchmarks/diagnostics{origin}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -130,6 +134,8 @@ rule exclude_file:
         _collect_exclusion_files
     output:
         "results/exclude{origin}.txt"
+    benchmark:
+        "benchmarks/exclude_file{origin}.txt"
     shell:
         """
         cat {input} > {output}
@@ -149,6 +155,8 @@ rule mask:
         alignment = "results/masked{origin}.fasta"
     log:
         "logs/mask{origin}.txt"
+    benchmark:
+        "benchmarks/mask{origin}.txt"
     params:
         mask_from_beginning = config["mask"]["mask_from_beginning"],
         mask_from_end = config["mask"]["mask_from_end"],
@@ -183,6 +191,8 @@ rule filter:
         sequences = "results/filtered{origin}.fasta"
     log:
         "logs/filtered{origin}.txt"
+    benchmark:
+        "benchmarks/filter{origin}.txt"
     params:
         min_length = lambda wildcards: _get_filter_value(wildcards, "min_length"),
         exclude_where = lambda wildcards: _get_filter_value(wildcards, "exclude_where"),
@@ -305,6 +315,8 @@ rule combine_sequences_for_subsampling:
         lambda w: [_get_path_for_input("filtered", f"_{origin}") for origin in config.get("inputs", {})]
     output:
         "results/combined_sequences_for_subsampling.fasta"
+    benchmark:
+        "benchmarks/combine_sequences_for_subsampling.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -359,6 +371,8 @@ rule subsample:
         sequences = "results/{build_name}/sample-{subsample}.fasta"
     log:
         "logs/subsample_{build_name}_{subsample}.txt"
+    benchmark:
+        "benchmarks/subsample_{build_name}_{subsample}.txt"
     params:
         group_by = _get_specific_subsampling_setting("group_by", optional=True),
         sequences_per_group = _get_specific_subsampling_setting("seq_per_group", optional=True),
@@ -432,6 +446,8 @@ rule priority_score:
         sequence_index = rules.index_sequences.output.sequence_index,
     output:
         priorities = "results/{build_name}/priorities_{focus}.tsv"
+    benchmark:
+        "benchmarks/priority_score_{build_name}_{focus}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -461,6 +477,8 @@ rule combine_samples:
         sequences = "results/{build_name}/subsampled_sequences.fasta"
     log:
         "logs/subsample_regions_{build_name}.txt"
+    benchmark:
+        "benchmarks/subsample_regions_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -553,6 +571,8 @@ rule adjust_metadata_regions:
         region = lambda wildcards: config["builds"][wildcards.build_name]["region"]
     log:
         "logs/adjust_metadata_regions_{build_name}.txt"
+    benchmark:
+        "benchmarks/adjust_metadata_regions_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -660,6 +680,8 @@ rule ancestral:
         node_data = "results/{build_name}/nt_muts.json"
     log:
         "logs/ancestral_{build_name}.txt"
+    benchmark:
+        "benchmarks/ancestral_{build_name}.txt"
     params:
         inference = config["ancestral"]["inference"]
     resources:
@@ -683,6 +705,8 @@ rule haplotype_status:
         node_data = "results/{build_name}/haplotype_status.json"
     log:
         "logs/haplotype_status_{build_name}.txt"
+    benchmark:
+        "benchmarks/haplotype_status_{build_name}.txt"
     params:
         reference_node_name = config["reference_node_name"]
     conda: config["conda_environment"]
@@ -704,6 +728,8 @@ rule translate:
         node_data = "results/{build_name}/aa_muts.json"
     log:
         "logs/translate_{build_name}.txt"
+    benchmark:
+        "benchmarks/translate_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -725,6 +751,8 @@ rule aa_muts_explicit:
         genes = config.get('genes', 'S')
     log:
         "logs/aamuts_{build_name}.txt"
+    benchmark:
+        "benchmarks/aamuts_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -748,6 +776,8 @@ rule traits:
         node_data = "results/{build_name}/traits.json"
     log:
         "logs/traits_{build_name}.txt"
+    benchmark:
+        "benchmarks/traits_{build_name}.txt"
     params:
         columns = _get_trait_columns_by_wildcards,
         sampling_bias_correction = _get_sampling_bias_correction_for_wildcards
@@ -774,6 +804,8 @@ rule clade_files:
         clade_files = _get_clade_files
     output:
         "results/{build_name}/clades.tsv"
+    benchmark:
+        "benchmarks/clade_files_{build_name}.txt"
     shell:
         '''
         cat {input.clade_files} > {output}
@@ -790,6 +822,8 @@ rule clades:
         clade_data = "results/{build_name}/clades.json"
     log:
         "logs/clades_{build_name}.txt"
+    benchmark:
+        "benchmarks/clades_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -813,6 +847,8 @@ rule subclades:
         clade_file = "results/{build_name}/temp_subclades.tsv"
     log:
         "logs/subclades_{build_name}.txt"
+    benchmark:
+        "benchmarks/subclades_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -828,6 +864,8 @@ rule rename_subclades:
         node_data = rules.subclades.output.clade_data
     output:
         clade_data = "results/{build_name}/subclades.json"
+    benchmark:
+        "benchmarks/rename_subclades_{build_name}.txt"
     run:
         import json
         with open(input.node_data, 'r', encoding='utf-8') as fh:
@@ -850,6 +888,8 @@ rule colors:
         colors = "results/{build_name}/colors.tsv"
     log:
         "logs/colors_{build_name}.txt"
+    benchmark:
+        "benchmarks/colors_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -868,6 +908,8 @@ rule recency:
         node_data = "results/{build_name}/recency.json"
     log:
         "logs/recency_{build_name}.txt"
+    benchmark:
+        "benchmarks/recency_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -885,6 +927,8 @@ rule tip_frequencies:
         tip_frequencies_json = "results/{build_name}/tip-frequencies.json"
     log:
         "logs/tip_frequencies_{build_name}.txt"
+    benchmark:
+        "benchmarks/tip_frequencies_{build_name}.txt"
     params:
         min_date = config["frequencies"]["min_date"],
         max_date = _get_max_date_for_frequencies,
@@ -917,6 +961,8 @@ rule nucleotide_mutation_frequencies:
         frequencies = "results/{build_name}/nucleotide_mutation_frequencies.json"
     log:
         "logs/nucleotide_mutation_frequencies_{build_name}.txt"
+    benchmark:
+        "benchmarks/nucleotide_mutation_frequencies_{build_name}.txt"
     params:
         min_date = config["frequencies"]["min_date"],
         minimal_frequency = config["frequencies"]["minimal_frequency"],
@@ -995,6 +1041,8 @@ rule export:
         root_sequence_json = "results/{build_name}/ncov_with_accessions_root-sequence.json"
     log:
         "logs/export_{build_name}.txt"
+    benchmark:
+        "benchmarks/export_{build_name}.txt"
     params:
         title = export_title
     conda: config["conda_environment"]
@@ -1027,6 +1075,8 @@ rule incorporate_travel_history:
         auspice_json = "results/{build_name}/ncov_with_accessions_and_travel_branches.json"
     log:
         "logs/incorporate_travel_history_{build_name}.txt"
+    benchmark:
+        "benchmarks/incorporate_travel_history_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """
@@ -1051,6 +1101,8 @@ rule finalize:
         root_sequence_json = "auspice/ncov_{build_name}_root-sequence.json"
     log:
         "logs/fix_colorings_{build_name}.txt"
+    benchmark:
+        "benchmarks/fix_colorings_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         """


### PR DESCRIPTION
Adds benchmark directives to all rules in the workflow, to help us better understand where the workflow is spending the most time and memory. Since memory is not currently logged by the `--stats` output, we need this additional level of metadata for the workflow.

Note that benchmarks do not report memory on OS X (at least on older Macs), so this information will come solely from Linux-based systems like AWS Batch runs, etc.

Related to #576