### PR TITLE
Emerging lineages update

### DIFF
--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -13598,7 +13598,7 @@ emerging_lineage	A.23.1
 emerging_lineage	B.1.1.7 (Alpha)
 emerging_lineage	B.1.1.519
 emerging_lineage	B.1.351 (Beta)
-emerging_lineage	B.1.427+B.1.429 (Epsilon)
+emerging_lineage	B.1.427/429 (Epsilon)
 emerging_lineage	B.1.525 (Eta)
 emerging_lineage	B.1.526 (Iota)
 emerging_lineage	B.1.617.1 (Kappa)

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -13595,18 +13595,22 @@ clade_membership	21F (Iota)
 ################
 
 emerging_lineage	A.23.1
-emerging_lineage	B.1.1.7
-emerging_lineage	B.1.351
-emerging_lineage	B.1.427+B.1.429
-emerging_lineage	B.1.525
-emerging_lineage	B.1.526
-emerging_lineage	B.1.617
+emerging_lineage	B.1.1.7 (Alpha)
+emerging_lineage	B.1.1.519
+emerging_lineage	B.1.351 (Beta)
+emerging_lineage	B.1.427+B.1.429 (Epsilon)
+emerging_lineage	B.1.525 (Eta)
+emerging_lineage	B.1.526 (Iota)
+emerging_lineage	B.1.617.1 (Kappa)
+emerging_lineage	B.1.617.2 (Delta)
+emerging_lineage	B.1.619
+emerging_lineage	B.1.620
+emerging_lineage	B.1.621
 emerging_lineage	C.37
-emerging_lineage	P.1
-emerging_lineage	P.3
+emerging_lineage	P.1 (Gamma)
+emerging_lineage	P.3 (Theta)
 
 ################
-
 
 pango_lineage	A
 pango_lineage	A.1

--- a/defaults/emerging_lineages.tsv
+++ b/defaults/emerging_lineages.tsv
@@ -7,58 +7,87 @@ A.23.1	nuc	23401	T
 A.23.1	nuc	23604	G
 A.23.1	nuc	24097	C
 
-B.1.1.7	nuc	8782	C
-B.1.1.7	nuc	14408	T
-B.1.1.7	nuc	23403	G
-B.1.1.7	nuc	28881	A
-B.1.1.7	nuc	28882	A
-B.1.1.7	nuc	23063	T
-B.1.1.7	nuc	14676	T
-B.1.1.7	nuc	15279	T
+B.1.1.7 (Alpha)	nuc	8782	C
+B.1.1.7 (Alpha)	nuc	14408	T
+B.1.1.7 (Alpha)	nuc	23403	G
+B.1.1.7 (Alpha)	nuc	28881	A
+B.1.1.7 (Alpha)	nuc	28882	A
+B.1.1.7 (Alpha)	nuc	23063	T
+B.1.1.7 (Alpha)	nuc	14676	T
+B.1.1.7 (Alpha)	nuc	15279	T
 
-B.1.351	nuc	1059	T
-B.1.351	nuc	8782	C
-B.1.351	nuc	14408	T
-B.1.351	nuc	23403	G
-B.1.351	nuc	25563	T
-B.1.351	nuc	23063	T
-B.1.351	nuc	23012	A
+B.1.1.519	nuc	22995	A
+B.1.1.519	nuc	10954	T
+B.1.1.519	nuc	12789	T
+B.1.1.519	nuc	21306	T
 
-B.1.427+B.1.429	nuc	17014	T
-B.1.427+B.1.429	nuc	21600	T
-B.1.427+B.1.429	nuc	22018	T
-B.1.427+B.1.429	nuc	22917	G
+B.1.351 (Beta)	nuc	1059	T
+B.1.351 (Beta)	nuc	8782	C
+B.1.351 (Beta)	nuc	14408	T
+B.1.351 (Beta)	nuc	23403	G
+B.1.351 (Beta)	nuc	25563	T
+B.1.351 (Beta)	nuc	23063	T
+B.1.351 (Beta)	nuc	23012	A
 
-B.1.525	nuc	14407	T
-B.1.525	nuc	21717	G
-B.1.525	nuc	24224	C
-B.1.525	nuc	24748	T
+B.1.427+B.1.429 (Epsilon)	nuc	17014	T
+B.1.427+B.1.429 (Epsilon)	nuc	21600	T
+B.1.427+B.1.429 (Epsilon)	nuc	22018	T
+B.1.427+B.1.429 (Epsilon)	nuc	22917	G
 
-B.1.526	nuc	16500	C
-B.1.526	nuc	20262	G
-B.1.526	nuc	21575	T
-B.1.526	nuc	22320	G
+B.1.525 (Eta)	nuc	14407	T
+B.1.525 (Eta)	nuc	21717	G
+B.1.525 (Eta)	nuc	24224	C
+B.1.525 (Eta)	nuc	24748	T
 
-B.1.617	nuc	22917	G
-B.1.617	nuc	27638	C
-B.1.617	nuc	28881	T
-B.1.617	nuc	29402	T
+B.1.526 (Iota)	nuc	16500	C
+B.1.526 (Iota)	nuc	20262	G
+B.1.526 (Iota)	nuc	21575	T
+B.1.526 (Iota)	nuc	22320	G
+
+B.1.617.1 (Kappa)	nuc	17523	T
+B.1.617.1 (Kappa)	nuc	22917	G
+B.1.617.1 (Kappa)	nuc	23012	C
+B.1.617.1 (Kappa)	nuc	27638	C
+B.1.617.1 (Kappa)	nuc	28881	T
+B.1.617.1 (Kappa)	nuc	29402	T
+
+B.1.617.2 (Delta)	nuc	22917	G
+B.1.617.2 (Delta)	nuc	22995	A
+B.1.617.2 (Delta)	nuc	24410	A
+B.1.617.2 (Delta)	nuc	27638	C
+B.1.617.2 (Delta)	nuc	28881	T
+B.1.617.2 (Delta)	nuc	29402	T
+
+B.1.619	nuc	5008	T
+B.1.619	nuc	14403	T
+B.1.619	S	936	N
+B.1.619	S	939	F
+
+B.1.620	nuc	6236	A
+B.1.620	nuc	20049	C
+B.1.620	S	1027	I
+B.1.620	S	245	Y
+
+B.1.621	nuc	11451	G
+B.1.621	nuc	13057	T
+B.1.621	nuc	17491	T
+B.1.621	nuc	19035	C
 
 C.37	nuc	21786	T
 C.37	nuc	21789	T
 C.37	nuc	22917	A
 C.37	nuc	23031	C
 
-P.1	nuc	733	C
-P.1	nuc	2749	T
-P.1	nuc	3828	T
-P.1	nuc	5648	C
-P.1	nuc	12778	T
-P.1	nuc	13860	T
+P.1 (Gamma)	nuc	733	C
+P.1 (Gamma)	nuc	2749	T
+P.1 (Gamma)	nuc	3828	T
+P.1 (Gamma)	nuc	5648	C
+P.1 (Gamma)	nuc	12778	T
+P.1 (Gamma)	nuc	13860	T
 
-P.3	nuc	12049	T
-P.3	nuc	22356	G
-P.3	nuc	23341	C
-P.3	nuc	23604	A
-P.3	nuc	24187	A
-P.3	nuc	24836	A
+P.3 (Theta)	nuc	12049	T
+P.3 (Theta)	nuc	22356	G
+P.3 (Theta)	nuc	23341	C
+P.3 (Theta)	nuc	23604	A
+P.3 (Theta)	nuc	24187	A
+P.3 (Theta)	nuc	24836	A

--- a/defaults/emerging_lineages.tsv
+++ b/defaults/emerging_lineages.tsv
@@ -18,7 +18,7 @@ B.1.1.7 (Alpha)	nuc	15279	T
 
 B.1.1.519	nuc	22995	A
 B.1.1.519	nuc	10954	T
-B.1.1.519	nuc	12789	T
+B.1.1.519	nuc	22995	A
 B.1.1.519	nuc	21306	T
 
 B.1.351 (Beta)	nuc	1059	T
@@ -29,10 +29,10 @@ B.1.351 (Beta)	nuc	25563	T
 B.1.351 (Beta)	nuc	23063	T
 B.1.351 (Beta)	nuc	23012	A
 
-B.1.427+B.1.429 (Epsilon)	nuc	17014	T
-B.1.427+B.1.429 (Epsilon)	nuc	21600	T
-B.1.427+B.1.429 (Epsilon)	nuc	22018	T
-B.1.427+B.1.429 (Epsilon)	nuc	22917	G
+B.1.427/429 (Epsilon)	nuc	17014	T
+B.1.427/429 (Epsilon)	nuc	21600	T
+B.1.427/429 (Epsilon)	nuc	22018	T
+B.1.427/429 (Epsilon)	nuc	22917	G
 
 B.1.525 (Eta)	nuc	14407	T
 B.1.525 (Eta)	nuc	21717	G


### PR DESCRIPTION
Simple update to emerging lineages. This adds WHO label as alias to existing emerging lineages, splits B.1.617.1 and B.1.617.2 and additionally includes B.1.1.519, B.1.619, B.1.620 and B.1.621.