### PR TITLE
Enable priorities to be fetched from file

### DIFF
--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -5,6 +5,7 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+ - 22 June 2021: Add the ability to specify subsampling via a `priorities.tsv` file. To use, set the `priorities > type: file` and add `priorities > file: path/to/priorities.tsv` to your build's `subsampling` schema. `priorities.tsv` contains `strain name\tarbitrary numerical value`. Higher values = higher priority. ([#664](https://github.com/nextstrain/ncov/pull/664))
  - 18 June 2021: Change default behavior of frequency estimation to estimate frequencies starting 1 year prior to the current date. To override this default behavior, define a `min_date` in the `frequencies` section of the builds configuration. ([#659](https://github.com/nextstrain/ncov/pull/659))
 
 ## v7 (27 May 2021)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -612,8 +612,9 @@ Each named subsampling scheme supports the following attributes that the workflo
 
 ### priorities
 * type: object
-* description: Parameters to prioritize strains selected for the current subsampling rule. Currently, the workflow only supports one `type` of priority which is `proximity`. The proximity-based priority requires an additional reference to the rule in the current subsampling scheme whose sequences should be used to calculate genetic proximity.
-* examples:
+* description: Parameters to prioritize strains selected for the current subsampling rule. Currently, the workflow supports two `type`s of priority, `proximity` and `file`.
+* description [proximity]: `proximity` selects samples that are genetically similar to the `focus` sample set; the `focus` sample set must be a rule in the current subsampling scheme.
+* example [proximity]:
 ```yaml
 subsampling:
   my-scheme:
@@ -627,6 +628,25 @@ subsampling:
       priorities:
         type: proximity
         focus: my-first-rule
+```
+* description [file]: `file` selects samples based on arbitrarily-defined rankings in a TSV file formatted as `strain\tnumber`. The numbers are only used to sort the samples, and are therefore arbitrary. Higher values = higher priority.
+
+* example [file]:
+```yaml
+subsampling:
+  my-scheme:
+    my-first-rule:
+      max_sequences: 10
+      group_by: "country"
+      priorities:
+        type: "file"
+        file: "path/to/priorities.tsv"
+```
+
+```
+hCoV-19/USA/CZB-1234/2021	8.2
+hCoV-19/USA/CZB-2345/2021	0
+hCoV-19/USA/CZB-3456/2021	-3.1
 ```
 
 ## title

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -283,9 +283,13 @@ def get_priorities(wildcards):
 
 def get_priority_argument(wildcards):
     subsampling_settings = _get_subsampling_settings(wildcards)
+    if "priorities" not in subsampling_settings:
+        return ""
 
-    if "priorities" in subsampling_settings and subsampling_settings["priorities"]["type"] == "proximity":
+    if subsampling_settings["priorities"]["type"] == "proximity":
         return "--priority " + get_priorities(wildcards)
+    elif subsampling_settings["priorities"]["type"] == "file" and "file" in subsampling_settings["priorities"]:
+        return "--priority " + subsampling_settings["priorities"]["file"]
     else:
         return ""
 


### PR DESCRIPTION
## Description of proposed changes

Currently, there's not a great way to specify a `priorities.tsv` file from within the `builds.yaml`. This small PR enables one to specify a priorities file like so:

```
## within builds.yaml
subsampling:
  test_subsampling_schema:
    test_subsampling_schema_tier:
      group_by: "country"
      max_sequences: 5
      priorities:
        type: "file"
        file: "my_profiles/example/priorities.tsv"
```

This is useful for many situations. For example, I'm currently trying to define a build that prioritizes samples based on a combination of their collection date and their submission date, which isn't currently possible without being able to load in a `priorities.tsv` for one particular `subsampling_schema_tier`. 


## Related issue(s)
I ended up needing this one on the fly and thought it would be useful upstream for other folks. I don't see a current issue open for it, though. Would love any and all feedback you have! 

<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Fixes #
Related to #

## Testing

What steps should be taken to test the changes you've proposed? 
**NOTE: I included two demo files here to make testing easy, but will remove them before merge.**
Ran builds using a demo dataset, configured as above. Also ran a vanilla `getting_started` build (w/o a priorities file). Both worked as expected :)

If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
