### PR TITLE
Preprocessing profiles

### DIFF
--- a/.github/workflows/preprocess-gisaid.yml
+++ b/.github/workflows/preprocess-gisaid.yml
@@ -1,0 +1,60 @@
+name: preprocess-gisaid
+
+on:
+  ## This workflow is intended to be run via a repository dispatch event sent from
+  ## https://github.com/nextstrain/ncov-ingest/blob/master/.github/workflows/fetch-and-ingest-gisaid-master.yml
+  repository_dispatch:
+    types:
+      - preprocess-gisaid
+  ## Manual running (via GitHub UI) is also be available, if needed, via workflow dispatch
+  workflow_dispatch:
+    inputs:
+      trial_name:
+        description: 'Short name to use as a prefix for the uploaded data. WARNING: without this we will overwrite the files in s3://nextstrain-ncov-private.'
+        required: false
+
+env:
+  S3_DST_BUCKET: ${{ github.event.inputs.trial_name && format('nextstrain-ncov-private/trial/{0}', github.event.inputs.trial_name) || 'nextstrain-ncov-private' }}
+
+
+jobs:
+  gisaid:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup
+      run: ./scripts/setup-github-workflow
+
+    - name: Launch preprocess build
+      run: |
+        set -x
+        nextstrain build \
+          --aws-batch \
+          --cpus 16 \
+          --detach \
+          --memory 14GiB \
+            . \
+            upload \
+            --set-threads align=16 \
+            --profile nextstrain_profiles/nextstrain-gisaid-preprocess \
+            --config S3_DST_BUCKET=${S3_DST_BUCKET} \
+        |& tee build-launch.log
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: Build info
+      run: |
+        echo "--> Preprocessed files will be uploaded as:"
+        echo "    s3://${S3_DST_BUCKET}/aligned.fasta.xz"
+        echo "    s3://${S3_DST_BUCKET}/masked.fasta.xz"
+        echo "    s3://${S3_DST_BUCKET}/filtered.fasta.xz"
+        echo "    s3://${S3_DST_BUCKET}/mutation-summary.tsv.xz"
+        echo
+        echo "--> Attach command"
+        tail -n1 build-launch.log
+        echo
+        JOBID=$( tail -n1 build-launch.log | sed -E 's/.+attach ([-a-f0-9]+).+/\1/' )
+        echo "--> View this job in the AWS console via"
+        echo "    https://console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/${JOBID}"

--- a/.github/workflows/preprocess-open.yml
+++ b/.github/workflows/preprocess-open.yml
@@ -1,0 +1,60 @@
+name: preprocess-open
+
+on:
+  ## This workflow is intended to be run via a repository dispatch event sent from
+  ## https://github.com/nextstrain/ncov-ingest/blob/master/.github/workflows/fetch-and-ingest-genbank-master.yml
+  repository_dispatch:
+    types:
+      - preprocess-open
+      - preprocess-genbank
+  ## Manual running (via GitHub UI) is also be available, if needed, via workflow dispatch.
+  workflow_dispatch:
+    inputs:
+      trial_name:
+        description: 'Short name to use as a prefix for the uploaded data. WARNING: without this we will overwrite the files in s3://nextstrain-data/files/ncov/open.'
+        required: false
+
+env:
+  S3_DST_BUCKET: ${{ github.event.inputs.trial_name && format('nextstrain-staging/files/ncov/open/trial/{0}', github.event.inputs.trial_name) || 'nextstrain-data/files/ncov/open' }}
+
+jobs:
+  open:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup
+      run: ./scripts/setup-github-workflow
+
+    - name: Launch preprocess build
+      run: |
+        set -x
+        nextstrain build \
+          --aws-batch \
+          --cpus 16 \
+          --detach \
+          --memory 14GiB \
+            . \
+            upload \
+            --set-threads align=16 \
+            --profile nextstrain_profiles/nextstrain-open-preprocess \
+            --config S3_DST_BUCKET=${S3_DST_BUCKET} \
+        |& tee build-launch.log
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    - name: Build info
+      run: |
+        echo "--> Preprocessed files will be uploaded as:"
+        echo "    s3://${S3_DST_BUCKET}/aligned.fasta.xz"
+        echo "    s3://${S3_DST_BUCKET}/masked.fasta.xz"
+        echo "    s3://${S3_DST_BUCKET}/filtered.fasta.xz"
+        echo "    s3://${S3_DST_BUCKET}/mutation-summary.tsv.xz"
+        echo
+        echo "--> Attach command"
+        tail -n1 build-launch.log
+        echo
+        JOBID=$( tail -n1 build-launch.log | sed -E 's/.+attach ([-a-f0-9]+).+/\1/' )
+        echo "--> View this job in the AWS console via"
+        echo "    https://console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/${JOBID}"

--- a/nextstrain_profiles/nextstrain-gisaid-preprocess/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid-preprocess/builds.yaml
@@ -1,0 +1,22 @@
+custom_rules:
+  - workflow/snakemake_rules/export_for_nextstrain.smk
+
+# These parameters are only used by the `export_for_nextstrain` rule and shouldn't need to be modified.
+# To modify the s3 _source_ bucket, specify this directly in the `inputs` section of the config.
+# P.S. These are intentionally set as top-level keys as this allows command-line overrides.
+S3_DST_BUCKET: "nextstrain-ncov-private"
+S3_DST_COMPRESSION: "xz"
+S3_DST_ORIGINS: ["gisaid"]
+
+upload:
+  - preprocessing-files
+
+inputs:
+  - name: gisaid
+    metadata: "s3://nextstrain-ncov-private/metadata.tsv.gz"
+    sequences: "s3://nextstrain-ncov-private/sequences.fasta.xz"
+
+# Deploy and Slack options are related to Nextstrain live builds and don't need to be modified for local builds
+deploy_url: s3://nextstrain-data
+slack_token: ~
+slack_channel: "#ncov-gisaid-updates"

--- a/nextstrain_profiles/nextstrain-gisaid-preprocess/config.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid-preprocess/config.yaml
@@ -1,0 +1,10 @@
+configfile:
+  - defaults/parameters.yaml
+  - nextstrain_profiles/nextstrain-gisaid-preprocess/builds.yaml
+
+keep-going: True
+printshellcmds: True
+show-failed-logs: True
+restart-times: 1
+reason: True
+stats: stats.json

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -11,22 +11,19 @@ custom_rules:
 S3_DST_BUCKET: "nextstrain-ncov-private"
 S3_DST_COMPRESSION: "xz"
 S3_DST_ORIGINS: ["gisaid"]
+upload:
+  - build-files
 
 genes: ["ORF1a", "ORF1b", "S", "ORF3a", "E", "M", "ORF6", "ORF7a", "ORF7b", "ORF8", "N", "ORF9b"]
 use_nextalign: true
 
-# NOTE for shepherds -- there are commented out inputs here, you can
-# uncomment them to start the pipeline at that stage.
-# E.g. if you uncomment `filtered` then the pipeline
-# will start by downloading that file and proceeding straight to
-# subsampling
+# Note: we have a separate profile for aligning GISAID sequences. This is triggered
+# as soon as new sequences are available. This workflow is thus intended to be
+# started from the filtered alignment.                        james, sept 2021
 inputs:
   - name: gisaid
     metadata: "s3://nextstrain-ncov-private/metadata.tsv.gz"
-    sequences: "s3://nextstrain-ncov-private/sequences.fasta.xz"
-    # aligned: "s3://nextstrain-ncov-private/aligned.fasta.xz"
-    # masked: "s3://nextstrain-ncov-private/masked.fasta.xz"
-    # filtered: "s3://nextstrain-ncov-private/filtered.fasta.xz"
+    filtered: "s3://nextstrain-ncov-private/filtered.fasta.xz"
 
 # Define locations for which builds should be created.
 # For each build we specify a subsampling scheme via an explicit key.

--- a/nextstrain_profiles/nextstrain-open-preprocess/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open-preprocess/builds.yaml
@@ -1,0 +1,22 @@
+custom_rules:
+  - workflow/snakemake_rules/export_for_nextstrain.smk
+
+# These parameters are only used by the `export_for_nextstrain` rule and shouldn't need to be modified.
+# To modify the s3 _source_ bucket, specify this directly in the `inputs` section of the config.
+# P.S. These are intentionally set as top-level keys as this allows command-line overrides.
+S3_DST_BUCKET: "nextstrain-data/files/ncov/open"
+S3_DST_COMPRESSION: "xz"
+S3_DST_ORIGINS: ["open"]
+
+upload:
+  - preprocessing-files
+
+inputs:
+  - name: open
+    metadata: "s3://nextstrain-data/files/ncov/open/metadata.tsv.gz"
+    sequences: "s3://nextstrain-data/files/ncov/open/sequences.fasta.xz"
+
+# Deploy and Slack options are related to Nextstrain live builds and don't need to be modified for local builds
+deploy_url: s3://nextstrain-data
+slack_token: ~
+slack_channel: "#ncov-genbank-updates"

--- a/nextstrain_profiles/nextstrain-open-preprocess/config.yaml
+++ b/nextstrain_profiles/nextstrain-open-preprocess/config.yaml
@@ -1,0 +1,10 @@
+configfile:
+  - defaults/parameters.yaml
+  - nextstrain_profiles/nextstrain-open-preprocess/builds.yaml
+
+keep-going: True
+printshellcmds: True
+show-failed-logs: True
+restart-times: 1
+reason: True
+stats: stats.json

--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -11,19 +11,16 @@ custom_rules:
 S3_DST_BUCKET: "nextstrain-data/files/ncov/open"
 S3_DST_COMPRESSION: "xz"
 S3_DST_ORIGINS: ["open"]
+upload:
+  - build-files
 
-# NOTE for shepherds -- there are commented out inputs here, you can
-# uncomment them to start the pipeline at that stage.
-# E.g. if you uncomment `filtered` then the pipeline
-# will start by downloading that file and proceeding straight to
-# subsampling
+# Note: we have a separate profile for aligning open sequences. This is triggered
+# as soon as new sequences are available. This workflow is thus intended to be
+# started from the filtered alignment.                        james, sept 2021
 inputs:
   - name: open
     metadata: "s3://nextstrain-data/files/ncov/open/metadata.tsv.gz"
-    sequences: "s3://nextstrain-data/files/ncov/open/sequences.fasta.xz"
-    # aligned: "s3://nextstrain-data/files/ncov/open/aligned.fasta.xz"
-    # masked: "s3://nextstrain-data/files/ncov/open/masked.fasta.xz"
-    # filtered: "s3://nextstrain-data/files/ncov/open/filtered.fasta.xz"
+    filtered: "s3://nextstrain-data/files/ncov/open/filtered.fasta.xz"
 
 # Define locations for which builds should be created.
 # For each build we specify a subsampling scheme via an explicit key.

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -61,3 +61,12 @@ properties:
       type: string
       # A similar pattern is used in the workflow's wildcard constraints.
       pattern: "^[a-zA-Z0-9-]+$"
+
+  upload:
+    type: array
+    minItems: 1
+    items:
+      type: string
+      enum:
+        - preprocessing-files
+        - build-files

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -152,15 +152,16 @@ def _get_upload_inputs(wildcards):
     origin = config["S3_DST_ORIGINS"][0]
 
     # mapping of remote → local filenames
-    uploads = {
+    preprocessing_files = {
         f"aligned.fasta.xz":              f"results/aligned_{origin}.fasta.xz",              # from `rule align`
         f"masked.fasta.xz":               f"results/masked_{origin}.fasta.xz",               # from `rule mask`
         f"filtered.fasta.xz":             f"results/filtered_{origin}.fasta.xz",             # from `rule filter`
         f"mutation-summary.tsv.xz":       f"results/mutation_summary_{origin}.tsv.xz",       # from `rule mutation_summary`
     }
 
+    build_files = {}
     for build_name in config["builds"]:
-        uploads.update({
+        build_files.update({
             f"{build_name}/sequences.fasta.xz": f"results/{build_name}/{build_name}_subsampled_sequences.fasta.xz",   # from `rule combine_samples`
             f"{build_name}/metadata.tsv.xz":    f"results/{build_name}/{build_name}_subsampled_metadata.tsv.xz",      # from `rule combine_samples`
             f"{build_name}/aligned.fasta.xz":   f"results/{build_name}/aligned.fasta.xz",                             # from `rule build_align`
@@ -170,4 +171,13 @@ def _get_upload_inputs(wildcards):
             f"{build_name}/{build_name}_root-sequence.json":    f"auspice/{config['auspice_json_prefix']}_{build_name}_root-sequence.json"
         })
 
-    return uploads
+    req_upload = config.get("upload", [])
+    if "preprocessing-files" in req_upload and "build-files" in req_upload:
+        return {**preprocessing_files, **build_files}
+    elif "preprocessing-files" in req_upload:
+        return preprocessing_files
+    elif "build-files" in req_upload:
+        return build_files
+    else:
+        raise Exception("The upload rule requires an 'upload' parameter in the config.")
+

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -146,6 +146,7 @@ from os import environ
 
 SLACK_TOKEN   = environ["SLACK_TOKEN"]   = config["slack_token"]   or ""
 SLACK_CHANNEL = environ["SLACK_CHANNEL"] = config["slack_channel"] or ""
+BUILD_DESCRIPTION = f"Build to upload {' & '.join(config.get('upload', ['nothing']))}"
 
 try:
     deploy_origin = (
@@ -197,7 +198,7 @@ rule upload:
             shell("./scripts/upload-to-s3 {local:q} s3://{params.s3_bucket:q}/{remote:q} | tee -a {log:q}")
 
 onstart:
-    slack_message = f"Build {deploy_origin} started."
+    slack_message = f"{BUILD_DESCRIPTION} {deploy_origin} started."
 
     if SLACK_TOKEN and SLACK_CHANNEL:
         shell(f"""
@@ -210,7 +211,7 @@ onstart:
         """)
 
 onerror:
-    slack_message = f"Build {deploy_origin} failed."
+    slack_message = f"{BUILD_DESCRIPTION} {deploy_origin} failed."
 
     if SLACK_TOKEN and SLACK_CHANNEL:
         shell(f"""


### PR DESCRIPTION
This breaks each of our main nextstrain profiles into two profiles each - one to perform alignment (etc) and a second to run the phylogenetics. This is part of a wider effort to generate alignments as soon as new sequences are available.

**First commit**

Using GISAID as an example (also implemented for open, read the following but replace `gisaid` with `open` ):

The first profile `nextstrain_profiles/nextstrain-gisaid-preprocess` takes sequences and metadata and produces four files which we upload to S3,  `results/filtered_gisaid.fasta.xz`, `results/masked_gisaid.fasta.xz`, `mutation-summary.tsv.xz` and `results/aligned_gisaid.fasta.xz`.  While this is a separate profile, the  `builds.yaml` file is around a dozen lines of code.

The second profile, `nextstrain_profiles/nextstrain-gisaid` is relatively unchanged, except that we now start from `results/filtered_gisaid.fasta.xz` and thus should be much faster to run. Note that the `upload`  rule here will no longer upload the files which are now within the previous profile. Iit is still possible to start this workflow from (unaligned) sequences, however there should be no reason to do so.

Note that both profiles will run `rule sanitize_metadata`, as each depend on its output which is not uploaded as an intermediate file.

None of these changes should affect non-nextstrain-core builds / profiles.

**Second commit**

A GitHub action to allow the preprocessing profiles to be triggered once the relevant nextstrain/ncov-ingest workflows finish via a repository dispatch event. ~This commit is a WIP~


**Next steps**

- [x] Test preprocess profile on AWS - [In progress](https://console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/d04b02fa-0c95-4cd1-8ad9-ddff61e867fa)
- [x] Test (phylogenetic) build profiles - [In progress](https://console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/35d7d2c5-c495-4384-9374-6e95eedeab85)
- [x] Test this GitHub action (you should be able to use a POST request, [even on a branch](https://docs.github.com/en/rest/reference/repos#create-a-repository-dispatch-event), I think). _UPDATE: tested using a push event, which will now be removed_
- [x] Modify actions to upload to the correct S3 address & add a GISAID action
- [x] Test a range of nextalign runs with different numbers of threads to see how long this will take - _This is currently in progress_
- [x] Ensure alignment is comfortably within the 6h run time limit, else we need `--dispatch` _UPDATE: using --detach_
- [ ] Merge this PR
- [ ] Add the workflow dispatch REST calls to [fetch-and-ingest-genbank-master](https://github.com/nextstrain/ncov-ingest/blob/master/.github/workflows/fetch-and-ingest-genbank-master.yml) and [fetch-and-ingest-gisaid-master](https://github.com/nextstrain/ncov-ingest/blob/master/.github/workflows/fetch-and-ingest-gisaid-master.yml)
- [ ] (bonus) if the resulting builds which start from `filtered.fasta.xz` are comfortably within 6 hours, we can remove `--detach` from any actions which run those profiles. _UPDATE they take less than 3 hours_
- [ ] ??? Create rebuild actions in this repo which are either triggered via workflow dispatches or on a schedule
