### PR TITLE
Update unified_metadata comment

### DIFF
--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -57,8 +57,9 @@ def _get_unified_metadata(wildcards):
     """
     Returns a single metadata file representing the input metadata file(s).
     If there was only one supplied metadata file in the `config["inputs"] dict`,
-    then that file is returned. Else "results/combined_metadata.tsv" is returned
-    which will run the `combine_input_metadata` rule to make it.
+    then that file is run through `sanitize_metadata` and the new file name returned. 
+    Else "results/combined_metadata.tsv.xz" is returned which will run the 
+    `combine_input_metadata` rule (and `sanitize_metadata` rule) to make it.
     """
     if len(list(config["inputs"].keys()))==1:
         return "results/sanitized_metadata_{origin}.tsv.xz".format(origin=list(config["inputs"].keys())[0])


### PR DESCRIPTION
Description of `_get_unified_metadata` is outdated and doesn't reflect the 'sanitize' function. This updates to make it clearer what happens.