### PR TITLE
Set global recursion limit for shell commands

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -12,6 +12,10 @@ from collections import OrderedDict
 import textwrap
 import time
 
+# Set the maximum recursion limit globally for all shell commands, to avoid
+# issues with large trees crashing the workflow.
+shell.prefix("export AUGUR_RECURSION_LIMIT=10000; ")
+
 # Store the user's configuration prior to loading defaults, so we can check for
 # reused subsampling scheme names in the user's config. We need to make a deep
 # copy because Snakemake will deep merge the subsampling dictionary later,

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1194,7 +1194,7 @@ rule export:
     conda: config["conda_environment"]
     shell:
         """
-        export AUGUR_RECURSION_LIMIT=10000 && augur export v2 \
+        augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata} \
             --node-data {input.node_data} \


### PR DESCRIPTION
## Description of proposed changes

Instead of setting the recursion limit for individual rules as issues with maximum recursion occur, we set the recursion limit as an environment variable prefixed to all shell commands in the workflow. This approach allows us to control the limit with a single variable and affect the entire workflow.

## Related issue(s)

Fixes #689

## Testing

 - [x] Tested by CI

## Release checklist

This is a minor change.