### PR TITLE
Infer compression for downloaded sequence data

### DIFF
--- a/docs/remote_inputs.md
+++ b/docs/remote_inputs.md
@@ -135,12 +135,11 @@ The following table summarises the current situation:
 
 |            | local (uncompressed)  | local (compressed)| remote (uncompressed) | remote (compressed)|
 | ---        | ---                   | ---               | ---                   | ---               |
-| sequences  |  ✅                   |  ✅                |  ❌  <sup>1</sup>     |  ✅  <sup>2</sup> |
-| metadata   |  ✅                   |  ✅                |  ✅                   |  ✅  <sup>3</sup> |
-| aligned    |  ✅                   |  ✅                |  ✅                   |  ✅  <sup>3</sup> |
-| masked     |  ✅                   |  ✅                |  ✅                   |  ✅  <sup>3</sup> |
-| filtered   |  ✅                   |  ✅                |  ✅                   |  ✅  <sup>3</sup> |
+| sequences  |  ✅                   |  ✅                |  ✅                   |  ✅  <sup>1</sup> |
+| metadata   |  ✅                   |  ✅                |  ✅                   |  ✅  <sup>2</sup> |
+| aligned    |  ✅                   |  ✅                |  ✅                   |  ✅  <sup>1</sup> |
+| masked     |  ✅                   |  ✅                |  ✅                   |  ✅  <sup>1</sup> |
+| filtered   |  ✅                   |  ✅                |  ✅                   |  ✅  <sup>1</sup> |
 
-1. Download succeeds but `.xz` suffix is appended which causes errors downstream in the pipeline.
-2. File is downloaded with a `.xz` suffix, but gzip compression will still work!
-3. Decompressed during download.
+1. Compression suffix (e.g. `.xz`, `.gz`) is not part of the filename after downloading. Compression must be inferred by inspecting the file contents.
+2. Decompressed during download.

--- a/tests/different-inputs.t
+++ b/tests/different-inputs.t
@@ -54,7 +54,7 @@ Test various input starting points, all from local uncompressed files
 
   $ rm -rf tests/output/results tests/local-inputs-uncompressed/data/*.fasta tests/local-inputs-uncompressed/data/*.tsv
 
-Test various input starting points which support remote uncompressed files (this is a subset of available inputs)
+Test various input starting points which support remote uncompressed files
 
   $ snakemake --directory tests/output  --profile tests/remote-inputs-uncompressed \
   > auspice/ncov_test-remote-uncompressed.json >tests/output/remote-inputs-uncompressed.cram.log.txt 2>&1

--- a/tests/remote-inputs-uncompressed/builds.yaml
+++ b/tests/remote-inputs-uncompressed/builds.yaml
@@ -1,6 +1,7 @@
 inputs:
-  # NOTE: there is no input defining an uncompressed `sequences` address
-  # as this pipeline only supports compressed sequence input
+  - name: test-remote-uncompressed-asia-sequences
+    metadata: s3://nextstrain-data/files/ncov/test-data/asia_metadata.tsv
+    sequences: s3://nextstrain-data/files/ncov/test-data/asia_sequences.fasta
   - name: test-remote-uncompressed-europe-aligned
     metadata: s3://nextstrain-data/files/ncov/test-data/europe_metadata.tsv
     aligned: s3://nextstrain-data/files/ncov/test-data/europe_aligned.fasta
@@ -10,9 +11,6 @@ inputs:
   - name: test-remote-uncompressed-americas-filtered
     metadata: s3://nextstrain-data/files/ncov/test-data/americas_metadata.tsv
     filtered: s3://nextstrain-data/files/ncov/test-data/americas_filtered.fasta
-  - name: reference
-    metadata: data/references_metadata.tsv
-    sequences: data/references_sequences.fasta
 
 # As we are not including the test data from Asia (see above), this build will
 # be missing the default root sequence. We instead use

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -55,7 +55,7 @@ def _get_path_for_input(stage, origin_wildcard):
     if stage=="sequences":
         if not path_or_url:
             raise Exception(f"ERROR: config->input->{origin_wildcard}->sequences is not defined.")
-        return f"data/downloaded_{origin_wildcard}.fasta.gz" if remote else path_or_url
+        return f"data/downloaded_{origin_wildcard}.fasta" if remote else path_or_url
     if stage=="aligned":
         if remote:
             return f"results/precomputed-aligned_{origin_wildcard}.fasta"

--- a/workflow/snakemake_rules/download.smk
+++ b/workflow/snakemake_rules/download.smk
@@ -33,7 +33,7 @@ def _infer_decompression(input):
 rule download_sequences:
     message: "Downloading sequences from {params.address} -> {output.sequences}"
     output:
-        sequences = "data/downloaded_{origin}.fasta.gz"
+        sequences = "data/downloaded_{origin}.fasta"
     conda: config["conda_environment"]
     params:
         address = lambda w: config["inputs"][w.origin]["sequences"],
@@ -62,10 +62,9 @@ rule download_aligned:
     conda: config["conda_environment"]
     params:
         address = lambda w: config["inputs"][w.origin]["aligned"],
-        deflate = lambda w: _infer_decompression(config["inputs"][w.origin]["aligned"])
     shell:
         """
-        aws s3 cp {params.address} - | {params.deflate} > {output.sequences:q}
+        aws s3 cp {params.address} {output.sequences:q}
         """
 
 
@@ -76,10 +75,9 @@ rule download_masked:
     conda: config["conda_environment"]
     params:
         address = lambda w: config["inputs"][w.origin]["masked"],
-        deflate = lambda w: _infer_decompression(config["inputs"][w.origin]["masked"])
     shell:
         """
-        aws s3 cp {params.address} - | {params.deflate} > {output.sequences:q}
+        aws s3 cp {params.address} {output.sequences:q}
         """
 
 
@@ -90,8 +88,7 @@ rule download_filtered:
     conda: config["conda_environment"]
     params:
         address = lambda w: config["inputs"][w.origin]["filtered"],
-        deflate = lambda w: _infer_decompression(config["inputs"][w.origin]["filtered"])
     shell:
         """
-        aws s3 cp {params.address} - | {params.deflate} > {output.sequences:q}
+        aws s3 cp {params.address} {output.sequences:q}
         """


### PR DESCRIPTION
Downloading of sequence data ("sequences", "masked",
"aligned" and "filtered" remote inputs) used an inconsistent approach
which caused errors in certain situations.

(1) "sequences" were downloaded by `rule download_sequences` with no
attempt to decompress the data, but the resulting output always ended in
`.gz`. This file was read by `scripts/sanitize_sequences.py` which
uses `xopen` [1] to read the file. Xopen uses the file suffix to infer
the compression algorithm, and thus failed when the file used xz
compression [2], or no compression at all, with errors similar to
`OSError: Not a gzipped file (b'\xfd7')`.

Here we change the rule to save downloaded "sequences" inputs with only
a `.fasta` suffix, regardless of whether compression is used. This
forces xopen to infer the compression used from the file contents, thus
allowing various compression algorithms to be used (as well as
uncompressed remote inputs). Note that our open (GenBank) sequences
input (via `ncov-ingest`) is XZ compressed.

(2) When "masked", "aligned" and "filtered" remote inputs were
specified, these were decompressed during download, and saved with a
".fasta" suffix. All the scripts / augur commands which read this data
use xopen internally, and so we can avoid decompressing these files.
This results in large space savings: currently the open (GenBank)
"aligned" input is 35MB xz compressed and 24GB decompressed! We still
decompress remote metadata inputs as these are read by
`scripts/sanitize_metadata.py` which uses `pd.read_csv` which does not
infer compression from file contents.

The tests have been expanded to cover uncompressed inputs, and the
documentation has been updated accordingly.

[1] https://github.com/pycompression/xopen

[2] Note that this error did not occur on MacOS (where xopen would read
a `.gz` file which used xz compression). The error was observed in our 
AWS jobs (Linux).

## Testing

Successful AWS run using `nextstrain-open` profile. 

Tests pass for me (MacOS). It would be good for a linux user to run them as well (`cram --preserve-env tests/different-inputs.t`)

## Release checklist


 - [ ] Update `docs/change_log.md` in this pull request to document these changes by the date they were added.

