### PR TITLE
Write index output to log file

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -347,7 +347,7 @@ rule index_sequences:
         """
         augur index \
             --sequences {input.sequences} \
-            --output {output.sequence_index}
+            --output {output.sequence_index} 2>&1 | tee {log}
         """
 
 rule subsample:


### PR DESCRIPTION
## Description of proposed changes

Writes output from the augur index command to the rule's log file (which
was defined in the rule but unused).

## Related issue(s)

Related to https://github.com/nextstrain/augur/issues/718

## Testing

Tested by CI.

## Release checklist

No major updates or features.