### PR TITLE
Include lineage B.1.617 as named clade 21A

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -72,3 +72,8 @@ clade	gene	site	alt
 20J/501Y.V3	nuc	5648	C
 20J/501Y.V3	nuc	12778	T
 20J/501Y.V3	nuc	13860	T
+
+21A	nuc	22917	G
+21A	nuc	27638	C
+21A	nuc	28881	T
+21A	nuc	29402	T


### PR DESCRIPTION
I've not yet tested this, but it really should just work. This is same definition used for "emerging lineages" for a little while now and it's seemed very stable.