### PR TITLE
Find clusters of closely related strains

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -170,6 +170,8 @@ logistic_growth:
 
 # Cluster-specific settings
 cluster:
+  # Require a minimum number of tips to be annotated as a cluster.
+  min_tips: 3
   # Find clusters per division.
   group_by: division
 

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -168,6 +168,11 @@ logistic_growth:
   min_frequency: 0.000001
   max_frequency: 0.95
 
+# Cluster-specific settings
+cluster:
+  # Find clusters per division.
+  group_by: division
+
 #
 # Region-specific settings
 #

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -172,7 +172,7 @@ logistic_growth:
 cluster:
   # Require a minimum number of tips to be annotated as a cluster.
   min_tips: 3
-  # Find clusters per division.
+  # Find clusters with the same values in the given column (e.g., division, country, etc.).
   group_by: division
 
 #

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -674,6 +674,11 @@ priorities:
 * type: object
 * description: Parameters for clustering of closely related strains
 
+### min_tips
+* type: integer
+* description: Number of tips to require in a polytomy to be considered part of a cluster.
+* default: `3`
+
 ### group_by
 * type: string
 * description: Metadata column whose values should be used to determine whether closely related strains should be assigned to the same cluster. For example, the default column ensures that strains belong to the same division to be considered part of the same cluster.

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -670,6 +670,15 @@ priorities:
 * type: string
 * description: Title to provide to `augur export` and display as the title of the analysis in Auspice.
 
+## cluster
+* type: object
+* description: Parameters for clustering of closely related strains
+
+### group_by
+* type: string
+* description: Metadata column whose values should be used to determine whether closely related strains should be assigned to the same cluster. For example, the default column ensures that strains belong to the same division to be considered part of the same cluster.
+* default: `division`
+
 ## traits
 * type: object
 * description: Parameters for inference of ancestral traits by `augur traits` with support for default traits and build-specific traits.

--- a/scripts/find_clusters.py
+++ b/scripts/find_clusters.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import argparse
+from augur.utils import read_tree, read_node_data, read_metadata, write_json
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Find polytomies in a given tree that all belong to the same metadata group",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--tree", required=True, help="Newick tree")
+    parser.add_argument("--metadata", required=True, help="metadata")
+    parser.add_argument("--mutations", required=True, help="mutations node data JSON")
+    parser.add_argument("--attribute-name", default="cluster_id", help="name of attribute to store in output JSON")
+    parser.add_argument("--group-by", default="division", help="identify polytomies where all tips are in the same group")
+    parser.add_argument("--min-tips", type=int, default=3, help="minimum tips per polytomy to be consider as a cluster")
+    parser.add_argument("--output-node-data", required=True, help="node data JSON with cluster id")
+
+    args = parser.parse_args()
+
+    tree = read_tree(args.tree)
+    tree.collapse_all(lambda c: c.branch_length < 1e-5)
+
+    metadata, columns = read_metadata(args.metadata)
+    muts = read_node_data(args.mutations)
+    attribute_name = args.attribute_name
+    group_by = args.group_by
+
+    polytomies = []
+    for node in tree.find_clades(terminal=False):
+        if node == tree.root:
+            continue
+
+        any_muts = False
+        groups = set()
+        children = 0
+        for child in node.clades:
+            if child.is_terminal() and child.name:
+                children += 1
+                any_muts |= (len(muts["nodes"].get(child.name, {}).get("muts", [])) > 0)
+                groups.add(metadata[child.name][group_by])
+
+        if not any_muts and children >= args.min_tips and len(groups) == 1:
+            polytomies.append(node)
+
+    node_data = {}
+    clusters = 0
+    for polytomy in polytomies:
+        if polytomy.name:
+            node_data[polytomy.name] = {
+                attribute_name: f"cluster_{clusters}",
+            }
+
+        for child in polytomy.clades:
+            if child.is_terminal():
+                node_data[child.name] = {
+                    attribute_name: f"cluster_{clusters}",
+                }
+
+        clusters += 1
+
+    write_json({"nodes": node_data}, args.output_node_data)

--- a/scripts/find_clusters.py
+++ b/scripts/find_clusters.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
             if polytomy.name:
                 writer.writerow({
                     "strain": polytomy.name,
-                    args.attribute_name: clusters,
+                    args.attribute_name: f"cluster_{clusters}",
                     group_by: metadata[polytomy.name][group_by]
                 })
 
@@ -68,7 +68,7 @@ if __name__ == "__main__":
                 if child.is_terminal():
                     writer.writerow({
                         "strain": child.name,
-                        args.attribute_name: clusters,
+                        args.attribute_name: f"cluster_{clusters}",
                         group_by: metadata[child.name][group_by]
                     })
 

--- a/scripts/find_clusters.py
+++ b/scripts/find_clusters.py
@@ -33,14 +33,14 @@ if __name__ == "__main__":
         if node == tree.root:
             continue
 
-        any_muts = False
         count_by_group = Counter()
         for child in node.clades:
             if child.is_terminal() and child.name:
-                any_muts |= (len(muts["nodes"].get(child.name, {}).get("muts", [])) > 0)
-                count_by_group[metadata[child.name][group_by]] += 1
+                any_muts = (len(muts["nodes"].get(child.name, {}).get("muts", [])) > 0)
+                if not any_muts:
+                    count_by_group[metadata[child.name][group_by]] += 1
 
-        if not any_muts and any(count >= args.min_tips for count in count_by_group.values()):
+        if any(count >= args.min_tips for count in count_by_group.values()):
             polytomies.append(node)
 
     with open(args.output, "w") as oh:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1231,6 +1231,31 @@ rule calculate_epiweeks:
             --output-node-data {output.node_data} 2>&1 | tee {log}
         """
 
+rule find_clusters:
+    input:
+        tree="results/{build_name}/tree_raw.nwk",
+        metadata="results/{build_name}/metadata_adjusted.tsv.xz",
+        mutations="results/{build_name}/nt_muts.json",
+    output:
+        node_data="results/{build_name}/clusters.json",
+    benchmark:
+        "benchmarks/find_clusters_{build_name}.txt",
+    log:
+        "logs/find_clusters_{build_name}.txt",
+    params:
+        group_by=config["cluster"]["group_by"],
+    resources:
+        mem_mb=12000,
+    shell:
+       """
+       python3 scripts/find_clusters.py \
+           --tree {input.tree} \
+           --metadata {input.metadata} \
+           --mutations {input.mutations} \
+           --group-by {params.group_by} \
+           --output-node-data {output.node_data}
+       """
+
 def export_title(wildcards):
     # TODO: maybe we could replace this with a config entry for full/human-readable build name?
     location_name = wildcards.build_name
@@ -1266,7 +1291,8 @@ def _get_node_data_by_wildcards(wildcards):
         rules.logistic_growth.output.node_data,
         rules.mutational_fitness.output.node_data,
         rules.distances.output.node_data,
-        rules.calculate_epiweeks.output.node_data
+        rules.calculate_epiweeks.output.node_data,
+        rules.find_clusters.output.node_data,
     ]
 
     if "run_pangolin" in config and config["run_pangolin"]:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1237,7 +1237,7 @@ rule find_clusters:
         metadata="results/{build_name}/metadata_adjusted.tsv.xz",
         mutations="results/{build_name}/nt_muts.json",
     output:
-        node_data="results/{build_name}/clusters.json",
+        clusters="results/{build_name}/clusters.tsv",
     benchmark:
         "benchmarks/find_clusters_{build_name}.txt",
     conda:
@@ -1255,7 +1255,7 @@ rule find_clusters:
            --metadata {input.metadata} \
            --mutations {input.mutations} \
            --group-by {params.group_by} \
-           --output-node-data {output.node_data}
+           --output {output.clusters}
        """
 
 def export_title(wildcards):
@@ -1294,7 +1294,6 @@ def _get_node_data_by_wildcards(wildcards):
         rules.mutational_fitness.output.node_data,
         rules.distances.output.node_data,
         rules.calculate_epiweeks.output.node_data,
-        rules.find_clusters.output.node_data,
     ]
 
     if "run_pangolin" in config and config["run_pangolin"]:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1240,6 +1240,8 @@ rule find_clusters:
         node_data="results/{build_name}/clusters.json",
     benchmark:
         "benchmarks/find_clusters_{build_name}.txt",
+    conda:
+        config["conda_environment"],
     log:
         "logs/find_clusters_{build_name}.txt",
     params:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1245,6 +1245,7 @@ rule find_clusters:
     log:
         "logs/find_clusters_{build_name}.txt",
     params:
+        min_tips=config["cluster"]["min_tips"],
         group_by=config["cluster"]["group_by"],
     resources:
         mem_mb=12000,
@@ -1254,6 +1255,7 @@ rule find_clusters:
            --tree {input.tree} \
            --metadata {input.metadata} \
            --mutations {input.mutations} \
+           --min-tips {params.min_tips} \
            --group-by {params.group_by} \
            --output {output.clusters}
        """


### PR DESCRIPTION
## Description of proposed changes

This PR is based on work from @josephfauver who has been manually curating cluster annotations for SARS-CoV-2 in Nebraska. This PR attempts to automate the initial discovery of potential clusters by identifying polytomies in a phylogeny such that each polytomy has at least N tips (N=3 by default) and at least N of those tips in the polytomy belong to the same group based on strain-specific values from a predefined metadata column.

By default, strains are grouped by values in the `division` column. Users can change this behavior by changing the parameter `group_by` parameter of the new `cluster` section of the workflow configuration (see docs update in this PR).

The workflow annotates clusters as a separate tab-separated file that includes strain, cluster id, and the value of the group column used to assign strains to the same group. Users can drag-and-drop this file onto their trees in Auspice to view the clusters. We expect users will want to manually curate clusters (e.g., merge or delete) based on their epidemiological insights, expertise, or PII data that isn't available to the clustering algorithm. Users can then merge these curated clusters into their main workflow metadata.

Note that the work proposed here would be much simpler for users if [the workflow could join multiple metadata files from a single named input](https://github.com/nextstrain/ncov/issues/698). For example, most users will likely want to:

1. curate GISAID metadata and sequences to build their tree
2. generate a tree and clusters from these data
3. review and curate clusters in the tree
4. re-run their analysis with the clusters joined into the original GISAID metadata on strain name

## TODO

 - [x] emit clusters in a TSV file instead of a node data JSON file
 - [x] allow clusters to include strains from other groups as long as the original group meets the minimum thresholds (i.e., allow clusters to grow in future builds without disappearing)
 - [x] compare clusters with [manually annotated clusters for the same tree](https://nextstrain.org/community/josephfauver/ncovNE@main/Build-13?c=Cluster_ID&label=clade:B.1.617.2)
 - [x] name clusters deterministically
 - ~generate clusters as a default output of the workflow~ (not a feature we want, after all)

## Testing

 - [x] CI
 - [x] Custom South Africa build
 - [x] [Custom Nebraska build](https://nextstrain.org/staging/ncov/nebraska)

## Additional context

Thank you to @BryanTegomoh for requesting this feature!