### PR TITLE
Support custom Auspice JSON prefixes

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -122,8 +122,8 @@ localrules: download_metadata, download_sequences, clean
 # Create a standard ncov build for auspice, by default.
 rule all:
     input:
-        auspice_json = expand("auspice/ncov_{build_name}.json", build_name=BUILD_NAMES),
-        tip_frequency_json = expand("auspice/ncov_{build_name}_tip-frequencies.json", build_name=BUILD_NAMES)
+        auspice_json = expand("auspice/{ext}_{build_name}.json", build_name=BUILD_NAMES,ext=config["auspice_json_prefix"]),
+        tip_frequency_json = expand("auspice/{ext}_{build_name}_tip-frequencies.json", build_name=BUILD_NAMES,ext=config["auspice_json_prefix"])
 
 rule clean:
     message: "Removing directories: {params}"

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -272,3 +272,6 @@ subsampling:
       group_by: "country year month"
       seq_per_group: 10
       exclude: "--exclude-where 'location={location}'"
+
+# Configure the prefix to use for Auspice JSONs.
+auspice_json_prefix: ncov

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -3,6 +3,10 @@
 As of April 2021, we use major version numbers (e.g. v2) to reflect backward incompatible changes to the workflow that likely require you to update your Nextstrain installation.
 We also use this change log to document new features that maintain backward compatibility, indicating these features by the date they were added.
 
+## New features since last version update
+
+ - 25 May 2021: Support custom Auspice JSON prefixes with a new configuration parameter, `auspice_json_prefix`. [See the configuration reference for more details](https://nextstrain.github.io/ncov/configuration.html#auspice_json_prefix). ([#643](https://github.com/nextstrain/ncov/pull/643))
+
 ## v6 (20 May 2021)
 
 ### Major changes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -631,3 +631,8 @@ Each named traits configuration (`default` or build-named) supports the followin
 * type: string
 * description: Arguments specific to the tree method (`iqtree`) to be passed through to the tree builder command run by `augur tree`.
 * default: `'-ninit 10 -n 4'`
+
+## auspice_json_prefix
+* type: string
+* description: Prefix to use for Auspice JSON outputs. Change this value to produce JSONs named like `auspice/<your_prefix>_global.json` for a build named `global`, for example. If you are using [Nextstrain's Community Sharing](https://docs.nextstrain.org/en/latest/guides/share/community-builds.html) to view your builds, set this value to your GitHub repository name and the `ncov` default. For example, if your repository is named `evolution`, set `auspice_json_prefix: evolution_ncov` to get JSONs you can view your `global` build at https://nextstrain.org/community/*your_github_organization*/evolution/ncov/global.
+* default: `ncov`

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -26,10 +26,10 @@ def get_todays_date():
 
 rule all_regions:
     input:
-        auspice_json = expand("auspice/ncov_{build_name}.json", build_name=BUILD_NAMES),
-        tip_frequencies_json = expand("auspice/ncov_{build_name}_tip-frequencies.json", build_name=BUILD_NAMES),
-        dated_auspice_json = expand("auspice/ncov_{build_name}_{date}.json", build_name=BUILD_NAMES, date=get_todays_date()),
-        dated_tip_frequencies_json = expand("auspice/ncov_{build_name}_{date}_tip-frequencies.json", build_name=BUILD_NAMES, date=get_todays_date())
+        auspice_json = expand("auspice/{prefix}_{build_name}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
+        tip_frequencies_json = expand("auspice/{prefix}_{build_name}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
+        dated_auspice_json = expand("auspice/{prefix}_{build_name}_{date}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=get_todays_date()),
+        dated_tip_frequencies_json = expand("auspice/{prefix}_{build_name}_{date}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=get_todays_date())
 
 # This cleans out files to allow re-run of 'normal' run with `export`
 # to check lat-longs & orderings
@@ -128,10 +128,10 @@ rule dated_json:
         auspice_json = rules.finalize.output.auspice_json,
         tip_frequencies_json = rules.tip_frequencies.output.tip_frequencies_json
     output:
-        dated_auspice_json = "auspice/ncov_{build_name}_{date}.json",
-        dated_tip_frequencies_json = "auspice/ncov_{build_name}_{date}_tip-frequencies.json"
+        dated_auspice_json = "auspice/{prefix}_{build_name}_{date}.json",
+        dated_tip_frequencies_json = "auspice/{prefix}_{build_name}_{date}_tip-frequencies.json"
     benchmark:
-        "benchmarks/dated_json_{build_name}_{date}.txt"
+        "benchmarks/dated_json_{prefix}_{build_name}_{date}.txt"
     conda: config["conda_environment"]
     shell:
         """

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1255,9 +1255,9 @@ rule finalize:
         frequencies = rules.tip_frequencies.output.tip_frequencies_json,
         root_sequence_json = rules.export.output.root_sequence_json
     output:
-        auspice_json = "auspice/ncov_{build_name}.json",
-        tip_frequency_json = "auspice/ncov_{build_name}_tip-frequencies.json",
-        root_sequence_json = "auspice/ncov_{build_name}_root-sequence.json"
+        auspice_json = f"auspice/{config['auspice_json_prefix']}_{{build_name}}.json",
+        tip_frequency_json = f"auspice/{config['auspice_json_prefix']}_{{build_name}}_tip-frequencies.json",
+        root_sequence_json = f"auspice/{config['auspice_json_prefix']}_{{build_name}}_root-sequence.json"
     log:
         "logs/fix_colorings_{build_name}.txt"
     benchmark:


### PR DESCRIPTION
## Description of proposed changes

Adds support for custom Auspice JSON prefixes other than the default `ncov`. This is a fork of @ignasiialemany's original PR #536 that includes some updates for the latest version of the workflow including documentation in the configuration reference (and support for authorized Docker pulls in CI, etc.).

## Related issue(s)

Fixes #488
Related to #536

## Testing

 - [x] Tested by CI

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/change_log.md` in this pull request to document these changes by the date they were added.