### PR TITLE
Update with clade definitions with WHO VOCs/VOIs

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -49,31 +49,62 @@ clade	gene	site	alt
 20G	nuc	28472	T
 20G	nuc	28869	T
 
-20H/501Y.V2	nuc	1059	T
-20H/501Y.V2	nuc	8782	C
-20H/501Y.V2	nuc	14408	T
-20H/501Y.V2	nuc	23403	G
-20H/501Y.V2	nuc	25563	T
-20H/501Y.V2	nuc	23063	T
-20H/501Y.V2	nuc	23012	A
+20H (Beta, V2)	nuc	1059	T
+20H (Beta, V2)	nuc	8782	C
+20H (Beta, V2)	nuc	14408	T
+20H (Beta, V2)	nuc	23403	G
+20H (Beta, V2)	nuc	25563	T
+20H (Beta, V2)	nuc	23063	T
+20H (Beta, V2)	nuc	23012	A
 
-20I/501Y.V1	nuc	8782	C
-20I/501Y.V1	nuc	14408	T
-20I/501Y.V1	nuc	23403	G
-20I/501Y.V1	nuc	28881	A
-20I/501Y.V1	nuc	28882	A
-20I/501Y.V1	nuc	23063	T
-20I/501Y.V1	nuc	14676	T
-20I/501Y.V1	nuc	15279	T
+20I (Alpha, V1)	nuc	8782	C
+20I (Alpha, V1)	nuc	14408	T
+20I (Alpha, V1)	nuc	23403	G
+20I (Alpha, V1)	nuc	28881	A
+20I (Alpha, V1)	nuc	28882	A
+20I (Alpha, V1)	nuc	23063	T
+20I (Alpha, V1)	nuc	14676	T
+20I (Alpha, V1)	nuc	15279	T
 
-20J/501Y.V3	nuc	733	C
-20J/501Y.V3	nuc	2749	T
-20J/501Y.V3	nuc	3828	T
-20J/501Y.V3	nuc	5648	C
-20J/501Y.V3	nuc	12778	T
-20J/501Y.V3	nuc	13860	T
+20J (Gamma, V3)	nuc	733	C
+20J (Gamma, V3)	nuc	2749	T
+20J (Gamma, V3)	nuc	3828	T
+20J (Gamma, V3)	nuc	5648	C
+20J (Gamma, V3)	nuc	12778	T
+20J (Gamma, V3)	nuc	13860	T
 
-21A	nuc	22917	G
-21A	nuc	27638	C
-21A	nuc	28881	T
-21A	nuc	29402	T
+21A (Delta)	nuc	22917	G
+21A (Delta)	nuc	22995	A
+21A (Delta)	nuc	24410	A
+21A (Delta)	nuc	27638	C
+21A (Delta)	nuc	28881	T
+21A (Delta)	nuc	29402	T
+
+21B (Kappa)	nuc	17523	T
+21B (Kappa)	nuc	22917	G
+21B (Kappa)	nuc	23012	C
+21B (Kappa)	nuc	27638	C
+21B (Kappa)	nuc	28881	T
+21B (Kappa)	nuc	29402	T
+
+21C (Epsilon)	nuc	17014	T
+21C (Epsilon)	nuc	21600	T
+21C (Epsilon)	nuc	22018	T
+21C (Epsilon)	nuc	22917	G
+
+21D (Eta)	nuc	14407	T
+21D (Eta)	nuc	21717	G
+21D (Eta)	nuc	24224	C
+21D (Eta)	nuc	24748	T
+
+21E (Theta)	nuc	12049	T
+21E (Theta)	nuc	22356	G
+21E (Theta)	nuc	23341	C
+21E (Theta)	nuc	23604	A
+21E (Theta)	nuc	24187	A
+21E (Theta)	nuc	24836	A
+
+21F (Iota)	nuc	16500	C
+21F (Iota)	nuc	20262	G
+21F (Iota)	nuc	21575	T
+21F (Iota)	nuc	22320	G

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -13527,6 +13527,17 @@ recency	New
 
 ################
 
+clade_membership	20H (Beta, V2)
+clade_membership	20I (Alpha, V1)
+clade_membership	20J (Gamma, V3)
+clade_membership	21A (Delta)
+clade_membership	21B (Kappa)
+clade_membership	21C (Epsilon)
+clade_membership	21D (Eta)
+clade_membership	21E (Theta)
+clade_membership	21F (Iota)
+
+################
 
 emerging_lineage	A.23.1
 emerging_lineage	B.1.1.7


### PR DESCRIPTION
This adds 5 new clade definitions drawing from WHO labelled VOCs and VOIs (https://www.who.int/en/activities/tracking-SARS-CoV-2-variants/). Additionally, previous VOCs labeled as "501Y.V1", "501Y.V2" and "501Y.V3" have been updated to use WHO shorthand, eg "20H (Beta, V2)".

Example outputs can be seen at:
- [Global](https://nextstrain.org/staging/who-clades/ncov/global)
- [Africa](https://nextstrain.org/staging/who-clades/ncov/africa)
- [Asia](https://nextstrain.org/staging/who-clades/ncov/asia)
- [Europe](https://nextstrain.org/staging/who-clades/ncov/europe)
- [North America](https://nextstrain.org/staging/who-clades/ncov/north-america)
- [Oceania](https://nextstrain.org/staging/who-clades/ncov/oceania)
- [South America](https://nextstrain.org/staging/who-clades/ncov/south-america)