### PR TITLE
Enable workflows based on curated global context sequences

### DIFF
--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -3,6 +3,13 @@
 As of April 2021, we use major version numbers (e.g. v2) to reflect backward incompatible changes to the workflow that likely require you to update your Nextstrain installation.
 We also use this change log to document new features that maintain backward compatibility, indicating these features by the date they were added.
 
+## v3 (12 April 2021)
+
+  - Use Augur 11.2.0's metadata-only output arguments to aggregate subsampled sequences and metadata [#592][]
+  - Use Augur 11.3.0's `io.py` module to combine and deduplicate uncompressed or compressed sequences when handling multiple input datasets [#592][]
+
+[#592]: https://github.com/nextstrain/ncov/pull/592
+
 ## v2 (9 April 2021)
 
 This release reflects the state of the workflow when we instituted our workflow versioning system.

--- a/my_profiles/example_global_context/builds.yaml
+++ b/my_profiles/example_global_context/builds.yaml
@@ -1,0 +1,52 @@
+
+## This YAML file is sparsely commented, with a focus on the parts relevant to multiple inputs
+## See my_profiles/example/builds.yaml for more general comments
+## See docs/multiple_inputs.md for a walkthrough of this config.
+
+# custom_rules:
+#   - my_profiles/example_multiple_inputs/rules.smk
+
+use_nextalign: true
+
+inputs:
+  - name: aus
+    metadata: "data/example_metadata_aus.tsv"
+    sequences: "data/example_sequences_aus.fasta"
+  - name: global
+    metadata: "data/global_subsampled_metadata.tsv.gz"
+    filtered: "data/global_subsampled_sequences.fasta.gz"
+    # TODO: ideally, we could support something like the following, to inject
+    # a collection of contextual sequences into the analysis after all other
+    # subsampling.
+    # subsampled: "data/global_subsampled_sequences.fasta.gz"
+
+builds:
+  global-context:
+    subsampling_scheme: custom-scheme # use a custom subsampling scheme defined below
+
+# STAGE 1: Input-specific filtering parameters
+filter:
+  aus:
+    min_length: 5000 # Allow shorter genomes. Parameter used to filter alignment.
+    skip_diagnostics: True # skip diagnostics (which can remove genomes) for this input
+
+# STAGE 2: Subsampling parameters
+subsampling:
+  custom-scheme:
+    # Use metadata key to include ALL from `input1`
+    australian_focus:
+      exclude: "--exclude-where 'aus!=yes'" # subset to sequences from input `aus`
+    # Include all global contextual sequences without subsampling.
+    global_context:
+      exclude: "--exclude-where 'aus=yes'" # i.e. subset to sequences _not_ from input `aus`
+
+files:
+  auspice_config: "my_profiles/example_global_context/my_auspice_config.json"
+  description: "my_profiles/example_global_context/my_description.md"
+
+skip_travel_history_adjustment: True
+
+traits:
+  global-context:
+    sampling_bias_correction: 2.5
+    columns: ["country"]

--- a/my_profiles/example_global_context/builds.yaml
+++ b/my_profiles/example_global_context/builds.yaml
@@ -9,9 +9,9 @@
 use_nextalign: true
 
 inputs:
-  - name: aus
-    metadata: "data/example_metadata_aus.tsv"
-    sequences: "data/example_sequences_aus.fasta"
+  - name: local
+    metadata: "data/example_metadata.tsv"
+    sequences: "data/example_sequences.fasta"
   - name: global
     # Define local paths to a pre-filtered global context.
     metadata: "data/global_subsampled_metadata.tsv.gz"

--- a/my_profiles/example_global_context/builds.yaml
+++ b/my_profiles/example_global_context/builds.yaml
@@ -13,8 +13,12 @@ inputs:
     metadata: "data/example_metadata_aus.tsv"
     sequences: "data/example_sequences_aus.fasta"
   - name: global
+    # Define local paths to a pre-filtered global context.
     metadata: "data/global_subsampled_metadata.tsv.gz"
     filtered: "data/global_subsampled_sequences.fasta.gz"
+    # Paths to files on S3 also work. For example:
+    #metadata: "s3://nextstrain-ncov-private/global_subsampled_metadata.tsv.xz"
+    #filtered: "s3://nextstrain-ncov-private/global_subsampled_sequences.fasta.xz"
     # TODO: ideally, we could support something like the following, to inject
     # a collection of contextual sequences into the analysis after all other
     # subsampling.

--- a/my_profiles/example_global_context/config.yaml
+++ b/my_profiles/example_global_context/config.yaml
@@ -1,0 +1,20 @@
+#####################################################################################
+#### NOTE: head over to `builds.yaml` to define what builds you'd like to run. ####
+#### (i.e., datasets and subsampling schemas)  ####
+#####################################################################################
+
+# This analysis-specific config file overrides the settings in the default config file.
+# If a parameter is not defined here, it will fall back to the default value.
+
+configfile:
+  - defaults/parameters.yaml # Pull in the default values
+  - my_profiles/example_global_context/builds.yaml # Pull in our list of desired builds
+
+# Set the maximum number of cores you want Snakemake to use for this pipeline.
+cores: 2
+
+# Always print the commands that will be run to the screen for debugging.
+printshellcmds: True
+
+# Print log files of failed jobs
+show-failed-logs: True

--- a/my_profiles/example_global_context/my_auspice_config.json
+++ b/my_profiles/example_global_context/my_auspice_config.json
@@ -1,0 +1,113 @@
+{
+  "title": "Example of a build generated using multiple inputs",
+  "build_url": "https://github.com/nextstrain/ncov",
+  "maintainers": [
+    {"name": "James Hadfield", "url": "https://bedford.io/people/jameshadfield"}
+  ],
+  "colorings": [
+    {
+      "key": "aus",
+      "title": "Source: Australia",
+      "type": "boolean"
+    },
+    {
+      "key": "division",
+      "title": "Admin Division",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "host",
+      "title": "Host",
+      "type": "categorical"
+    },
+    {
+      "key": "age",
+      "title": "Age",
+      "type": "continuous"
+    },
+    {
+      "key": "sex",
+      "title": "Sex",
+      "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Authors",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission Date",
+      "type": "categorical"
+    },
+    {
+      "key": "gisaid_epi_isl",
+      "type": "categorical"
+    },
+    {
+      "key": "genbank_accession",
+      "type": "categorical"
+    },
+    {
+      "key": "country_exposure",
+      "title": "Country of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "division_exposure",
+      "title": "Division of exposure",
+      "type": "categorical"
+    },
+    {
+      "key": "region_exposure",
+      "title": "Region of exposure",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "division",
+    "country",
+    "region"
+  ],
+  "display_defaults": {
+    "color_by": "aus",
+    "distance_measure": "num_date",
+    "geo_resolution": "country",
+    "map_triplicate": false,
+    "branch_label": "none"
+  },
+  "filters": [
+    "recency",
+    "aus",
+    "division",
+    "country",
+    "region",
+    "host",
+    "author"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy"
+  ]
+}

--- a/my_profiles/example_global_context/my_description.md
+++ b/my_profiles/example_global_context/my_description.md
@@ -1,0 +1,1 @@
+This is the description that appears below your visualization in Auspice. Edit me in `my_profiles/example_global_context/description.md`.

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -79,7 +79,12 @@ def _get_path_for_input(stage, origin_wildcard):
     if stage=="masked":
         return f"results/precomputed-masked{origin_wildcard}.fasta" if remote else f"results/masked{origin_wildcard}.fasta"
     if stage=="filtered":
-        return f"results/precomputed-filtered{origin_wildcard}.fasta" if remote else f"results/filtered{origin_wildcard}.fasta"
+        if remote:
+            return f"results/precomputed-filtered{origin_wildcard}.fasta"
+        elif path_or_url:
+            return path_or_url
+        else:
+            return f"results/filtered{origin_wildcard}.fasta"
 
     raise Exception(f"_get_path_for_input with unknown stage \"{stage}\"")
 

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -176,7 +176,9 @@ rule upload:
         expand("results/to-exclude_{origin}.txt", origin=config["S3_DST_ORIGINS"]),             # from `rule diagnostic`
         expand("results/masked_{origin}.fasta", origin=config["S3_DST_ORIGINS"]),               # from `rule mask`
         expand("results/filtered_{origin}.fasta", origin=config["S3_DST_ORIGINS"]),             # from `rule filter`
-        expand("results/mutation_summary_{origin}.tsv", origin=config["S3_DST_ORIGINS"]),       # from `rule mutation_summary`
+        expand("results/mutation_summary_{origin}.tsv", origin=config["S3_DST_ORIGINS"]),       # from `rule mutation_summary
+        "results/global/global_subsampled_sequences.fasta",
+        "results/global/global_subsampled_metadata.tsv"
     params:
         s3_bucket = config["S3_DST_BUCKET"],
         compression = config["S3_DST_COMPRESSION"]

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -374,7 +374,8 @@ rule subsample:
         priorities = get_priorities,
         exclude = config["files"]["exclude"]
     output:
-        sequences = "results/{build_name}/sample-{subsample}.fasta"
+        sequences = "results/{build_name}/sample-{subsample}.fasta",
+        strains="results/{build_name}/sample-{subsample}.txt",
     log:
         "logs/subsample_{build_name}_{subsample}.txt"
     benchmark:
@@ -414,7 +415,8 @@ rule subsample:
             {params.sequences_per_group} \
             {params.subsample_max_sequences} \
             {params.sampling_scheme} \
-            --output {output.sequences} 2>&1 | tee {log}
+            --output {output.sequences} \
+            --output-strains {output.strains} 2>&1 | tee {log}
         """
 
 rule proximity_score:
@@ -473,7 +475,7 @@ def _get_subsampled_files(wildcards):
     subsampling_settings = _get_subsampling_settings(wildcards)
 
     return [
-        f"results/{wildcards.build_name}/sample-{subsample}.fasta"
+        f"results/{wildcards.build_name}/sample-{subsample}.txt"
         for subsample in subsampling_settings
     ]
 
@@ -483,9 +485,13 @@ rule combine_samples:
         Combine and deduplicate FASTAs
         """
     input:
-        _get_subsampled_files
+        sequences=_get_unified_alignment,
+        sequence_index=rules.index_sequences.output.sequence_index,
+        metadata=_get_unified_metadata,
+        include=_get_subsampled_files,
     output:
-        sequences = "results/{build_name}/subsampled_sequences.fasta"
+        sequences = "results/{build_name}/{build_name}_subsampled_sequences.fasta",
+        metadata = "results/{build_name}/{build_name}_subsampled_metadata.tsv"
     log:
         "logs/subsample_regions_{build_name}.txt"
     benchmark:
@@ -493,9 +499,14 @@ rule combine_samples:
     conda: config["conda_environment"]
     shell:
         """
-        python3 scripts/combine-and-dedup-fastas.py \
-            --input {input} \
-            --output {output} 2>&1 | tee {log}
+        augur filter \
+            --sequences {input.sequences} \
+            --sequence-index {input.sequence_index} \
+            --metadata {input.metadata} \
+            --exclude-all \
+            --include {input.include} \
+            --output-sequences {output.sequences} \
+            --output-metadata {output.metadata} 2>&1 | tee {log}
         """
 
 if "use_nextalign" in config and config["use_nextalign"]:


### PR DESCRIPTION
### Description of proposed changes

This PR proposes the following two changes to the ncov workflow to address the issue of how to start a custom SARS-CoV-2 analysis without starting from the full GISAID database of >800,000 sequences.

#### Prepare global context sequences for upload to S3

During the course of standard Nextstrain builds, output a list of strains for each subsampling job and use these lists to aggregate the final FASTA file of subsampled sequences while also exporting a metadata file for those sequences. Then, add the Nextstrain global build's subsampled sequences to the list of files to upload to S3. With the sequences and metadata available on S3, our team can start to use these as a global context for our own bespoke analyses.

We include the build name in the subsampled sequence/metadata outputs to distinguish these data from other data in the current flat S3 bucket naming approach (e.g., `global_subsampled_sequences.fasta` is clearer than `subsampled_sequences.fasta`).

#### Add support for workflows starting with curated contextual inputs

Modifies the path-or-URL logic for multiple inputs so users can start from a local "filtered" input file (e.g., one downloaded from GISAID instead of a remote file on S3) that represents a set of contextual sequences to use for a new analysis. Adds an example profile, `example_global_context`, with a build that contextualizes the example Australian samples with a curated global subsampled set. The new build's inputs look like this:

```yaml
inputs:
  - name: aus
    metadata: "data/example_metadata_aus.tsv"
    sequences: "data/example_sequences_aus.fasta"
  - name: global
    metadata: "data/global_subsampled_metadata.tsv.gz"
    filtered: "data/global_subsampled_sequences.fasta.gz"
```

Assuming that the curated inputs will be compressed when downloaded by the user, this PR also enables reading compressed sequences when combining and deduplicating multiple inputs.

A potentially useful alternative to the approach above would allow users to inject their global context sequences into the workflow _after_ all other subsampling (at the `combine_samples` step) to avoid combining and de-duping, realigning, etc. This functionality could be supported with another input keyword like `subsampled` like so:

```yaml
inputs:
  - name: aus
    metadata: "data/example_metadata_aus.tsv"
    sequences: "data/example_sequences_aus.fasta"
  - name: global
    metadata: "data/global_subsampled_metadata.tsv.gz"
    subsampled: "data/global_subsampled_sequences.fasta.gz"
```

### Testing

As a sanity check, I first prepared contextual sequences locally with the CI build using the following command:

```bash
snakemake \
  results/global/global_subsampled_sequences.fasta \
  results/global/global_subsampled_metadata.tsv \
  -j 4 \
  --profile nextstrain_profiles/nextstrain-ci/
```

Then, I prepared contextual sequences with full Nextstrain global build on the cluster with:

```bash
snakemake \
  results/global/global_subsampled_sequences.fasta \
  results/global/global_subsampled_metadata.tsv \
  -j 4 \
  --profile nextstrain_profiles/nextstrain/ \
  --config active_builds=global
```

Next, I compressed the global subsampled sequences and metadata from the full global build with gzip and copied these into my `data` directory on my local system (as `data/global_subsampled_sequences.fasta.gz` and `data/global_subsampled_metadata.tsv.gz`). Normally, these files would be automatically uploaded to our S3 bucket by the standard Nextstrain `upload` rule.

I ran the `example_global_context` build locally with these local curated contextual sequences.

```bash
snakemake -j 4 -p --profile my_profiles/example_global_context/
```

Finally, I uploaded the compressed global context files to the Nextstrain S3 bucket and updated the `example_global_context` build's inputs to look like:

```yaml
inputs:
  - name: aus
    metadata: "data/example_metadata_aus.tsv"
    sequences: "data/example_sequences_aus.fasta"
  - name: global
    metadata: "s3://nextstrain-ncov-private/global_subsampled_metadata.tsv.gz"
    filtered: "s3://nextstrain-ncov-private/global_subsampled_sequences.fasta.gz"
```

Then, I ran this example workflow again with the S3 inputs:

```bash
snakemake --forceall -j 4 -p --profile my_profiles/example_global_context/
```