### PR TITLE
Support compressed metadata, sequence indices, and early intermediate sequences

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,6 +1,7 @@
 import copy
 from datetime import date
 import os
+from pathlib import Path
 import sys
 from os import environ
 from socket import getfqdn

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -5,7 +5,7 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
- - 17 May 2021: Compress metadata, sequence indices, and early intermediate sequences (aligned, masked, filtered, combined for subsampling, and subsampled files) to save disk space. ([#636](https://github.com/nextstrain/ncov/pull/636))
+ - 19 May 2021: Compress metadata, sequence indices, and early intermediate sequences (aligned, masked, filtered, combined for subsampling, and subsampled files) to save disk space. ([#636](https://github.com/nextstrain/ncov/pull/636))
  - 12 May 2021: Include S1 mutations and nextalign-based ancestral amino acid mutations in Auspice JSONs by default instead of requiring the now-unnecessary `use_nextalign` configuration parameter. ([#630](https://github.com/nextstrain/ncov/pull/630))
  - 12 May 2021: [Document all available workflow configuration parameters](https://nextstrain.github.io/ncov/configuration). ([#633](https://github.com/nextstrain/ncov/pull/633))
 

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -5,6 +5,7 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+ - 17 May 2021: Compress metadata, sequence indices, and early intermediate sequences (aligned, masked, filtered, combined for subsampling, and subsampled files) to save disk space. ([#636](https://github.com/nextstrain/ncov/pull/636))
  - 12 May 2021: Include S1 mutations and nextalign-based ancestral amino acid mutations in Auspice JSONs by default instead of requiring the now-unnecessary `use_nextalign` configuration parameter. ([#630](https://github.com/nextstrain/ncov/pull/630))
  - 12 May 2021: [Document all available workflow configuration parameters](https://nextstrain.github.io/ncov/configuration). ([#633](https://github.com/nextstrain/ncov/pull/633))
 

--- a/scripts/combine-and-dedup-fastas.py
+++ b/scripts/combine-and-dedup-fastas.py
@@ -1,5 +1,5 @@
 import argparse
-from augur.io import read_sequences
+from augur.io import open_file, read_sequences, write_sequences
 from Bio import SeqIO
 import hashlib
 import sys
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     duplicate_strains = set()
 
     counter = 0
-    with open(args.output, "w") as output_handle:
+    with open_file(args.output, "w") as output_handle:
         # Stream sequences from all input files into a single output file,
         # skipping duplicate records (same strain and sequence) and noting
         # mismatched sequences for the same strain name.
@@ -46,7 +46,7 @@ if __name__ == '__main__':
                 continue
 
             sequence_hash_by_name[record.name] = sequence_hash
-            SeqIO.write(record, output_handle, 'fasta')
+            write_sequences(record, output_handle)
 
     if len(duplicate_strains) > 0:
         error_mode = "ERROR"

--- a/scripts/combine_metadata.py
+++ b/scripts/combine_metadata.py
@@ -1,4 +1,5 @@
 import argparse
+from augur.io import open_file
 from augur.utils import read_metadata
 from Bio import SeqIO
 import csv
@@ -88,7 +89,7 @@ if __name__ == '__main__':
 
     print(f"Combined metadata: {len(combined_data.keys())} strains x {len(combined_columns)} columns")
 
-    with open(args.output, 'w') as fh:
+    with open_file(args.output, 'w') as fh:
         tsv_writer = csv.writer(fh, delimiter='\t')
         tsv_writer.writerow(combined_columns)
         for row in combined_data.values():

--- a/scripts/diagnostic.py
+++ b/scripts/diagnostic.py
@@ -3,6 +3,7 @@ Run a number QC checks on an alignment. these involve divergence from a referenc
 """
 import argparse, gzip, sys
 sys.path.insert(0,'.')
+from augur.io import open_file
 from collections import defaultdict
 import numpy as np
 from Bio.SeqIO.FastaIO import SimpleFastaParser
@@ -33,7 +34,7 @@ def analyze_divergence(sequences, metadata, reference, mask_5p=0, mask_3p=0):
         known_true_cluster_array[b:e]=0
 
     cluster_cut_off = 10
-    with open(sequences) as fasta:
+    with open_file(sequences) as fasta:
         for h,s in SimpleFastaParser(fasta):
             left_gaps = len(s) - len(s.lstrip('-'))
             right_gaps = len(s) - len(s.rstrip('-'))

--- a/scripts/diagnostic.py
+++ b/scripts/diagnostic.py
@@ -101,7 +101,7 @@ if __name__ == '__main__':
     no_data_cutoff = 3000
     flagged_sequences = []
     # output diagnostics for each sequence, ordered by divergence
-    with open(args.output_diagnostics, 'w') as diag:
+    with open_file(args.output_diagnostics, 'w') as diag:
         diag.write('\t'.join(['strain', 'divergence', 'excess divergence', '#Ns', '#gaps', 'clusters', 'gaps', 'all_snps', 'gap_list'])+'\n')
         for s, d in sorted(diagnostics.items(), key=lambda x:len(x[1]['snps']), reverse=True):
             expected_div = expected_divergence(metadata[s]['date']) if s in metadata else np.nan
@@ -130,14 +130,14 @@ if __name__ == '__main__':
 
     # write out file with sequences flagged for exclusion sorted by date
     to_exclude_by_reason = defaultdict(list)
-    with open(args.output_flagged, 'w') as flag:
+    with open_file(args.output_flagged, 'w') as flag:
         flag.write(f'strain\tcollection_date\tsubmission_date\tflagging_reason\n')
         for s, msg, reasons, meta in sorted(flagged_sequences, key=lambda x:x[3].get('date_submitted', 'XX'), reverse=True):
             flag.write(f"{s}\t{metadata[s]['date'] if s in metadata else 'XXXX-XX-XX'}\t{metadata[s].get('date_submitted', 'XXXX-XX-XX') if s in metadata else 'XXXX-XX-XX'}\t{msg}\n")
             to_exclude_by_reason[reasons].append(s)
 
     # write out file with sequences flagged for exclusion sorted by date
-    with open(args.output_exclusion_list, 'w') as excl:
+    with open_file(args.output_exclusion_list, 'w') as excl:
         for reason in to_exclude_by_reason:
             excl.write(f'\n# {"&".join(reason)}\n')
             excl.write('\n'.join(to_exclude_by_reason[reason])+'\n')

--- a/scripts/get_distance_to_focal_set.py
+++ b/scripts/get_distance_to_focal_set.py
@@ -2,6 +2,7 @@
 Calculate minimal distances between sequences in an alignment and a set of focal sequences
 """
 import argparse
+from augur.io import read_sequences
 from random import shuffle
 from collections import defaultdict
 import Bio
@@ -52,7 +53,10 @@ def calculate_snp_matrix(fastafile, consensus=None, zipped=False, fill_value=110
     filled_positions = []
     current_length = INITIALISATION_LENGTH
 
-    for h,s in fastafile:
+    for record in fastafile:
+        h = record.name
+        s = str(record.seq)
+
         if h in ignore_seqs:
             continue
         if consensus is None:
@@ -147,8 +151,7 @@ if __name__ == '__main__':
     ref = sequence_to_int_array(SeqIO.read(args.reference, 'fasta').seq)
     alignment_length = len(ref)
 
-    fh_focal = open(args.focal_alignment, 'rt')
-    focal_seqs = SimpleFastaParser(fh_focal)
+    focal_seqs = read_sequences(args.focal_alignment)
     focal_seqs_dict = calculate_snp_matrix(focal_seqs, consensus = ref, ignore_seqs=args.ignore_seqs)
 
     if focal_seqs_dict is None:
@@ -159,8 +162,7 @@ if __name__ == '__main__':
         )
         sys.exit(1)
 
-    fh_seqs = open(args.alignment, 'rt')
-    seqs = SimpleFastaParser(fh_seqs)
+    seqs = read_sequences(args.alignment)
 
     # export priorities
     fh_out = open(args.output, 'w')
@@ -194,5 +196,3 @@ if __name__ == '__main__':
         chunk_count += 1
 
     fh_out.close()
-    fh_seqs.close()
-    fh_focal.close()

--- a/scripts/mask-alignment.py
+++ b/scripts/mask-alignment.py
@@ -2,6 +2,7 @@
 Mask initial bases from alignment FASTA
 """
 import argparse
+from augur.io import open_file, read_sequences, write_sequences
 import Bio
 import Bio.SeqIO
 from Bio.Seq import Seq
@@ -35,8 +36,8 @@ if __name__ == '__main__':
     if args.mask_from_end:
         end_length = args.mask_from_end
 
-    with open(args.output, 'w') as outfile:
-        for record in Bio.SeqIO.parse(args.alignment, 'fasta'):
+    with open_file(args.output, 'w') as outfile:
+        for record in read_sequences(args.alignment):
             seq = str(record.seq)
             if args.mask_terminal_gaps:
                 seq = mask_terminal_gaps(seq)
@@ -49,4 +50,4 @@ if __name__ == '__main__':
                 for site in args.mask_sites:
                     seq_list[site-1] = "N"
             record.seq = Seq("".join(seq_list))
-            Bio.SeqIO.write(record, outfile, 'fasta')
+            write_sequences(record, outfile)

--- a/scripts/mutation_summary.py
+++ b/scripts/mutation_summary.py
@@ -1,4 +1,5 @@
 import argparse, os, glob
+from augur.io import open_file
 from Bio import SeqIO, SeqFeature, Seq
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 import numpy as np
@@ -42,7 +43,7 @@ def to_mutations(aln_file, ref, aa=False):
     res = {}
     ambiguous = 'X' if aa else 'N'
 
-    with open(aln_file, 'r') as fh:
+    with open_file(aln_file, 'r') as fh:
         for si, (name, seq) in enumerate(SimpleFastaParser(fh)):
             if si%1000==0 and si:
                 print(f"sequence {si}")
@@ -69,10 +70,10 @@ if __name__ == '__main__':
     ref = res['nuc']
     translations = res['translations']
 
-    nucleotide_alignment = args.alignment or os.path.join(args.directory, args.basename+'.aligned.fasta')
+    nucleotide_alignment = args.alignment or os.path.join(args.directory, args.basename+'.aligned.fasta.xz')
     insertions = os.path.join(args.directory, args.basename+'.insertions.csv')
 
-    gene_files = glob.glob(os.path.join(args.directory, args.basename+'.gene.*.fasta'))
+    gene_files = glob.glob(os.path.join(args.directory, args.basename+'.gene.*.fasta.xz'))
 
     compressed = {}
     res = to_mutations(nucleotide_alignment, ref)

--- a/scripts/upload-to-s3
+++ b/scripts/upload-to-s3
@@ -32,13 +32,7 @@ main() {
 
     if [[ $src_hash != "$dst_hash" ]]; then
         echo "Uploading $src → $dst"
-        if [[ "$dst" == *.gz ]]; then
-            gzip -c "$src"
-        elif [[ "$dst" == *.xz ]]; then
-            xz -2 -c "$src"
-        else
-            cat "$src"
-        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")" "$(content-encoding "$dst")"
+        aws s3 cp --no-progress "$src" "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")" "$(content-encoding "$dst")"
 
         if [[ $quiet == 1 ]]; then
             echo "Quiet mode. No Slack notification sent."

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -58,18 +58,18 @@ def _get_path_for_input(stage, origin_wildcard):
     if stage=="sequences":
         return f"data/downloaded_{origin_wildcard}.fasta" if remote else path_or_url
     if stage=="aligned":
-        return f"results/precomputed-aligned_{origin_wildcard}.fasta" if remote else f"results/aligned_{origin_wildcard}.fasta"
+        return f"results/precomputed-aligned_{origin_wildcard}.fasta" if remote else f"results/aligned_{origin_wildcard}.fasta.gz"
     if stage=="to-exclude":
         return f"results/precomputed-to-exclude_{origin_wildcard}.txt" if remote else f"results/to-exclude_{origin_wildcard}.txt"
     if stage=="masked":
-        return f"results/precomputed-masked_{origin_wildcard}.fasta" if remote else f"results/masked_{origin_wildcard}.fasta"
+        return f"results/precomputed-masked_{origin_wildcard}.fasta" if remote else f"results/masked_{origin_wildcard}.fasta.gz"
     if stage=="filtered":
         if remote:
             return f"results/precomputed-filtered_{origin_wildcard}.fasta"
         elif path_or_url:
             return path_or_url
         else:
-            return f"results/filtered_{origin_wildcard}.fasta"
+            return f"results/filtered_{origin_wildcard}.fasta.gz"
 
     raise Exception(f"_get_path_for_input with unknown stage \"{stage}\"")
 
@@ -88,7 +88,7 @@ def _get_unified_metadata(wildcards):
 def _get_unified_alignment(wildcards):
     if len(list(config["inputs"].keys()))==1:
         return _get_path_for_input("filtered", list(config["inputs"].keys())[0])
-    return "results/combined_sequences_for_subsampling.fasta",
+    return "results/combined_sequences_for_subsampling.fasta.gz",
 
 def _get_metadata_by_build_name(build_name):
     """Returns a path associated with the metadata for the given build name.

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -60,7 +60,7 @@ def _get_path_for_input(stage, origin_wildcard):
     if stage=="aligned":
         return f"results/precomputed-aligned_{origin_wildcard}.fasta" if remote else f"results/aligned_{origin_wildcard}.fasta.xz"
     if stage=="to-exclude":
-        return f"results/precomputed-to-exclude_{origin_wildcard}.txt" if remote else f"results/to-exclude_{origin_wildcard}.txt.xz"
+        return f"results/precomputed-to-exclude_{origin_wildcard}.txt" if remote else f"results/to-exclude_{origin_wildcard}.txt"
     if stage=="masked":
         return f"results/precomputed-masked_{origin_wildcard}.fasta" if remote else f"results/masked_{origin_wildcard}.fasta.xz"
     if stage=="filtered":

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -82,8 +82,8 @@ def _get_unified_metadata(wildcards):
     which will run the `combine_input_metadata` rule to make it.
     """
     if len(list(config["inputs"].keys()))==1:
-        return "results/sanitized_metadata_{origin}.tsv".format(origin=list(config["inputs"].keys())[0])
-    return "results/combined_metadata.tsv"
+        return "results/sanitized_metadata_{origin}.tsv.gz".format(origin=list(config["inputs"].keys())[0])
+    return "results/combined_metadata.tsv.gz"
 
 def _get_unified_alignment(wildcards):
     if len(list(config["inputs"].keys()))==1:

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -58,18 +58,18 @@ def _get_path_for_input(stage, origin_wildcard):
     if stage=="sequences":
         return f"data/downloaded_{origin_wildcard}.fasta" if remote else path_or_url
     if stage=="aligned":
-        return f"results/precomputed-aligned_{origin_wildcard}.fasta" if remote else f"results/aligned_{origin_wildcard}.fasta.gz"
+        return f"results/precomputed-aligned_{origin_wildcard}.fasta" if remote else f"results/aligned_{origin_wildcard}.fasta.xz"
     if stage=="to-exclude":
-        return f"results/precomputed-to-exclude_{origin_wildcard}.txt" if remote else f"results/to-exclude_{origin_wildcard}.txt"
+        return f"results/precomputed-to-exclude_{origin_wildcard}.txt" if remote else f"results/to-exclude_{origin_wildcard}.txt.xz"
     if stage=="masked":
-        return f"results/precomputed-masked_{origin_wildcard}.fasta" if remote else f"results/masked_{origin_wildcard}.fasta.gz"
+        return f"results/precomputed-masked_{origin_wildcard}.fasta" if remote else f"results/masked_{origin_wildcard}.fasta.xz"
     if stage=="filtered":
         if remote:
             return f"results/precomputed-filtered_{origin_wildcard}.fasta"
         elif path_or_url:
             return path_or_url
         else:
-            return f"results/filtered_{origin_wildcard}.fasta.gz"
+            return f"results/filtered_{origin_wildcard}.fasta.xz"
 
     raise Exception(f"_get_path_for_input with unknown stage \"{stage}\"")
 
@@ -82,13 +82,13 @@ def _get_unified_metadata(wildcards):
     which will run the `combine_input_metadata` rule to make it.
     """
     if len(list(config["inputs"].keys()))==1:
-        return "results/sanitized_metadata_{origin}.tsv.gz".format(origin=list(config["inputs"].keys())[0])
-    return "results/combined_metadata.tsv.gz"
+        return "results/sanitized_metadata_{origin}.tsv.xz".format(origin=list(config["inputs"].keys())[0])
+    return "results/combined_metadata.tsv.xz"
 
 def _get_unified_alignment(wildcards):
     if len(list(config["inputs"].keys()))==1:
         return _get_path_for_input("filtered", list(config["inputs"].keys())[0])
-    return "results/combined_sequences_for_subsampling.fasta.gz",
+    return "results/combined_sequences_for_subsampling.fasta.xz",
 
 def _get_metadata_by_build_name(build_name):
     """Returns a path associated with the metadata for the given build name.

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -56,7 +56,7 @@ def _get_path_for_input(stage, origin_wildcard):
     if stage=="metadata":
         return f"data/downloaded_{origin_wildcard}.tsv" if remote else path_or_url
     if stage=="sequences":
-        return f"data/downloaded_{origin_wildcard}.fasta" if remote else path_or_url
+        return f"data/downloaded_{origin_wildcard}.fasta.gz" if remote else path_or_url
     if stage=="aligned":
         return f"results/precomputed-aligned_{origin_wildcard}.fasta" if remote else f"results/aligned_{origin_wildcard}.fasta.xz"
     if stage=="to-exclude":

--- a/workflow/snakemake_rules/download.smk
+++ b/workflow/snakemake_rules/download.smk
@@ -33,14 +33,14 @@ def _infer_decompression(input):
 rule download_sequences:
     message: "Downloading sequences from {params.address} -> {output.sequences}"
     output:
-        sequences = "data/downloaded_{origin}.fasta"
+        sequences = "data/downloaded_{origin}.fasta.gz"
     conda: config["conda_environment"]
     params:
         address = lambda w: config["inputs"][w.origin]["sequences"],
         deflate = lambda w: _infer_decompression(config["inputs"][w.origin]["sequences"])
     shell:
         """
-        aws s3 cp {params.address} - | {params.deflate} > {output.sequences:q}
+        aws s3 cp {params.address} {output.sequences:q}
         """
 
 rule download_metadata:

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -101,7 +101,8 @@ rule mutation_summary:
         "benchmarks/mutation_summary_{origin}.txt"
     params:
         outdir = "results/translations",
-        basename = "seqs_{origin}"
+        basename = "seqs_{origin}",
+        genes=config["genes"],
     conda: config["conda_environment"]
     shell:
         """
@@ -111,6 +112,7 @@ rule mutation_summary:
             --directory {params.outdir} \
             --basename {params.basename} \
             --reference {input.reference} \
+            --genes {params.genes:q} \
             --genemap {input.genemap} \
             --output {output.mutation_summary} 2>&1 | tee {log}
         """

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -94,7 +94,7 @@ rule mutation_summary:
         reference = config["files"]["alignment_reference"],
         genemap = config["files"]["annotation"]
     output:
-        mutation_summary = "results/mutation_summary_{origin}.tsv"
+        mutation_summary = "results/mutation_summary_{origin}.tsv.xz"
     log:
         "logs/mutation_summary_{origin}.txt"
     benchmark:
@@ -196,30 +196,29 @@ rule upload_reference_sets:
             cmd = f"./scripts/upload-to-s3 {fname} s3://{params.s3_bucket}/{os.path.dirname(fname).split('/')[-1]}_metadata.tsv.{params.compression} | tee -a {log}"
             print("upload command:", cmd)
             shell(cmd)
-					    
+
 
 rule upload:
     message: "Uploading intermediate files for specified origins to {params.s3_bucket}"
     input:
-        expand("results/aligned_{origin}.fasta", origin=config["S3_DST_ORIGINS"]),              # from `rule align`
-        expand("results/sequence-diagnostics_{origin}.tsv", origin=config["S3_DST_ORIGINS"]),   # from `rule diagnostic`
-        expand("results/flagged-sequences_{origin}.tsv", origin=config["S3_DST_ORIGINS"]),      # from `rule diagnostic`
-        expand("results/to-exclude_{origin}.txt", origin=config["S3_DST_ORIGINS"]),             # from `rule diagnostic`
-        expand("results/masked_{origin}.fasta", origin=config["S3_DST_ORIGINS"]),               # from `rule mask`
-        expand("results/filtered_{origin}.fasta", origin=config["S3_DST_ORIGINS"]),             # from `rule filter`
-        expand("results/mutation_summary_{origin}.tsv", origin=config["S3_DST_ORIGINS"]),       # from `rule mutation_summary
-        expand("results/{build_name}/{build_name}_subsampled_sequences.fasta", build_name=config["builds"]),
-        expand("results/{build_name}/{build_name}_subsampled_metadata.tsv", build_name=config["builds"]),
+        expand("results/aligned_{origin}.fasta.xz", origin=config["S3_DST_ORIGINS"]),              # from `rule align`
+        expand("results/sequence-diagnostics_{origin}.tsv.xz", origin=config["S3_DST_ORIGINS"]),   # from `rule diagnostic`
+        expand("results/flagged-sequences_{origin}.tsv.xz", origin=config["S3_DST_ORIGINS"]),      # from `rule diagnostic`
+        expand("results/to-exclude_{origin}.txt.xz", origin=config["S3_DST_ORIGINS"]),             # from `rule diagnostic`
+        expand("results/masked_{origin}.fasta.xz", origin=config["S3_DST_ORIGINS"]),               # from `rule mask`
+        expand("results/filtered_{origin}.fasta.xz", origin=config["S3_DST_ORIGINS"]),             # from `rule filter`
+        expand("results/mutation_summary_{origin}.tsv.xz", origin=config["S3_DST_ORIGINS"]),       # from `rule mutation_summary
+        expand("results/{build_name}/{build_name}_subsampled_sequences.fasta.xz", build_name=config["builds"]),
+        expand("results/{build_name}/{build_name}_subsampled_metadata.tsv.xz", build_name=config["builds"]),
     params:
         s3_bucket = config["S3_DST_BUCKET"],
-        compression = config["S3_DST_COMPRESSION"]
     log:
         "logs/upload_gisaid.txt"
     benchmark:
         "benchmarks/upload_gisaid.txt"
     run:
         for fname in input:
-            cmd = f"./scripts/upload-to-s3 {fname} s3://{params.s3_bucket}/{os.path.basename(fname)}.{params.compression} | tee -a {log}"
+            cmd = f"./scripts/upload-to-s3 {fname} s3://{params.s3_bucket}/{os.path.basename(fname)} | tee -a {log}"
             print("upload command:", cmd)
             shell(cmd)
 

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -2,7 +2,7 @@ rule sanitize_metadata:
     input:
         metadata=lambda wildcards: _get_path_for_input("metadata", wildcards.origin)
     output:
-        metadata="results/sanitized_metadata_{origin}.tsv"
+        metadata="results/sanitized_metadata_{origin}.tsv.gz"
     benchmark:
         "benchmarks/sanitize_metadata_{origin}.txt"
     conda:
@@ -27,9 +27,9 @@ rule combine_input_metadata:
         Combining metadata files {input.metadata} -> {output.metadata} and adding columns to represent origin
         """
     input:
-        metadata=expand("results/sanitized_metadata_{origin}.tsv", origin=config.get("inputs")),
+        metadata=expand("results/sanitized_metadata_{origin}.tsv.gz", origin=config.get("inputs")),
     output:
-        metadata = "results/combined_metadata.tsv"
+        metadata = "results/combined_metadata.tsv.gz"
     params:
         origins = lambda wildcards: list(config["inputs"].keys())
     log:
@@ -95,7 +95,7 @@ rule diagnostic:
     message: "Scanning aligned sequences {input.alignment} for problematic sequences"
     input:
         alignment = lambda wildcards: _get_path_for_input("aligned", wildcards.origin),
-        metadata = "results/sanitized_metadata_{origin}.tsv",
+        metadata = "results/sanitized_metadata_{origin}.tsv.gz",
         reference = config["files"]["reference"]
     output:
         diagnostics = "results/sequence-diagnostics_{origin}.tsv",
@@ -176,7 +176,7 @@ rule filter:
         """
     input:
         sequences = lambda wildcards: _get_path_for_input("masked", wildcards.origin),
-        metadata = "results/sanitized_metadata_{origin}.tsv",
+        metadata = "results/sanitized_metadata_{origin}.tsv.gz",
         # TODO - currently the include / exclude files are not input (origin) specific, but this is possible if we want
         include = config["files"]["include"],
         exclude = _collect_exclusion_files,
@@ -348,7 +348,7 @@ rule index_sequences:
     input:
         sequences = _get_unified_alignment
     output:
-        sequence_index = "results/combined_sequence_index.tsv"
+        sequence_index = "results/combined_sequence_index.tsv.gz"
     log:
         "logs/index_sequences.txt"
     benchmark:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -87,8 +87,8 @@ rule align:
             --output-basename {params.basename} \
             --output-fasta {params.uncompressed_alignment} \
             --output-insertions {output.insertions} > {log} 2>&1;
-        xz {params.uncompressed_alignment};
-        xz {params.outdir}/{params.basename}*.fasta
+        xz -2 {params.uncompressed_alignment};
+        xz -2 {params.outdir}/{params.basename}*.fasta
         """
 
 rule diagnostic:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -2,7 +2,7 @@ rule sanitize_metadata:
     input:
         metadata=lambda wildcards: _get_path_for_input("metadata", wildcards.origin)
     output:
-        metadata="results/sanitized_metadata_{origin}.tsv.gz"
+        metadata="results/sanitized_metadata_{origin}.tsv.xz"
     benchmark:
         "benchmarks/sanitize_metadata_{origin}.txt"
     conda:
@@ -27,9 +27,9 @@ rule combine_input_metadata:
         Combining metadata files {input.metadata} -> {output.metadata} and adding columns to represent origin
         """
     input:
-        metadata=expand("results/sanitized_metadata_{origin}.tsv.gz", origin=config.get("inputs")),
+        metadata=expand("results/sanitized_metadata_{origin}.tsv.xz", origin=config.get("inputs")),
     output:
-        metadata = "results/combined_metadata.tsv.gz"
+        metadata = "results/combined_metadata.tsv.xz"
     params:
         origins = lambda wildcards: list(config["inputs"].keys())
     log:
@@ -53,9 +53,9 @@ rule align:
         genemap = config["files"]["annotation"],
         reference = config["files"]["alignment_reference"]
     output:
-        alignment = "results/aligned_{origin}.fasta.gz",
+        alignment = "results/aligned_{origin}.fasta.xz",
         insertions = "results/insertions_{origin}.tsv",
-        translations = expand("results/translations/seqs_{{origin}}.gene.{gene}.fasta.gz", gene=config.get('genes', ['S']))
+        translations = expand("results/translations/seqs_{{origin}}.gene.{gene}.fasta.xz", gene=config.get('genes', ['S']))
     params:
         outdir = "results/translations",
         genes = ','.join(config.get('genes', ['S'])),
@@ -95,12 +95,12 @@ rule diagnostic:
     message: "Scanning aligned sequences {input.alignment} for problematic sequences"
     input:
         alignment = lambda wildcards: _get_path_for_input("aligned", wildcards.origin),
-        metadata = "results/sanitized_metadata_{origin}.tsv.gz",
+        metadata = "results/sanitized_metadata_{origin}.tsv.xz",
         reference = config["files"]["reference"]
     output:
-        diagnostics = "results/sequence-diagnostics_{origin}.tsv",
-        flagged = "results/flagged-sequences_{origin}.tsv",
-        to_exclude = "results/to-exclude_{origin}.txt"
+        diagnostics = "results/sequence-diagnostics_{origin}.tsv.xz",
+        flagged = "results/flagged-sequences_{origin}.tsv.xz",
+        to_exclude = "results/to-exclude_{origin}.txt.xz"
     log:
         "logs/diagnostics_{origin}.txt"
     params:
@@ -145,7 +145,7 @@ rule mask:
     input:
         alignment = lambda w: _get_path_for_input("aligned", w.origin)
     output:
-        alignment = "results/masked_{origin}.fasta.gz"
+        alignment = "results/masked_{origin}.fasta.xz"
     log:
         "logs/mask_{origin}.txt"
     benchmark:
@@ -176,12 +176,12 @@ rule filter:
         """
     input:
         sequences = lambda wildcards: _get_path_for_input("masked", wildcards.origin),
-        metadata = "results/sanitized_metadata_{origin}.tsv.gz",
+        metadata = "results/sanitized_metadata_{origin}.tsv.xz",
         # TODO - currently the include / exclude files are not input (origin) specific, but this is possible if we want
         include = config["files"]["include"],
         exclude = _collect_exclusion_files,
     output:
-        sequences = "results/filtered_{origin}.fasta.gz"
+        sequences = "results/filtered_{origin}.fasta.xz"
     log:
         "logs/filtered_{origin}.txt"
     benchmark:
@@ -321,7 +321,7 @@ rule combine_sequences_for_subsampling:
     input:
         lambda w: [_get_path_for_input("filtered", origin) for origin in config.get("inputs", {})]
     output:
-        "results/combined_sequences_for_subsampling.fasta.gz"
+        "results/combined_sequences_for_subsampling.fasta.xz"
     benchmark:
         "benchmarks/combine_sequences_for_subsampling.txt"
     conda: config["conda_environment"]
@@ -348,7 +348,7 @@ rule index_sequences:
     input:
         sequences = _get_unified_alignment
     output:
-        sequence_index = "results/combined_sequence_index.tsv.gz"
+        sequence_index = "results/combined_sequence_index.tsv.xz"
     log:
         "logs/index_sequences.txt"
     benchmark:
@@ -501,8 +501,8 @@ rule combine_samples:
         metadata=_get_unified_metadata,
         include=_get_subsampled_files,
     output:
-        sequences = "results/{build_name}/{build_name}_subsampled_sequences.fasta",
-        metadata = "results/{build_name}/{build_name}_subsampled_metadata.tsv"
+        sequences = "results/{build_name}/{build_name}_subsampled_sequences.fasta.xz",
+        metadata = "results/{build_name}/{build_name}_subsampled_metadata.tsv.xz"
     log:
         "logs/subsample_regions_{build_name}.txt"
     benchmark:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -62,7 +62,8 @@ rule align:
         basename = "seqs_{origin}",
         strain_prefixes=config["strip_strain_prefixes"],
         # Strip the compression suffix for the intermediate output from the aligner.
-        uncompressed_alignment=lambda wildcards, output: Path(output.alignment).with_suffix("")
+        uncompressed_alignment=lambda wildcards, output: Path(output.alignment).with_suffix(""),
+        sanitize_log="logs/sanitize_sequences_{origin}.txt"
     log:
         "logs/align_{origin}.txt"
     benchmark:
@@ -76,7 +77,7 @@ rule align:
         python3 scripts/sanitize_sequences.py \
             --sequences {input.sequences} \
             --strip-prefixes {params.strain_prefixes:q} \
-            --output /dev/stdout \
+            --output /dev/stdout 2> {params.sanitize_log} \
             | nextalign \
             --jobs={threads} \
             --reference {input.reference} \

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -179,7 +179,7 @@ rule mask:
             --mask-from-end {params.mask_from_end} \
             --mask-sites {params.mask_sites} \
             --mask-terminal-gaps \
-            --output {output.alignment} 2>&1 | tee {log}
+            --output /dev/stdout | xz -c -2 > {output.alignment} 2>| tee {log}
         """
 
 rule filter:
@@ -224,7 +224,7 @@ rule filter:
             --exclude {input.exclude} \
             --exclude-where {params.exclude_where}\
             --min-length {params.min_length} \
-            --output {output.sequences} 2>&1 | tee {log}
+            --output /dev/stdout | xz -c -2 > {output.sequences} 2>| tee {log}
         """
 
 def _get_subsampling_settings(wildcards):


### PR DESCRIPTION
## Description of proposed changes

Working with multiple copies of full, uncompressed GISAID sequences has become unsustainable. This PR modifies early workflow outputs to use compressed sequences for aligned, masked, filtered, and combined sequence sets. This PR also changes metadata and sequence index outputs to compressed formats. Commit messages provide full details on the rationale of the implementation.

## Testing

- [x] Test by CI
- [x] Test a Nextstrain build on SLURM cluster
- [x] [Trial build on AWS](https://github.com/nextstrain/ncov/runs/2592498791?check_suite_focus=true)
- [x] [Second trial build on AWS after major bug fixes](https://github.com/nextstrain/ncov/runs/2615297965?check_suite_focus=true)

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/change_log.md` in this pull request to document these changes by the date they were added.