### PR TITLE
Use subsampled metadata for per-build outputs

### DIFF
--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -46,7 +46,7 @@ rule clean_export_regions:
 rule extract_meta:
     input:
         alignment = rules.build_align.output.alignment,
-        metadata = _get_metadata_by_wildcards
+        metadata="results/{build_name}/metadata_adjusted.tsv.xz",
     output:
         metadata = "results/{build_name}/extracted_metadata.tsv"
     run:
@@ -65,8 +65,7 @@ rule export_all_regions:
     input:
         auspice_json = expand("results/{build_name}/ncov_with_accessions.json", build_name=BUILD_NAMES),
         lat_longs = config["files"]["lat_longs"],
-        metadata = [_get_metadata_by_build_name(build_name).format(build_name=build_name)
-                    for build_name in BUILD_NAMES],
+        metadata=expand("results/{build_name}/metadata_adjusted.tsv.xz", build_name=BUILD_NAMES),
         colors = expand("results/{build_name}/colors.tsv", build_name=BUILD_NAMES),
     benchmark:
         "benchmarks/export_all_regions.txt"

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -637,7 +637,7 @@ rule adjust_metadata_regions:
         Adjusting metadata for build '{wildcards.build_name}'
         """
     input:
-        metadata = _get_unified_metadata
+        metadata="results/{build_name}/{build_name}_subsampled_metadata.tsv.xz",
     output:
         metadata = "results/{build_name}/metadata_adjusted.tsv.xz"
     params:
@@ -694,7 +694,7 @@ rule refine:
     input:
         tree = rules.tree.output.tree,
         alignment = rules.build_align.output.alignment,
-        metadata = _get_metadata_by_wildcards
+        metadata="results/{build_name}/metadata_adjusted.tsv.xz",
     output:
         tree = "results/{build_name}/tree.nwk",
         node_data = "results/{build_name}/branch_lengths.json"
@@ -888,7 +888,7 @@ rule traits:
         """
     input:
         tree = rules.refine.output.tree,
-        metadata = _get_metadata_by_wildcards
+        metadata="results/{build_name}/metadata_adjusted.tsv.xz",
     output:
         node_data = "results/{build_name}/traits.json"
     log:
@@ -1006,7 +1006,7 @@ rule colors:
     input:
         ordering = config["files"]["ordering"],
         color_schemes = config["files"]["color_schemes"],
-        metadata = _get_metadata_by_wildcards
+        metadata="results/{build_name}/metadata_adjusted.tsv.xz",
     output:
         colors = "results/{build_name}/colors.tsv"
     log:
@@ -1031,7 +1031,7 @@ rule colors:
 rule recency:
     message: "Use metadata on submission date to construct submission recency field"
     input:
-        metadata = _get_metadata_by_wildcards
+        metadata="results/{build_name}/metadata_adjusted.tsv.xz",
     output:
         node_data = "results/{build_name}/recency.json"
     log:
@@ -1053,7 +1053,7 @@ rule tip_frequencies:
     message: "Estimating censored KDE frequencies for tips"
     input:
         tree = rules.refine.output.tree,
-        metadata = _get_metadata_by_wildcards
+        metadata="results/{build_name}/metadata_adjusted.tsv.xz",
     output:
         tip_frequencies_json = "results/{build_name}/tip-frequencies.json"
     log:
@@ -1170,7 +1170,7 @@ rule export:
     message: "Exporting data files for for auspice"
     input:
         tree = rules.refine.output.tree,
-        metadata = _get_metadata_by_wildcards,
+        metadata="results/{build_name}/metadata_adjusted.tsv.xz",
         node_data = _get_node_data_by_wildcards,
         auspice_config = lambda w: config["builds"][w.build_name]["auspice_config"] if "auspice_config" in config["builds"][w.build_name] else config["files"]["auspice_config"],
         colors = lambda w: config["builds"][w.build_name]["colors"] if "colors" in config["builds"][w.build_name] else ( config["files"]["colors"] if "colors" in config["files"] else rules.colors.output.colors.format(**w) ),

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -641,7 +641,9 @@ rule adjust_metadata_regions:
     output:
         metadata = "results/{build_name}/metadata_adjusted.tsv.xz"
     params:
-        region = lambda wildcards: config["builds"][wildcards.build_name]["region"]
+        # Default to a "global" region if none is defined. The adjust metadata
+        # script will not modify the metadata if the region is "global".
+        region = lambda wildcards: config["builds"][wildcards.build_name].get("region", "global")
     log:
         "logs/adjust_metadata_regions_{build_name}.txt"
     benchmark:


### PR DESCRIPTION
## Description of proposed changes

Replaces calls to unified metadata (or metadata-by-wildcards) with an explicit path to the subsampled metadata from the final subsampling filter step. The subsampled metadata should be substantially smaller than the full unified metadata, so the rules modified in this commit should all run correspondingly faster.

The use of the full metadata was a holdover from earlier versions of the workflow that did not produce a subsampled metadata. The use of the full metadata in the rules modified here was an oversight of mine when I added the subsampled metadata output.

## Related issue(s)

Fixes #654

## Testing

 - [x] CI build
 - [x] Nextstrain builds on SLURM cluster ("europe", "global", and "africa")
 - [x] [Trial Nextstrain builds on AWS](https://github.com/nextstrain/ncov/runs/2787879453?check_suite_focus=true)

## Release checklist

This is a bug fix.