### PR TITLE
Increase default recursion limit so users don't have to

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1244,7 +1244,7 @@ rule export:
     conda: config["conda_environment"]
     shell:
         """
-        augur export v2 \
+        export AUGUR_RECURSION_LIMIT=10000 && augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \
             --node-data {input.node_data} \


### PR DESCRIPTION
## Description of proposed changes

Trees with a lot of strains (~10,000) can easily hit the default
recursion limit for BioPython's tree traversal (1000). Despite the error
message from augur export explaining how to address this problem, the
actual implementation of the solution (as in "how and where do I define
this variable in my workflow?") is not obvious. This commit proposes
that we proactively define the recursion limit to a higher value in the
export rule, so users do not need to worry about this.

In other non-SC2 analyses I have also experienced issues with the
recursion limit when running augur tree, but I have not heard any
reports of users experiencing this issue for this workflow, so I haven't
included the increased recursion limit for the tree rule here.

## Testing

Tested by CI workflow.

## Release checklist

No major updates or features.