### PR TITLE
Gap aware mutation counts

### DIFF
--- a/scripts/mutation_counts.py
+++ b/scripts/mutation_counts.py
@@ -18,14 +18,23 @@ if __name__ == '__main__':
     parser.add_argument('--output', type=str, required=True, help="output json file")
     args = parser.parse_args()
 
+    if type(args.map)==str:
+        args.map = [args.map]
+
+    if type(args.attribute_name)==str:
+        args.attribute_name = [args.attribute_name]
+    
     node_data = {}
 
     T = Phylo.read(args.tree, 'newick')
     aln = {s.name:str(s.seq) for s in SeqIO.parse(args.alignment, 'fasta')}
     root = aln[T.root.name]
 
-    for map, attibute in zip(args.map, args.attribute_name):
-        weights = {int(k)-1:v for k,v in d["map"].items()}
+    for map_file, attribute in zip(args.map, args.attribute_name):
+        with open(map_file) as fh:
+            map = json.load(fh)
+
+        weights = {int(k)-1:v for k,v in map["map"][args.gene_names[0]].items()}
         default = map['default']
         for n in T.find_clades():
             if n.name not in node_data: node_data[n.name] = {}
@@ -40,7 +49,7 @@ if __name__ == '__main__':
                     distance+=weights.get(p, default)
 
                 gap_extend= d=='-'
-            node_data[n.name][f"attribute"] = distance
+            node_data[n.name][f"{attribute}"] = distance
 
     with open(args.output, 'w') as fh:
         json.dump({"nodes":node_data}, fh)

--- a/scripts/mutation_counts.py
+++ b/scripts/mutation_counts.py
@@ -1,32 +1,46 @@
 import argparse, json
-from Bio import Phylo
+from Bio import Phylo, SeqIO
 import pandas as pd
+import numpy as np
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description="transform nextalign output to sparse format",
+        description="count distances based on distance maps with counting gaps as one event",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
     parser.add_argument('--tree', type=str, required=True, help="tree file")
-    parser.add_argument('--mutation-summary')
-    parser.add_argument('--genes', nargs='+')
+    parser.add_argument('--alignment', type=str)
+    parser.add_argument('--gene-names', nargs='+')
+    parser.add_argument('--compare-to', nargs='+')
+    parser.add_argument('--map', nargs='+')
+    parser.add_argument('--attribute-name', nargs='+')
     parser.add_argument('--output', type=str, required=True, help="output json file")
     args = parser.parse_args()
 
-    mutations = pd.read_csv(args.mutation_summary, sep='\t', index_col=0).fillna('')
+    node_data = {}
 
-    d = {}
     T = Phylo.read(args.tree, 'newick')
-    for n in T.get_terminals():
-        d[n.name] = {}
-        try:
-            m = mutations.loc[n.name]
-        except:
-            print(f"no data found for {n.name}")
-            continue
-        for gene in args.genes:
-            d[n.name][f"{gene}_mutation_count"] = len([x for x in m[gene].split(',') if x and x[-1]!='-'])
+    aln = {s.name:str(s.seq) for s in SeqIO.parse(args.alignment, 'fasta')}
+    root = aln[T.root.name]
+
+    for map, attibute in zip(args.map, args.attribute_name):
+        weights = {int(k)-1:v for k,v in d["map"].items()}
+        default = map['default']
+        for n in T.find_clades():
+            if n.name not in node_data: node_data[n.name] = {}
+            distance = 0
+            gap_extend=False
+            if n.name not in aln:
+                print(f"{n.name} not found in alignment")
+                continue
+
+            for p, (a,d) in enumerate(zip(root, aln[n.name])):
+                if a!=d and (not gap_extend):
+                    distance+=weights.get(p, default)
+
+                gap_extend= d=='-'
+            node_data[n.name][f"attribute"] = distance
 
     with open(args.output, 'w') as fh:
-        json.dump({"nodes":d}, fh)
+        json.dump({"nodes":node_data}, fh)

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -804,7 +804,7 @@ if "use_nextalign" in config and config["use_nextalign"]:
             node_data = "results/{build_name}/distances.json"
         shell:
             """
-            augur distance \
+            python scripts/mutation_counts.py
                 --tree {input.tree} \
                 --alignment {input.alignments} \
                 --gene-names {params.genes} \

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -804,7 +804,7 @@ if "use_nextalign" in config and config["use_nextalign"]:
             node_data = "results/{build_name}/distances.json"
         shell:
             """
-            python scripts/mutation_counts.py
+            python scripts/mutation_counts.py \
                 --tree {input.tree} \
                 --alignment {input.alignments} \
                 --gene-names {params.genes} \


### PR DESCRIPTION
this PR temporarily replaces augur distance by a custom distance calculation to avoid the overcounting of long gaps:

instead of
https://nextstrain.org/staging/ncov/scounts/global?c=S1_mutations

this now looks like this:
https://nextstrain.org/staging/ncov/scounts2/global?c=S1_mutations