### PR TITLE
change: use `mamba` instead of `conda` consistently

### DIFF
--- a/docs/src/analysis/setup.md
+++ b/docs/src/analysis/setup.md
@@ -53,11 +53,11 @@ Update your environment regularly to the latest versions of these tools.
 
 ```bash
 # Update Conda and Mamba.
-conda update -n base conda mamba
+mamba update -n base conda mamba
 
 # Update tools in the Nextstrain environment.
 conda activate nextstrain
-conda update --all
+mamba update --all
 ```
 
 ## 2. Download the ncov workflow


### PR DESCRIPTION
## Description of proposed changes

Use `mamba` instead of `conda` consistently in the ncov tutorial here: https://docs.nextstrain.org/projects/ncov/en/latest/analysis/setup.html#update-the-nextstrain-environment

Right now, bash code for installation uses `mamba` but the update is still done through `conda`. This PR improves consistency by also using `mamba` for updates.