### PR TITLE
Include distances and explicit aa muts by default

### DIFF
--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -5,6 +5,7 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+ - 12 May 2021: Include S1 mutations and nextalign-based ancestral amino acid mutations in Auspice JSONs by default instead of requiring the now-unnecessary `use_nextalign` configuration parameter. ([#630](https://github.com/nextstrain/ncov/pull/630))
  - 12 May 2021: [Document all available workflow configuration parameters](https://nextstrain.github.io/ncov/configuration). ([#633](https://github.com/nextstrain/ncov/pull/633))
 
 ## v5 (7 May 2021)

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1128,12 +1128,11 @@ def _get_node_data_by_wildcards(wildcards):
         rules.clades.output.clade_data,
         rules.recency.output.node_data,
         rules.traits.output.node_data,
-        rules.logistic_growth.output.node_data
+        rules.logistic_growth.output.node_data,
+        rules.aa_muts_explicit.output.node_data,
+        rules.distances.output.node_data
     ]
 
-    if "use_nextalign" in config and config["use_nextalign"]:
-        inputs.append(rules.aa_muts_explicit.output.node_data)
-        inputs.append(rules.distances.output.node_data)
     if "run_pangolin" in config and config["run_pangolin"]:
         inputs.append(rules.make_pangolin_node_data.output.node_data)
 


### PR DESCRIPTION
## Description of proposed changes

We used to only include these annotations in auspice JSONs when `use_nextalign` was set to `true`. Now that nextalign is the default (and only) aligner, we should always include these annotations and allow users who never enabled nextalign to benefit from them.

## Related issue(s)

Related to #615 

## Testing

What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
