### PR TITLE
fix: clade definition of 21E is too restrictive

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -118,3 +118,4 @@ clade	gene	site	alt
 21H	nuc	17491	T
 21H	nuc	21995	A
 21H	nuc	21993	C
+21H	nuc	22599	A

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -98,7 +98,6 @@ clade	gene	site	alt
 21D (Eta)	nuc	24748	T
 
 21E (Theta)	nuc	12049	T
-21E (Theta)	nuc	22356	G
 21E (Theta)	nuc	23341	C
 21E (Theta)	nuc	23604	A
 21E (Theta)	nuc	24187	A

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -116,4 +116,5 @@ clade	gene	site	alt
 21H	nuc	11451	G
 21H	nuc	13057	T
 21H	nuc	17491	T
-21H	nuc	19035	C
+21H	nuc	21995	A
+21H	nuc	21993	C


### PR DESCRIPTION
the definition of clade 21E often only included a single sequence because of a mutation with patchy distribution. This PR deletes that position from the definition.