### PR TITLE
Update location of GenBank data for downloading

### DIFF
--- a/nextstrain_profiles/nextstrain-genbank/builds.yaml
+++ b/nextstrain_profiles/nextstrain-genbank/builds.yaml
@@ -86,8 +86,8 @@ conda_environment: "workflow/envs/nextstrain_with_nextalign.yaml"
 # subsampling
 inputs:
   - name: genbank
-    metadata: "s3://nextstrain-data/ncov-ingest/genbank_metadata.tsv.gz"
-    sequences: "s3://nextstrain-data/ncov-ingest/genbank_sequences.fasta.gz"
+    metadata: "s3://nextstrain-data/files/ncov/open/genbank_metadata.tsv.gz"
+    sequences: "s3://nextstrain-data/files/ncov/open/genbank_sequences.fasta.gz"
     # ---------------------- NOTE --------------------------
     # PR 550 changed the path of intermediate files on
     # the S3 bucket to include the origin (e.g. _gisaid).


### PR DESCRIPTION
Matches [a corresponding change in ncov-ingest](https://github.com/nextstrain/ncov-ingest/pull/164).  This new prefix will be
a consolidated, shared location for "open" build inputs and
intermediates.