### PR TITLE
Update definition of clade 21A to remove nuc 24410

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -75,7 +75,6 @@ clade	gene	site	alt
 
 21A (Delta)	nuc	22917	G
 21A (Delta)	nuc	22995	A
-21A (Delta)	nuc	24410	A
 21A (Delta)	nuc	27638	C
 21A (Delta)	nuc	28881	T
 21A (Delta)	nuc	29402	T


### PR DESCRIPTION
## Description of proposed changes

Nucleotide 24410 is polymorphic within 21A within the current Africa regional builds. This is causing 21A to be pushed down substantially relative to desired placement.

Removing requirement for 24410 could open up misplacement of 21A down the road, but I believe this is the best solution at the moment to have correctly called clades.

## Testing

Tested locally with the latest AWS output.

Build outputs are available at:

- [Global](https://nextstrain.org/staging/fix-21A/ncov/global)
- [Africa](https://nextstrain.org/staging/fix-21A/ncov/africa)
- [Asia](https://nextstrain.org/staging/fix-21A/ncov/asia)
- [Europe](https://nextstrain.org/staging/fix-21A/ncov/europe)
- [North America](https://nextstrain.org/staging/fix-21A/ncov/north-america)
- [Oceania](https://nextstrain.org/staging/fix-21A/ncov/oceania)
- [South America](https://nextstrain.org/staging/fix-21A/ncov/south-america)