### PR TITLE
Auto-deploy our core builds to production instead of staging

### DIFF
--- a/.github/workflows/trial-build.yml
+++ b/.github/workflows/trial-build.yml
@@ -37,7 +37,7 @@ jobs:
           --memory 180GiB \
           --detach \
           . \
-            deploy_to_staging \
+            deploy \
             upload \
             --config \
                 S3_DST_BUCKET=nextstrain-ncov-private/trial/"$TRIAL_NAME" \

--- a/.github/workflows/trial-build.yml
+++ b/.github/workflows/trial-build.yml
@@ -41,7 +41,7 @@ jobs:
             upload \
             --config \
                 S3_DST_BUCKET=nextstrain-ncov-private/trial/"$TRIAL_NAME" \
-                s3_staging_url=s3://nextstrain-staging/trial_"$TRIAL_NAME"_ \
+                deploy_url=s3://nextstrain-staging/trial_"$TRIAL_NAME"_ \
             --profile nextstrain_profiles/nextstrain \
             --set-threads tree=16 \
         |& tee build-launch.log

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -480,13 +480,13 @@ Valid attributes for list entries in `inputs` are provided below.
 * description: Enable annotation of Pangolin lineages for a given build’s subsampled sequences.
 * default: `false`
 
-## s3_staging_url
+## deploy_url
 * type: string
-* description: URL to an S3 bucket where Auspice JSONs should be uploaded by the `deploy_to_staging` rule of the Nextstrain workflows. Only valid for Nextstrain builds.
+* description: URL to an S3 bucket where Auspice JSONs should be uploaded by the `deploy` rule of the Nextstrain workflows. Only valid for Nextstrain builds.
 
 ## slack_channel
 * type: string
-* description: Slack channel to notify when Nextstrain builds start, fail, or get deployed to the staging URL. Only valid for Nextstrain builds.
+* description: Slack channel to notify when Nextstrain builds start, fail, or get deployed. Only valid for Nextstrain builds.
 
 ## slack_token
 * type: string

--- a/nextstrain_profiles/nextstrain-genbank/builds.yaml
+++ b/nextstrain_profiles/nextstrain-genbank/builds.yaml
@@ -197,8 +197,8 @@ traits:
 files:
   description: "nextstrain_profiles/nextstrain/nextstrain_description.md"
 
-# S3 and slack options are related to Nextstrain live builds and don't need to be modified for local builds
-s3_staging_url: s3://nextstrain-staging
+# Deploy and Slack options are related to Nextstrain live builds and don't need to be modified for local builds
+deploy_url: s3://nextstrain-staging
 slack_token: ~
 slack_channel: "#ncov-genbank-updates"
 

--- a/nextstrain_profiles/nextstrain/builds.yaml
+++ b/nextstrain_profiles/nextstrain/builds.yaml
@@ -131,7 +131,7 @@ files:
   description: "nextstrain_profiles/nextstrain/nextstrain_description.md"
 
 # Deploy and Slack options are related to Nextstrain live builds and don't need to be modified for local builds
-deploy_url: s3://nextstrain-staging
+deploy_url: s3://nextstrain-data
 slack_token: ~
 slack_channel: "#ncov-gisaid-updates"
 

--- a/nextstrain_profiles/nextstrain/builds.yaml
+++ b/nextstrain_profiles/nextstrain/builds.yaml
@@ -130,8 +130,8 @@ traits:
 files:
   description: "nextstrain_profiles/nextstrain/nextstrain_description.md"
 
-# S3 and slack options are related to Nextstrain live builds and don't need to be modified for local builds
-s3_staging_url: s3://nextstrain-staging
+# Deploy and Slack options are related to Nextstrain live builds and don't need to be modified for local builds
+deploy_url: s3://nextstrain-staging
 slack_token: ~
 slack_channel: "#ncov-gisaid-updates"
 

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -157,18 +157,18 @@ except:
     # means that the Snakefile won't crash.
     deploy_origin = "by an unknown identity"
 
-rule deploy_to_staging:
+rule deploy:
     input:
         *rules.all_regions.input
     params:
-        slack_message = f"Deployed <https://nextstrain.org/staging/ncov|nextstrain.org/staging/ncov> {deploy_origin}",
-        s3_staging_url = config["s3_staging_url"]
+        slack_message = f"Deployed to {config['deploy_url']} {deploy_origin}",
+        deploy_url = config["deploy_url"]
     benchmark:
-        "benchmarks/deploy_to_staging.txt"
+        "benchmarks/deploy.txt"
     conda: config["conda_environment"]
     shell:
         """
-        nextstrain deploy {params.s3_staging_url:q} {input:q}
+        nextstrain deploy {params.deploy_url:q} {input:q}
 
         if [[ -n "$SLACK_TOKEN" && -n "$SLACK_CHANNEL" ]]; then
             curl https://slack.com/api/chat.postMessage \


### PR DESCRIPTION
Discussion in Slack¹ led to consensus to switch.  The reasoning is that
nearly all the time the build shepherd's are just copying files between
staging and production.  Any occasional bad build can be fixed by
rolling back to yesterday's build (from the dated JSON files).

¹ https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1620422859124500