### PR TITLE
Specify memory requirements for most rules

### DIFF
--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -53,6 +53,11 @@ rule export_all_regions:
         colors = expand("results/{build_name}/colors.tsv", build_name=BUILD_NAMES),
     benchmark:
         "benchmarks/export_all_regions.txt"
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        # Compared to other rules, this rule loads metadata as a pandas
+        # DataFrame instead of a dictionary, so it uses much less memory.
+        mem_mb=lambda wildcards, input: 5 * int(input.metadata.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -46,7 +46,7 @@ if "use_nextalign" in config and config["use_nextalign"]:
         conda: config["conda_environment"]
         threads: 8
         resources:
-            mem_mb = 3000
+            mem_mb=3000
         shell:
             """
             nextalign \
@@ -106,6 +106,9 @@ rule diagnostic:
         mask_from_end = config["mask"]["mask_from_end"]
     benchmark:
         "benchmarks/diagnostics{origin}.txt"
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        mem_mb=lambda wildcards, input: 15 * int(input.metadata.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -199,6 +202,9 @@ rule filter:
         min_date = lambda wildcards: _get_filter_value(wildcards, "min_date"),
         ambiguous = lambda wildcards: f"--exclude-ambiguous-dates-by {_get_filter_value(wildcards, 'exclude_ambiguous_dates_by')}" if _get_filter_value(wildcards, "exclude_ambiguous_dates_by") else "",
         date = (date.today() + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        mem_mb=lambda wildcards, input: 15 * int(input.metadata.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -385,6 +391,9 @@ rule subsample:
         min_date = _get_specific_subsampling_setting("min_date", optional=True),
         max_date = _get_specific_subsampling_setting("max_date", optional=True),
         priority_argument = get_priority_argument
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        mem_mb=lambda wildcards, input: 15 * int(input.metadata.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -428,7 +437,7 @@ rule proximity_score:
         chunk_size=10000
     resources:
         # Memory scales at ~0.15 MB * chunk_size (e.g., 0.15 MB * 10000 = 1.5GB).
-        mem_mb = 4000
+        mem_mb=4000
     conda: config["conda_environment"]
     shell:
         """
@@ -513,7 +522,7 @@ if "use_nextalign" in config and config["use_nextalign"]:
         conda: config["conda_environment"]
         threads: 8
         resources:
-            mem_mb = 3000
+            mem_mb=3000
         shell:
             """
             nextalign \
@@ -685,7 +694,10 @@ rule ancestral:
     params:
         inference = config["ancestral"]["inference"]
     resources:
-        mem_mb = 4000
+        # Multiple sequence alignments can use up to 15 times their disk size in
+        # memory.
+        # Note that Snakemake >5.10.0 supports input.size_mb to avoid converting from bytes to MB.
+        mem_mb=lambda wildcards, input: 15 * int(input.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -730,6 +742,9 @@ rule translate:
         "logs/translate_{build_name}.txt"
     benchmark:
         "benchmarks/translate_{build_name}.txt"
+    resources:
+        # Memory use scales primarily with size of the node data.
+        mem_mb=lambda wildcards, input: 3 * int(input.node_data.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -753,6 +768,11 @@ rule aa_muts_explicit:
         "logs/aamuts_{build_name}.txt"
     benchmark:
         "benchmarks/aamuts_{build_name}.txt"
+    resources:
+        # Multiple sequence alignments can use up to 15 times their disk size in
+        # memory.
+        # Note that Snakemake >5.10.0 supports input.size_mb to avoid converting from bytes to MB.
+        mem_mb=lambda wildcards, input: 15 * int(input.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -781,6 +801,9 @@ rule traits:
     params:
         columns = _get_trait_columns_by_wildcards,
         sampling_bias_correction = _get_sampling_bias_correction_for_wildcards
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        mem_mb=lambda wildcards, input: 15 * int(input.metadata.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -824,6 +847,9 @@ rule clades:
         "logs/clades_{build_name}.txt"
     benchmark:
         "benchmarks/clades_{build_name}.txt"
+    resources:
+        # Memory use scales primarily with size of the node data.
+        mem_mb=lambda wildcards, input: 3 * int(input.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -849,6 +875,9 @@ rule subclades:
         "logs/subclades_{build_name}.txt"
     benchmark:
         "benchmarks/subclades_{build_name}.txt"
+    resources:
+        # Memory use scales primarily with size of the node data.
+        mem_mb=lambda wildcards, input: 3 * int(input.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -890,6 +919,11 @@ rule colors:
         "logs/colors_{build_name}.txt"
     benchmark:
         "benchmarks/colors_{build_name}.txt"
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        # Compared to other rules, this rule loads metadata as a pandas
+        # DataFrame instead of a dictionary, so it uses much less memory.
+        mem_mb=lambda wildcards, input: 5 * int(input.metadata.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -910,6 +944,9 @@ rule recency:
         "logs/recency_{build_name}.txt"
     benchmark:
         "benchmarks/recency_{build_name}.txt"
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        mem_mb=lambda wildcards, input: 15 * int(input.metadata.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -936,6 +973,9 @@ rule tip_frequencies:
         pivot_interval_units = config["frequencies"]["pivot_interval_units"],
         narrow_bandwidth = config["frequencies"]["narrow_bandwidth"],
         proportion_wide = config["frequencies"]["proportion_wide"]
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        mem_mb=lambda wildcards, input: 15 * int(input.metadata.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -969,6 +1009,9 @@ rule nucleotide_mutation_frequencies:
         pivot_interval = config["frequencies"]["pivot_interval"],
         stiffness = config["frequencies"]["stiffness"],
         inertia = config["frequencies"]["inertia"]
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        mem_mb=lambda wildcards, input: 15 * int(input.metadata.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """
@@ -1045,6 +1088,9 @@ rule export:
         "benchmarks/export_{build_name}.txt"
     params:
         title = export_title
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        mem_mb=lambda wildcards, input: 15 * int(input.metadata.size / 1024 / 1024)
     conda: config["conda_environment"]
     shell:
         """


### PR DESCRIPTION
### Description of proposed changes    

Adds `mem_mb` resource requirements for high-memory rules [based on benchmarks from a full Nextstrain build](https://gist.github.com/huddlej/020afba80fa4965e3d4d9d89234b6949) and corresponding input file sizes. The most common source of moderate memory usage is loading metadata in augur (or other scripts) as a dictionary with augur's `read_metadata` function. The most common source of high memory usage is loading multiple sequence alignments as in the
`refine` and `ancestral` rules.

Multipliers for memory usage based on input file sizes are conservative, erring on the side of requesting more memory than less to avoid hard memory limits that can kill jobs. For example, at the time the main metadata file for Nextstrain builds uses 165 MB on disk and ~2200 MB in memory (as a Python dictionary), so the multipler used for rules that load metadata is 15.

Interestingly, scripts that load metadata into a pandas DataFrame use 25% of the memory (~500 MB) than scripts (or augur commands) that load metadata into a dictionary (~2 GB). Future work on the metadata infrastructure should consider using pandas exclusively and take advantage of [pandas' tools to reduce memory usage](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.memory_usage.html) by storing some column values as categorical (essentially enum) values instead of as distinct objects.

### Related issue(s)  

Related to #576

### Testing

Tested with a full Nextstrain build for Europe on a SLURM cluster with:

```bash
snakemake \
  all_regions
  --conda-frontend mamba \
  --profile nextstrain_profiles/nextstrain-rhino/ \
  --config active_builds=europe
```