### PR TITLE
Add the new `data_provenance` field to Nextstrain's auspice JSONs

### DIFF
--- a/nextstrain_profiles/nextstrain/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/africa_auspice_config.json
@@ -4,6 +4,11 @@
   "maintainers": [
     {"name": "the Nextstrain team", "url": "https://nextstrain.org/"}
   ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
   "colorings": [
     {
       "key": "subclade_membership",

--- a/nextstrain_profiles/nextstrain/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/asia_auspice_config.json
@@ -4,6 +4,11 @@
   "maintainers": [
     {"name": "the Nextstrain team", "url": "https://nextstrain.org/"}
   ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
   "colorings": [
     {
       "key": "subclade_membership",

--- a/nextstrain_profiles/nextstrain/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/europe_auspice_config.json
@@ -4,6 +4,11 @@
   "maintainers": [
     {"name": "the Nextstrain team", "url": "https://nextstrain.org/"}
   ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
   "colorings": [
     {
       "key": "subclade_membership",

--- a/nextstrain_profiles/nextstrain/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/global_auspice_config.json
@@ -4,6 +4,11 @@
   "maintainers": [
     {"name": "the Nextstrain team", "url": "https://nextstrain.org/"}
   ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
   "colorings": [
     {
       "key": "subclade_membership",

--- a/nextstrain_profiles/nextstrain/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/north-america_auspice_config.json
@@ -4,6 +4,11 @@
   "maintainers": [
     {"name": "the Nextstrain team", "url": "https://nextstrain.org/"}
   ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
   "colorings": [
     {
       "key": "subclade_membership",

--- a/nextstrain_profiles/nextstrain/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/oceania_auspice_config.json
@@ -4,6 +4,11 @@
   "maintainers": [
     {"name": "the Nextstrain team", "url": "https://nextstrain.org/"}
   ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
   "colorings": [
    {
       "key": "subclade_membership",

--- a/nextstrain_profiles/nextstrain/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/south-america_auspice_config.json
@@ -4,6 +4,11 @@
   "maintainers": [
     {"name": "the Nextstrain team", "url": "https://nextstrain.org/"}
   ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
   "colorings": [
    {
       "key": "subclade_membership",

--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -19,6 +19,6 @@ dependencies:
   - pip
   - pip:
       - awscli==1.18.45
-      - nextstrain-augur==11.1.2
+      - nextstrain-augur==11.3.0
       - nextstrain-cli==1.16.5
       - rethinkdb==2.3.0.post6


### PR DESCRIPTION
### Description of proposed changes    

Adds the `data_provenance` field to Nextstrain's auspice config JSONs and updates the minimum Augur version to 11.3.0 that adds support for this new field to the auspice schema. This new field is not consumed by Auspice yet, but it will be used by our builds and others to explicitly display the data sources that enabled these builds.

### Related issue(s)  

Related to https://github.com/nextstrain/augur/issues/691

### Testing

Tested with the CI profile and the Conda environment but with all builds (global + regional) instead of just the European build.
CI on GitHub will test with [the Docker image using Augur 11.3.0](https://travis-ci.com/github/nextstrain/docker-base/builds/220659617).