### PR TITLE
add submitters to footer filters;

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/africa_auspice_config.json
@@ -146,7 +146,10 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/asia_auspice_config.json
@@ -146,7 +146,10 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/europe_auspice_config.json
@@ -146,7 +146,10 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/global_auspice_config.json
@@ -146,7 +146,10 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/north-america_auspice_config.json
@@ -147,7 +147,10 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/oceania_auspice_config.json
@@ -146,7 +146,10 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/south-america_auspice_config.json
@@ -146,7 +146,10 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
@@ -113,7 +113,10 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
@@ -113,7 +113,10 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
@@ -113,7 +113,10 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/global_auspice_config.json
@@ -113,7 +113,10 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
@@ -113,7 +113,10 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
@@ -113,7 +113,10 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
@@ -113,7 +113,10 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "author",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",


### PR DESCRIPTION
adds `author`, `originating_lab`, `submitting_lab`
to footer filters for main nextstrain builds
so that we can link to this instead of trying
to find the submitters' handles on twitter.