### PR TITLE
Fix proximity

### DIFF
--- a/nextstrain_profiles/nextstrain-ci/builds.yaml
+++ b/nextstrain_profiles/nextstrain-ci/builds.yaml
@@ -6,3 +6,29 @@ inputs:
   - name: gisaid
     metadata: "data/example_metadata.tsv"
     sequences: "data/example_sequences.fasta"
+
+builds:
+  # Override the default Nextstrain European build's subsampling scheme for more
+  # stable subsampling of a fixed dataset in continuous integration tests.
+  europe:
+    subsampling_scheme: nextstrain_ci_sampling
+    region: Europe
+
+subsampling:
+  # Custom subsampling logic for CI tests.
+  nextstrain_ci_sampling:
+    # Focal samples for region
+    region:
+      group_by: "division year month"
+      max_sequences: 20
+      sampling_scheme: "--no-probabilistic-sampling"
+      exclude: "--exclude-where 'region!={region}'"
+    # Contextual samples for region from the rest of the world
+    global:
+      group_by: "year month"
+      max_sequences: 10
+      sampling_scheme: "--no-probabilistic-sampling"
+      exclude: "--exclude-where 'region={region}'"
+      priorities:
+        type: "proximity"
+        focus: "region"

--- a/scripts/get_distance_to_focal_set.py
+++ b/scripts/get_distance_to_focal_set.py
@@ -155,6 +155,9 @@ if __name__ == '__main__':
     fh_out = open(args.output, 'w')
     fh_out.write('strain\tclosest strain\tdistance\n')
 
+    if focal_seqs_dict is None:
+        exit()
+
     chunk_size=args.chunk_size
     chunk_count = 0
     while True:

--- a/scripts/get_distance_to_focal_set.py
+++ b/scripts/get_distance_to_focal_set.py
@@ -35,7 +35,7 @@ def sequence_to_int_array(s, fill_value=110, fill_gaps=True):
     return seq
 
 # Function adapted from https://github.com/gtonkinhill/pairsnp-python
-def calculate_snp_matrix(fastafile, consensus=None, zipped=False, fill_value=110, chunk_size=0):
+def calculate_snp_matrix(fastafile, consensus=None, zipped=False, fill_value=110, chunk_size=0, ignore_seqs=[]):
     # This function generate a sparse matrix where differences to the consensus are coded as integers.
 
     row = np.empty(INITIALISATION_LENGTH)
@@ -50,6 +50,8 @@ def calculate_snp_matrix(fastafile, consensus=None, zipped=False, fill_value=110
     current_length = INITIALISATION_LENGTH
 
     for h,s in fastafile:
+        if h in ignore_seqs:
+            continue
         if consensus is None:
             align_length = len(s)
             # Take consensus as first sequence
@@ -132,6 +134,7 @@ if __name__ == '__main__':
     )
     parser.add_argument("--alignment", type=str, required=True, help="FASTA file of alignment")
     parser.add_argument("--reference", type = str, required=True, help="reference sequence (FASTA)")
+    parser.add_argument("--ignore-seqs", type = str, nargs='+', help="sequences to ignore in distance calculation")
     parser.add_argument("--focal-alignment", type = str, required=True, help="focal sample of sequences")
     parser.add_argument("--chunk-size", type=int, default=10000, help="number of samples in the global alignment to process at once. Reduce this number to reduce memory usage at the cost of increased run-time.")
     parser.add_argument("--output", type=str, required=True, help="FASTA file of output alignment")
@@ -143,7 +146,7 @@ if __name__ == '__main__':
 
     fh_focal = open(args.focal_alignment, 'rt')
     focal_seqs = SimpleFastaParser(fh_focal)
-    focal_seqs_dict = calculate_snp_matrix(focal_seqs, consensus = ref)
+    focal_seqs_dict = calculate_snp_matrix(focal_seqs, consensus = ref, ignore_seqs=args.ignore_seqs or [])
 
     fh_seqs = open(args.alignment, 'rt')
     seqs = SimpleFastaParser(fh_seqs)

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -434,7 +434,8 @@ rule proximity_score:
     benchmark:
         "benchmarks/proximity_score_{build_name}_{focus}.txt"
     params:
-        chunk_size=10000
+        chunk_size=10000,
+        ignore_seqs = config['refine']['root']
     resources:
         # Memory scales at ~0.15 MB * chunk_size (e.g., 0.15 MB * 10000 = 1.5GB).
         mem_mb=4000
@@ -445,6 +446,7 @@ rule proximity_score:
             --reference {input.reference} \
             --alignment {input.alignment} \
             --focal-alignment {input.focal_alignment} \
+            --ignore-seqs {params.ignore_seqs} \
             --chunk-size {params.chunk_size} \
             --output {output.proximities} 2>&1 | tee {log}
         """


### PR DESCRIPTION
It turns out that the proximity rule wasn't doing what it was supposed to do, for two reasons

 - the forced inclusion of the reference strains in the focal set meant that for many sequences the closest hit is the root, which isn't very useful
 - there was a sign problem related to confusion of what is a high and low priority.

This PR should fix this, but I had to introduce a fudge to make the CI work. 
