### PR TITLE
Log in to Docker Hub to avail ourselves of higher rate limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: python
 python:
   - "3.6"
 install:
+  - if [[ -n "${DOCKERHUB_TOKEN:-}" ]]; then docker login -u nextstrainbot --password-stdin <<<"$DOCKERHUB_TOKEN"; fi
   - pip3 install git+https://github.com/nextstrain/cli
   - nextstrain version
   - nextstrain check-setup


### PR DESCRIPTION
This allows image pulls to be authenticated, which avoids the anonymous
rate limit shared by all users' jobs on Travis CI's pool of IPs.
