### PR TITLE
Use ordinal scale for S1 mutations

### DIFF
--- a/nextstrain_profiles/nextstrain-genbank/auspice_config.json
+++ b/nextstrain_profiles/nextstrain-genbank/auspice_config.json
@@ -28,7 +28,7 @@
     {
       "key": "S1_mutations",
       "title": "S1 mutations",
-      "type": "continuous"
+      "type": "ordinal"
     },    
     {
       "key": "location",

--- a/nextstrain_profiles/nextstrain/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/africa_auspice_config.json
@@ -28,7 +28,7 @@
     {
       "key": "S1_mutations",
       "title": "S1 mutations",
-      "type": "continuous"
+      "type": "ordinal"
     },
     {
       "key": "logistic_growth",

--- a/nextstrain_profiles/nextstrain/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/asia_auspice_config.json
@@ -28,7 +28,7 @@
     {
       "key": "S1_mutations",
       "title": "S1 mutations",
-      "type": "continuous"
+      "type": "ordinal"
     },
     {
       "key": "logistic_growth",

--- a/nextstrain_profiles/nextstrain/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/europe_auspice_config.json
@@ -28,7 +28,7 @@
     {
       "key": "S1_mutations",
       "title": "S1 mutations",
-      "type": "continuous"
+      "type": "ordinal"
     },
     {
       "key": "logistic_growth",

--- a/nextstrain_profiles/nextstrain/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/global_auspice_config.json
@@ -28,7 +28,7 @@
     {
       "key": "S1_mutations",
       "title": "S1 mutations",
-      "type": "continuous"
+      "type": "ordinal"
     },
     {
       "key": "logistic_growth",

--- a/nextstrain_profiles/nextstrain/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/north-america_auspice_config.json
@@ -28,7 +28,7 @@
     {
       "key": "S1_mutations",
       "title": "S1 mutations",
-      "type": "continuous"
+      "type": "ordinal"
     },
     {
       "key": "logistic_growth",

--- a/nextstrain_profiles/nextstrain/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/oceania_auspice_config.json
@@ -28,7 +28,7 @@
     {
       "key": "S1_mutations",
       "title": "S1 mutations",
-      "type": "continuous"
+      "type": "ordinal"
     },
     {
       "key": "logistic_growth",

--- a/nextstrain_profiles/nextstrain/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain/south-america_auspice_config.json
@@ -28,7 +28,7 @@
     {
       "key": "S1_mutations",
       "title": "S1 mutations",
-      "type": "continuous"
+      "type": "ordinal"
     },
     {
       "key": "logistic_growth",


### PR DESCRIPTION
Traits with integer values are better displayed by auspice using
an ordinal scale. This will result in a legend with integer
entries rather than our current situation of floats.

![image](https://user-images.githubusercontent.com/8350992/116516165-60530300-a921-11eb-83e6-378032330f43.png)
_Left: this PR, right: current nextstrain.org_
