### PR TITLE
Run xz outside python.

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -353,10 +353,11 @@ rule combine_sequences_for_subsampling:
                 --sequences {input} \
                 --strip-prefixes {params.strain_prefixes:q} \
                 --output /dev/stdout \
-                | python3 scripts/combine-and-dedup-fastas.py \
+        | python3 scripts/combine-and-dedup-fastas.py \
             --input /dev/stdin \
             {params.warn_about_duplicates} \
-            --output {output}
+            --output /dev/stdout \
+        | xz -2 > {output}
         """
 
 rule index_sequences:


### PR DESCRIPTION
## Description of proposed changes

xopen+lzma has performance issues as it does not support passing compression levels to py-lzma.  This moves the compression out of the control of the python process.

## Testing

will kick off a nextstrain run.