### PR TITLE
Add 26456T to Beta defining muts

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -56,6 +56,7 @@ clade	gene	site	alt
 20H (Beta, V2)	nuc	25563	T
 20H (Beta, V2)	nuc	23063	T
 20H (Beta, V2)	nuc	23012	A
+20H (Beta, V2)	nuc	26456	T
 
 20I (Alpha, V1)	nuc	8782	C
 20I (Alpha, V1)	nuc	14408	T


### PR DESCRIPTION
The clade-defining mutations for Beta also define Mu, with the exception of the first position (1059T).  However, in some circumstances (particularly Mu-focused builds), if any sequences in Mu have 1059T, then this can then be designated as "Beta" while "real Beta" is then unlabelled on the tree.

To minimise the risk of this, add another mutation to the definition of Beta so that it is unlikely to be called in the wrong place (particularly inside of Mu).