### PR TITLE
Dynamically calculate min_date for frequencies

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -115,7 +115,9 @@ ancestral:
 
 # Frequencies settings
 frequencies:
-  min_date: 2020.0
+
+  # min_date is set by default to 1 year before present
+  # but can be explicitly set if desired
 
   # Number of months between pivots
   pivot_interval: 1

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -3,6 +3,10 @@
 As of April 2021, we use major version numbers (e.g. v2) to reflect backward incompatible changes to the workflow that likely require you to update your Nextstrain installation.
 We also use this change log to document new features that maintain backward compatibility, indicating these features by the date they were added.
 
+## New features since last version update
+
+ - 18 June 2021: Change default behavior of frequency estimation to estimate frequencies starting 1 year prior to the current date. To override this default behavior, define a `min_date` in the `frequencies` section of the builds configuration. ([#659](https://github.com/nextstrain/ncov/pull/659))
+
 ## v7 (27 May 2021)
 
 For more details about this release, see [the configuration reference for the new "sanitize metadata" parameters](https://nextstrain.github.io/ncov/configuration.html#sanitize_metadata) and [the corresponding pull request](https://github.com/nextstrain/ncov/pull/640).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,7 +227,7 @@ Builds support any named attributes that can be referenced by subsampling scheme
 ### min_date
 * type: float or string
 * description: Earliest date to estimate frequencies for. Dates can be numeric floating point values (e.g., `2019.74`) or ISO 8601-style strings (e.g., `2019-10-01`).
-* default: `2020.0`
+* default: without value supplied, defaults to 1 year before present
 
 ### pivot_interval
 * type: integer

--- a/my_profiles/example/my_auspice_config.json
+++ b/my_profiles/example/my_auspice_config.json
@@ -109,6 +109,7 @@
   "panels": [
     "tree",
     "map",
-    "entropy"
+    "entropy",
+    "frequencies"
   ]
 }

--- a/my_profiles/getting_started/builds.yaml
+++ b/my_profiles/getting_started/builds.yaml
@@ -30,3 +30,7 @@ builds:
 files:
   auspice_config: "my_profiles/example/my_auspice_config.json"
   description: "my_profiles/example/my_description.md"
+
+frequencies:
+  min_date: 2020-01-01
+  max_date: 2020-05-15

--- a/nextstrain_profiles/nextstrain/subsampling_ranges.smk
+++ b/nextstrain_profiles/nextstrain/subsampling_ranges.smk
@@ -4,11 +4,11 @@ import datetime
 today = datetime.date.today()
 
 # Set the earliest date to roughly 4 months ago (18 weeks).
-early_late_cuotff = today - datetime.timedelta(weeks=18)
+early_late_cutoff = today - datetime.timedelta(weeks=18)
 
 for build in config["subsampling"]:
     for scheme in config["subsampling"][build]:
         if "_early" in scheme:
-            config["subsampling"][build][scheme]["max_date"] = f"--max-date {early_late_cuotff.strftime('%Y-%m-%d')}"
+            config["subsampling"][build][scheme]["max_date"] = f"--max-date {early_late_cutoff.strftime('%Y-%m-%d')}"
         if "_late" in scheme:
-            config["subsampling"][build][scheme]["min_date"] = f"--min-date {early_late_cuotff.strftime('%Y-%m-%d')}"
+            config["subsampling"][build][scheme]["min_date"] = f"--min-date {early_late_cutoff.strftime('%Y-%m-%d')}"

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -132,6 +132,16 @@ def _get_sampling_bias_correction_for_wildcards(wildcards):
     else:
         return config["traits"]["default"]["sampling_bias_correction"]
 
+def _get_min_date_for_frequencies(wildcards):
+    if "frequencies" in config and "min_date" in config["frequencies"]:
+        return config["frequencies"]["min_date"]
+    else:
+        # If not explicitly specified, default to 1 year back from the present
+        min_date_cutoff = datetime.date.today() - datetime.timedelta(weeks=52)
+        return numeric_date(
+            min_date_cutoff
+        )
+
 def _get_max_date_for_frequencies(wildcards):
     if "frequencies" in config and "max_date" in config["frequencies"]:
         return config["frequencies"]["max_date"]

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1061,7 +1061,7 @@ rule tip_frequencies:
     benchmark:
         "benchmarks/tip_frequencies_{build_name}.txt"
     params:
-        min_date = config["frequencies"]["min_date"],
+        min_date = _get_min_date_for_frequencies,
         max_date = _get_max_date_for_frequencies,
         pivot_interval = config["frequencies"]["pivot_interval"],
         pivot_interval_units = config["frequencies"]["pivot_interval_units"],


### PR DESCRIPTION
## Description of proposed changes

By default, use 1 year before present for `min_date` value for frequencies estimates. This serves to emphasize more recent dynamics. If desired, some other `min_date` can be explicitly set in the build config.

## Testing

Testing has been performed locally. Resulting build output can be seen at: https://nextstrain.org/staging/restrict-frequencies/ncov/global

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/change_log.md` in this pull request to document these changes by the date they were added.

