### PR TITLE
Remove Location as Geo Resolution - except N America

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/africa_auspice_config.json
@@ -120,7 +120,6 @@
     }
   ],
   "geo_resolutions": [
-    "location",
     "division",
     "country",
     "region"

--- a/nextstrain_profiles/nextstrain-gisaid/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/asia_auspice_config.json
@@ -120,7 +120,6 @@
     }
   ],
   "geo_resolutions": [
-    "location",
     "division",
     "country",
     "region"

--- a/nextstrain_profiles/nextstrain-gisaid/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/europe_auspice_config.json
@@ -120,7 +120,6 @@
     }
   ],
   "geo_resolutions": [
-    "location",
     "division",
     "country",
     "region"

--- a/nextstrain_profiles/nextstrain-gisaid/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/global_auspice_config.json
@@ -120,7 +120,6 @@
     }
   ],
   "geo_resolutions": [
-    "location",
     "division",
     "country",
     "region"

--- a/nextstrain_profiles/nextstrain-gisaid/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/oceania_auspice_config.json
@@ -120,7 +120,6 @@
     }
   ],
   "geo_resolutions": [
-    "location",
     "division",
     "country",
     "region"

--- a/nextstrain_profiles/nextstrain-gisaid/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/south-america_auspice_config.json
@@ -120,7 +120,6 @@
     }
   ],
   "geo_resolutions": [
-    "location",
     "division",
     "country",
     "region"


### PR DESCRIPTION

As per discussion in the Slack, we are stopping curation of `location` for everywhere except North America. This is a field that in many places in the world corresponds to City, so is quite labour-intensive to curate and often only sporadically available. 

Because we won't be standardizing and adding new lat-long values for `location`, this PR removes `location` as a geographic resolution (so it won't be possible to view it on the map). However, it remains as a color-by and filter and none of the previous curation work is lost.

For any build, this can be re-enabled by simply adding `location` back to the list of geo-resolutions in the config file. 

In North America, since `location` is county, we are leaving this in for the time being, and will continue to curate this.

This is untested.
