### PR TITLE
Upload regional contexts to S3

### DIFF
--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -211,8 +211,8 @@ rule upload:
         expand("results/masked_{origin}.fasta", origin=config["S3_DST_ORIGINS"]),               # from `rule mask`
         expand("results/filtered_{origin}.fasta", origin=config["S3_DST_ORIGINS"]),             # from `rule filter`
         expand("results/mutation_summary_{origin}.tsv", origin=config["S3_DST_ORIGINS"]),       # from `rule mutation_summary
-        "results/global/global_subsampled_sequences.fasta",
-        "results/global/global_subsampled_metadata.tsv"
+        expand("results/{build_name}/{build_name}_subsampled_sequences.fasta", build_name=config["builds"]),
+        expand("results/{build_name}/{build_name}_subsampled_metadata.tsv", build_name=config["builds"]),
     params:
         s3_bucket = config["S3_DST_BUCKET"],
         compression = config["S3_DST_COMPRESSION"]


### PR DESCRIPTION
## Description of proposed changes

Updates the existing global context input of the upload rule to include
all Nextstrain regional builds. As a result, all subsampled sequences
and metadata for each regional build should get uploaded to S3 during
each run of the ncov workflow.

## Related issue(s)

Related to #592

## Testing

 - [x] Trial build through GitHub Actions

## Release checklist

No major updates or features for the public workflow.