### PR TITLE
Update clades and emerging lineages

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -108,3 +108,13 @@ clade	gene	site	alt
 21F (Iota)	nuc	20262	G
 21F (Iota)	nuc	21575	T
 21F (Iota)	nuc	22320	G
+
+21G (Lambda)	nuc	21786	T
+21G (Lambda)	nuc	21789	T
+21G (Lambda)	nuc	22917	A
+21G (Lambda)	nuc	23031	C
+
+21H	nuc	11451	G
+21H	nuc	13057	T
+21H	nuc	17491	T
+21H	nuc	19035	C

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -14636,12 +14636,15 @@ clade_membership	21C (Epsilon)
 clade_membership	21D (Eta)
 clade_membership	21E (Theta)
 clade_membership	21F (Iota)
+clade_membership	21G (Lambda)
+clade_membership	21H
 
 ################
 
 
 emerging_lineage	A.23.1
 emerging_lineage	B.1.1.7 (Alpha)
+emerging_lineage	B.1.1.318
 emerging_lineage	B.1.1.519
 emerging_lineage	B.1.351 (Beta)
 emerging_lineage	B.1.427/429 (Epsilon)
@@ -14652,7 +14655,8 @@ emerging_lineage	B.1.617.2 (Delta)
 emerging_lineage	B.1.619
 emerging_lineage	B.1.620
 emerging_lineage	B.1.621
-emerging_lineage	C.37
+emerging_lineage	C.36.3
+emerging_lineage	C.37 (Lambda)
 emerging_lineage	P.1 (Gamma)
 emerging_lineage	P.3 (Theta)
 
@@ -14660,13 +14664,9 @@ emerging_lineage	P.3 (Theta)
 
 
 pango_lineage	A
-pango_lineage	A.1
 pango_lineage	A.2
-pango_lineage	A.2.1
 pango_lineage	A.2.2
-pango_lineage	A.2.3
 pango_lineage	A.2.4
-pango_lineage	A.2.5
 pango_lineage	A.2.5.1
 pango_lineage	A.2.5.2
 pango_lineage	A.3
@@ -14696,6 +14696,7 @@ pango_lineage	A.25
 pango_lineage	A.26
 pango_lineage	A.27
 pango_lineage	A.28
+pango_lineage	A.29
 pango_lineage	AA.1
 pango_lineage	AA.2
 pango_lineage	AA.3
@@ -14737,6 +14738,10 @@ pango_lineage	AQ.2
 pango_lineage	AS.1
 pango_lineage	AS.2
 pango_lineage	AT.1
+pango_lineage	AU.1
+pango_lineage	AU.2
+pango_lineage	AU.3
+pango_lineage	AV.1
 pango_lineage	B
 pango_lineage	B.1
 pango_lineage	B.1.1
@@ -15205,6 +15210,8 @@ pango_lineage	B.1.1.517
 pango_lineage	B.1.1.518
 pango_lineage	B.1.1.519
 pango_lineage	B.1.1.521
+pango_lineage	B.1.1.522
+pango_lineage	B.1.1.523
 pango_lineage	B.1.2
 pango_lineage	B.1.3
 pango_lineage	B.1.3.1
@@ -15727,6 +15734,7 @@ pango_lineage	B.1.350.1
 pango_lineage	B.1.351
 pango_lineage	B.1.351.1
 pango_lineage	B.1.351.2
+pango_lineage	B.1.351.3
 pango_lineage	B.1.352
 pango_lineage	B.1.353
 pango_lineage	B.1.355
@@ -15946,7 +15954,6 @@ pango_lineage	B.1.549
 pango_lineage	B.1.550
 pango_lineage	B.1.551
 pango_lineage	B.1.552
-pango_lineage	B.1.553
 pango_lineage	B.1.554
 pango_lineage	B.1.555
 pango_lineage	B.1.556
@@ -16007,7 +16014,6 @@ pango_lineage	B.1.604
 pango_lineage	B.1.605
 pango_lineage	B.1.606
 pango_lineage	B.1.607
-pango_lineage	B.1.608
 pango_lineage	B.1.609
 pango_lineage	B.1.610
 pango_lineage	B.1.611
@@ -16024,6 +16030,8 @@ pango_lineage	B.1.618
 pango_lineage	B.1.619
 pango_lineage	B.1.620
 pango_lineage	B.1.621
+pango_lineage	B.1.622
+pango_lineage	B.1.623
 pango_lineage	B.2.1
 pango_lineage	B.2.6
 pango_lineage	B.2.10
@@ -16183,6 +16191,7 @@ pango_lineage	W.1
 pango_lineage	W.2
 pango_lineage	W.3
 pango_lineage	W.4
+pango_lineage	XA
 pango_lineage	Y.1
 pango_lineage	Z.1
 

--- a/defaults/emerging_lineages.tsv
+++ b/defaults/emerging_lineages.tsv
@@ -16,6 +16,11 @@ B.1.1.7 (Alpha)	nuc	23063	T
 B.1.1.7 (Alpha)	nuc	14676	T
 B.1.1.7 (Alpha)	nuc	15279	T
 
+B.1.1.318	nuc	21846	T
+B.1.1.318	nuc	24382	T
+B.1.1.318	nuc	25276	A
+B.1.1.318	nuc	26767	C
+
 B.1.1.519	nuc	22995	A
 B.1.1.519	nuc	10954	T
 B.1.1.519	nuc	22995	A
@@ -73,10 +78,15 @@ B.1.621	nuc	13057	T
 B.1.621	nuc	17491	T
 B.1.621	nuc	19035	C
 
-C.37	nuc	21786	T
-C.37	nuc	21789	T
-C.37	nuc	22917	A
-C.37	nuc	23031	C
+C.36.3	nuc	17743	A
+C.36.3	nuc	22016	A
+C.36.3	nuc	23329	A
+C.36.3	nuc	24257	T
+
+C.37 (Lambda)	nuc	21786	T
+C.37 (Lambda)	nuc	21789	T
+C.37 (Lambda)	nuc	22917	A
+C.37 (Lambda)	nuc	23031	C
 
 P.1 (Gamma)	nuc	733	C
 P.1 (Gamma)	nuc	2749	T

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -5,6 +5,7 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+ - 27 June 2021: Update clade definitions with 21G (Lambda, C.37) emerging from Peru and 21H (B.1.621) emerging from Colombia.
  - 22 June 2021: Add the ability to specify subsampling via a `priorities.tsv` file. To use, set the `priorities > type: file` and add `priorities > file: path/to/priorities.tsv` to your build's `subsampling` schema. `priorities.tsv` contains `strain name\tarbitrary numerical value`. Higher values = higher priority. ([#664](https://github.com/nextstrain/ncov/pull/664))
  - 18 June 2021: Change default behavior of frequency estimation to estimate frequencies starting 1 year prior to the current date. To override this default behavior, define a `min_date` in the `frequencies` section of the builds configuration. ([#659](https://github.com/nextstrain/ncov/pull/659))
 


### PR DESCRIPTION
## Description of proposed changes

This updates:
- clades to include 21G / C.37 / Lambda emerging from Peru and 21H / B.1.621 emerging from Colombia
- emerging lineages to include B.1.1.318 and C.36.3
- updates `pango_lineage` color ordering with fresh pull from cov-lineages.org

Example outputs can be seen at:
- [Global](https://nextstrain.org/staging/clades-lineages-update/ncov/global)
- [Africa](https://nextstrain.org/staging/clades-lineages-update/ncov/africa)
- [Asia](https://nextstrain.org/staging/clades-lineages-update/ncov/asia)
- [Europe](https://nextstrain.org/staging/clades-lineages-update/ncov/europe)
- [North America](https://nextstrain.org/staging/clades-lineages-update/ncov/north-america)
- [Oceania](https://nextstrain.org/staging/clades-lineages-update/ncov/oceania)
- [South America](https://nextstrain.org/staging/clades-lineages-update/ncov/south-america)

## Related issue(s)

Replaces #672

## Testing

This was run on top of latest run of `master` branch. Changes are unlikely to break workflow and review should be focused on whether clade / emerging lineages definitions are suitable.

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/change_log.md` in this pull request to document these changes by the date they were added.
