### PR TITLE
Change coalescent method to constant

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -107,7 +107,7 @@ refine:
   root: "Wuhan/Hu-1/2019"
   clock_rate: 0.0008
   clock_std_dev: 0.0004
-  coalescent: "skyline"
+  coalescent: "opt"
   date_inference: "marginal"
   divergence_unit: "mutations"
   clock_filter_iqd: 4


### PR DESCRIPTION
## Description of proposed changes

As people begin to build bigger trees (>10,000 strains), more have reported a TreeTime error when the skyline optimization of the coalescent fails. TreeTime's error message recommends that users switch from the "skyline" coalescent model to the "opt" model that uses a constant coalescent rate instead of a piecewise linear rate.

Rather than ask users to update their config files each time this error occurs, we can safely change the default to "opt" in this commit.

## Testing

 - [ ] Test with CI

## Release checklist

This change does not require a new release or feature note.
