### PR TITLE
Add spike mutations and emerging lineages as branch labels

### DIFF
--- a/scripts/add_branch_labels.py
+++ b/scripts/add_branch_labels.py
@@ -1,0 +1,60 @@
+import argparse
+import json
+from Bio import Phylo
+from collections import defaultdict
+
+def extract_spike_mutations(node_data):
+    data = {}
+    for name, node in node_data["nodes"].items():
+        smuts = node.get("aa_muts", {}).get("S", [])
+        if smuts:
+            data[name] = ", ".join(smuts)
+    return data
+
+def extract_clade_labels(node_data):
+    data = {}
+    for name, node in node_data["nodes"].items():
+        if "clade_annotation" in node:
+            data[name] = node["clade_annotation"]
+    return data
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Remove extraneous colorings",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument('--input', type=str, metavar="JSON", required=True, help="input Auspice JSON")
+    parser.add_argument('--mutations', type=str, required=True, help="mutations node data file")
+    parser.add_argument('--emerging-clades', type=str, required=True, help="emerging clades node data file")
+    parser.add_argument('--output', type=str, metavar="JSON", required=True, help="output Auspice JSON")
+    args = parser.parse_args()
+
+    with open(args.input, "r") as f:
+        auspice_json = json.load(f)
+
+    with open(args.mutations, "r") as f:
+        spike_mutations = extract_spike_mutations(json.load(f))
+
+    with open(args.emerging_clades, "r") as f:
+        clade_labels = extract_clade_labels(json.load(f))
+
+    def attach_labels(n): # closure
+      if n["name"] in spike_mutations or n["name"] in clade_labels:
+          if "branch_attrs" not in n:
+              n["branch_attrs"]={}
+          if "labels" not in n["branch_attrs"]:
+              n["branch_attrs"]["labels"]={}
+          if n["name"] in spike_mutations:
+              n["branch_attrs"]["labels"]["spike_mutations"] = spike_mutations[n["name"]]
+          if n["name"] in clade_labels:
+              n["branch_attrs"]["labels"]["emerging_lineage"] = clade_labels[n["name"]]
+
+      if "children" in n:
+          for c in n["children"]:
+              attach_labels(c)
+
+    attach_labels(auspice_json["tree"])
+
+    with open(args.output, 'w') as f:
+        json.dump(auspice_json, f, indent=2)

--- a/scripts/add_branch_labels.py
+++ b/scripts/add_branch_labels.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     )
 
     parser.add_argument('--input', type=str, metavar="JSON", required=True, help="input Auspice JSON")
-    parser.add_argument('--mutations', type=str, required=True, help="mutations node data file")
+    parser.add_argument('--mutations', type=str, required=False, help="mutations node data file")
     parser.add_argument('--emerging-clades', type=str, required=True, help="emerging clades node data file")
     parser.add_argument('--output', type=str, metavar="JSON", required=True, help="output Auspice JSON")
     args = parser.parse_args()
@@ -33,8 +33,11 @@ if __name__ == '__main__':
     with open(args.input, "r") as f:
         auspice_json = json.load(f)
 
-    with open(args.mutations, "r") as f:
-        spike_mutations = extract_spike_mutations(json.load(f))
+    if args.mutations:
+        with open(args.mutations, "r") as f:
+            spike_mutations = extract_spike_mutations(json.load(f))
+    else:
+        spike_mutations = {}
 
     with open(args.emerging_clades, "r") as f:
         clade_labels = extract_clade_labels(json.load(f))

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1261,7 +1261,6 @@ rule add_branch_labels:
     message: "Adding custom branch labels to the Auspice JSON"
     input:
         auspice_json = rules.export.output.auspice_json,
-        mutations = lambda w: rules.aa_muts_explicit.output.node_data if config.get("use_nextalign") else rules.translate.output.node_data,
         emerging_clades = rules.emerging_lineages.output.clade_data
     output:
         auspice_json = "results/{build_name}/ncov_with_branch_labels.json"
@@ -1272,7 +1271,6 @@ rule add_branch_labels:
         """
         python3 ./scripts/add_branch_labels.py \
             --input {input.auspice_json} \
-            --mutations {input.mutations} \
             --emerging-clades {input.emerging_clades} \
             --output {output.auspice_json} 
         """


### PR DESCRIPTION
Currently we have no ability for `augur export` to export branch labels and so we fall back to a small custom script, which adds yet more complexity to the Snakefile!

Closes #619

The emerging lineages look nice:

![image](https://user-images.githubusercontent.com/8350992/116523080-f1c67300-a929-11eb-9c4f-2a128db45f0c.png)

The spike mutations don't look so good! (But are useful when zoomed in)

![image](https://user-images.githubusercontent.com/8350992/116523137-0276e900-a92a-11eb-9906-a99cff5ee66c.png)


Two small auspice issues which I noticed:
1. The displayed text in the "Branch Labels" drop-down doesn't query the colorings in order to use the title.
2. The "aa" branch label text is small in auspice, but all others are large.
