### PR TITLE
upload-to-s3: Drop Content-Encoding from object metadata

### DIFF
--- a/scripts/upload-to-s3
+++ b/scripts/upload-to-s3
@@ -32,7 +32,7 @@ main() {
 
     if [[ $src_hash != "$dst_hash" ]]; then
         echo "Uploading $src → $dst"
-        aws s3 cp --no-progress "$src" "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")""$(content-encoding "$dst")"
+        aws s3 cp --no-progress "$src" "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")"
 
         if [[ $quiet == 1 ]]; then
             echo "Quiet mode. No Slack notification sent."
@@ -48,19 +48,14 @@ main() {
 }
 
 content-type() {
-    case "${1%.gz}" in
+    case "$1" in
         *.tsv)      echo --content-type=text/tab-separated-values;;
         *.csv)      echo --content-type=text/comma-separated-values;;
         *.ndjson)   echo --content-type=application/x-ndjson;;
         *.json)     echo --content-type=application/json;;
+        *.gz)       echo --content-type=application/gzip;;
+        *.xz)       echo --content-type=application/x-xz;;
         *)          echo --content-type=text/plain;;
-    esac
-}
-
-content-encoding() {
-    case "$1" in
-        *.gz) echo " --content-encoding=gzip";;
-        *.xz) echo " --content-encoding=xz";;
     esac
 }
 


### PR DESCRIPTION
This avoids the field being sent as an HTTP header, which causes most
HTTP clients to automatically decompress the content.  The automatic
decompression is useful if piping directly to another process, but
pretty confusing when downloading because the filename still retains the
.gz extension but the file isn't compressed!  This confuses both
browser-based downloads and the Broad's mirroring of S3 to GCP Storage.

Additionally, as Ivan and others have noted, ~no HTTP clients support
Content-Encoding: xz, even though we were setting it and the bulk of our
files are xz-compressed now.
