### PR TITLE
Dated freq file from hcov-19-d file

### DIFF
--- a/nextstrain_profiles/nextstrain-ci/builds.yaml
+++ b/nextstrain_profiles/nextstrain-ci/builds.yaml
@@ -33,6 +33,12 @@ subsampling:
         type: "proximity"
         focus: "region"
 
+# Override default frequency settings, so we can estimate frequencies from older
+# data with a fixed time range.
+frequencies:
+  min_date: 2020-01-01
+  max_date: 2020-05-10
+
 # Set CI-specific growth settings, such that the small tree still gets logistic
 # growth values and we properly test the growth calculations script.
 logistic_growth:

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -125,7 +125,7 @@ rule dated_json:
     message: "Copying dated Auspice JSON"
     input:
         auspice_json = rules.finalize.output.auspice_json,
-        tip_frequencies_json = rules.tip_frequencies.output.tip_frequencies_json
+        tip_frequencies_json = rules.include_hcov19_prefix.output.tip_frequencies
     output:
         dated_auspice_json = "auspice/{prefix}_{build_name}_{date}.json",
         dated_tip_frequencies_json = "auspice/{prefix}_{build_name}_{date}_tip-frequencies.json"


### PR DESCRIPTION
Date the copy of tip_frequencies that has been processed to add `hCoV-19`, rather than the unadjusted copy. Otherwise tips don't match & auspice can't display.

## Description of proposed changes

Frequencies broken for all dated builds since we switched to `gisaid` seem broken. 
https://nextstrain.org/ncov/gisaid/global/2021-08-04

Seems to be because tip's don't match - we are currently dating the non-`hCoV-19` adjusted file. This tries to fix that.

## Testing
 Untested!!! 

