### PR TITLE
Add metadata to nextstrain-open builds

### DIFF
--- a/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
@@ -19,6 +19,11 @@
       "type": "categorical"
     },
     {
+      "key": "pango_lineage",
+      "title": "PANGO Lineage",
+      "type": "categorical"
+    },
+    {
       "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
@@ -69,6 +69,16 @@
       "type": "categorical"
     },
     {
+      "key":"originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
       "key": "recency",
       "title": "Submission Date",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
@@ -19,6 +19,11 @@
       "type": "categorical"
     },
     {
+      "key": "pango_lineage",
+      "title": "PANGO Lineage",
+      "type": "categorical"
+    },
+    {
       "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
@@ -69,6 +69,16 @@
       "type": "categorical"
     },
     {
+      "key":"originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
       "key": "recency",
       "title": "Submission Date",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
@@ -19,6 +19,11 @@
       "type": "categorical"
     },
     {
+      "key": "pango_lineage",
+      "title": "PANGO Lineage",
+      "type": "categorical"
+    },
+    {
       "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
@@ -69,6 +69,16 @@
       "type": "categorical"
     },
     {
+      "key":"originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
       "key": "recency",
       "title": "Submission Date",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/global_auspice_config.json
@@ -19,6 +19,11 @@
       "type": "categorical"
     },
     {
+      "key": "pango_lineage",
+      "title": "PANGO Lineage",
+      "type": "categorical"
+    },
+    {
       "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/global_auspice_config.json
@@ -69,6 +69,16 @@
       "type": "categorical"
     },
     {
+      "key":"originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
       "key": "recency",
       "title": "Submission Date",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
@@ -19,6 +19,11 @@
       "type": "categorical"
     },
     {
+      "key": "pango_lineage",
+      "title": "PANGO Lineage",
+      "type": "categorical"
+    },
+    {
       "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
@@ -69,6 +69,16 @@
       "type": "categorical"
     },
     {
+      "key":"originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
       "key": "recency",
       "title": "Submission Date",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
@@ -19,6 +19,11 @@
       "type": "categorical"
     },
     {
+      "key": "pango_lineage",
+      "title": "PANGO Lineage",
+      "type": "categorical"
+    },
+    {
       "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
@@ -69,6 +69,16 @@
       "type": "categorical"
     },
     {
+      "key":"originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
       "key": "recency",
       "title": "Submission Date",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
@@ -19,6 +19,11 @@
       "type": "categorical"
     },
     {
+      "key": "pango_lineage",
+      "title": "PANGO Lineage",
+      "type": "categorical"
+    },
+    {
       "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"

--- a/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
@@ -69,6 +69,16 @@
       "type": "categorical"
     },
     {
+      "key":"originating_lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
+      "type": "categorical"
+    },
+    {
       "key": "recency",
       "title": "Submission Date",
       "type": "categorical"


### PR DESCRIPTION
## Description of proposed changes

Adds PANGO lineage, Submitting Lab and Originating Lab to nextstrain-open builds. The first of these was already present in the metadata via nextstrain/ncov-ingest@deba1d0. The latter 2 will be available once nextstrain/ncov-ingest#181 is merged. All three are already exported in nextstrain-gisaid builds. 

## Testing

Tested locally using [metadata](s3://nextstrain-staging/files/ncov/open/branch/genbank-biosample/metadata.tsv.gz) produced from nextstrain/ncov-ingest#181. 

## Release checklist

No updates to changelog needed. 
