### PR TITLE
Calculate Jaccard distances between strains

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -97,6 +97,8 @@ mask:
 combine_sequences_for_subsampling:
   warn_about_duplicates: true
 
+substitutions_field: aa_substitutions
+
 tree:
   tree-builder-args: "'-ninit 10 -n 4'"
 

--- a/scripts/get_jaccard_distance.py
+++ b/scripts/get_jaccard_distance.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+import argparse
+from augur.io import open_file
+from augur.utils import read_strains
+from collections import defaultdict
+import numpy as np
+import pandas as pd
+import sys
+import time
+
+
+def jaccard_distance(set_a, set_b, missing_from_a):
+    """Calculate the Jaccard similarity between two sets of categorical values.
+    """
+    return 1.0 - (len(set_a & set_b) / (len(set_a | set_b) + missing_from_a))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata", required=True, help="GISAID metadata with 'aa_substitutions' field for all records")
+    parser.add_argument("--focal", required=True, help="strains in the focal data set to find closest strains from the full set")
+    parser.add_argument("--substitutions-field", default="aa_substitutions", help="field with annotations of substitutions to use for distance calculations")
+    parser.add_argument("--drop-duplicates", action="store_true", help="drop duplicate combinations of substitutions, limiting distances to the first strain with a given set of substitutions in the metadata.")
+    parser.add_argument("--output", required=True, help="strain names of closest strains to focal set")
+
+    args = parser.parse_args()
+
+    # Load names of focal strains.
+    focal_strains = sorted(read_strains(args.focal))
+
+    # Load full metadata.
+    try:
+        print("Reading metadata")
+        metadata = pd.read_csv(
+            args.metadata,
+            sep="\t",
+            dtype={
+                "strain": "string",
+                "name": "string",
+            },
+            usecols=["strain", args.substitutions_field]
+        )
+    except ValueError as error:
+        if args.substitutions_field in str(error):
+            error_message = f"ERROR: The substitutions field '{args.substitutions_field}' is not a column in '{args.metadata}'."
+        else:
+            error_message = f"ERROR: {error}"
+
+        print(error_message, file=sys.stderr)
+        sys.exit(1)
+
+    # Drop duplicate mutations.
+    if args.drop_duplicates:
+        metadata = metadata.drop_duplicates(args.substitutions_field)
+
+    all_strains = metadata["strain"].values
+    focal_strains = [strain for strain in focal_strains if strain in all_strains]
+    other_strains = [strain for strain in all_strains if strain not in focal_strains]
+
+    print("Parsing and enumerating mutations per strain")
+    mutations_by_strain = {}
+    index_by_mutation = {}
+    current_index = 0
+    for strain, value in zip(all_strains, metadata[args.substitutions_field].values):
+        strain_mutations = set(str(value)[1:-1].split(","))
+        mutations_by_strain[strain] = strain_mutations
+
+        if strain in focal_strains:
+            for mutation in strain_mutations:
+                if mutation not in index_by_mutation:
+                    index_by_mutation[mutation] = current_index
+                    current_index += 1
+
+    del metadata
+
+    total_mutations = len(index_by_mutation)
+    print(f"Found {total_mutations} distinct mutations in focal strains")
+
+    print("Mapping enumerated mutations to strains")
+    mutation_indices_by_strain = defaultdict(set)
+    missing_mutations_by_strain = defaultdict(int)
+    for strain in all_strains:
+        for mutation in mutations_by_strain[strain]:
+            if mutation in index_by_mutation:
+                mutation_indices_by_strain[strain].add(index_by_mutation[mutation])
+            else:
+                missing_mutations_by_strain[strain] += 1
+
+    del mutations_by_strain
+    del index_by_mutation
+
+    print(f"Calculating distances for {len(other_strains)} non-focal strains")
+    with open_file(args.output, "w") as oh:
+        oh.write("strain\tclosest strain\tdistance\n")
+
+        then = time.time()
+        counter = 0
+        for strain in other_strains:
+            if counter > 0 and counter % 10000 == 0:
+                now = time.time()
+                print(f"Processed {counter} records in {now - then:.0f} seconds")
+                then = now
+
+            counter += 1
+            min_distance = np.inf
+            min_strain = None
+
+            for focal_strain in focal_strains:
+                distance = jaccard_distance(
+                    mutation_indices_by_strain[strain],
+                    mutation_indices_by_strain[focal_strain],
+                    missing_mutations_by_strain[strain]
+                )
+
+                if distance < min_distance:
+                    min_distance = distance
+                    min_strain = focal_strain
+
+                if min_distance == 0:
+                    break
+
+            oh.write("{strain}\t{closest_strain}\t{distance:.4f}\n".format(
+                strain=strain,
+                closest_strain=min_strain,
+                distance=min_distance
+            ))

--- a/scripts/priorities.py
+++ b/scripts/priorities.py
@@ -14,8 +14,8 @@ if __name__ == '__main__':
     )
     parser.add_argument("--sequence-index", type=str, required=True, help="sequence index file")
     parser.add_argument("--proximities", type = str, required=True, help="tsv file with proximities")
-    parser.add_argument("--Nweight", type = float, default=0.003, required=False, help="parameterizes de-prioritization of incomplete sequences")
-    parser.add_argument("--crowding-penalty", type = float, default=0.01, required=False, help="parameterizes how priorities decrease when there is many very similar sequences")
+    parser.add_argument("--Nweight", type = float, default=0.00003, required=False, help="parameterizes de-prioritization of incomplete sequences")
+    parser.add_argument("--crowding-penalty", type = float, default=0.001, required=False, help="parameterizes how priorities decrease when there is many very similar sequences")
     parser.add_argument("--output", type=str, required=True, help="tsv file with the priorities")
     args = parser.parse_args()
 


### PR DESCRIPTION
## Description of proposed changes

Uses Jaccard distance between sets of amino acid substitutions annotates in GISAID metadata as an alternative to the SNP-based proximity calculation. This approach does not require any alignment or interaction with sequence data, since the relevant information is already provided in the metadata.

Adds a top-level parameter of which field to look for in the metadata for comma-delimited substitutions to compare with Jaccard distances. This parameter might make more sense in the subsampling definitions,
though.

## Related issue(s)

<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Fixes #
Related to #

## Testing

What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
