### PR TITLE
Update deploy bucket for nextstrain-open profile

### DIFF
--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -108,7 +108,7 @@ refine:
   root: "Wuhan-Hu-1/2019"
 
 # Deploy and Slack options are related to Nextstrain live builds and don't need to be modified for local builds
-deploy_url: s3://nextstrain-staging
+deploy_url: s3://nextstrain-data
 slack_token: ~
 slack_channel: "#ncov-genbank-updates"
 


### PR DESCRIPTION
A recent AWS run completed successfully from the `nextstrain-open` profile, but the `deploy_url` hadn't been updated so the datasets ended up on the staging bucket, e.g. https://nextstrain.org/staging/ncov/open/global

Will merge immediately.
