### PR TITLE
Revert action through github interface

### DIFF
--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -1,0 +1,32 @@
+name: Revert nextstrain.org/ncov/gisaid or nextstrain.org/ncov/gisaid
+
+on:
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+    inputs:
+      build_name:
+        description: Which set of datasets on nextstrain.org/ncov to reset. "gisaid" or "open"
+        required: true
+      date:
+        description: Date to revert to. A corresponding set of date-stamped datasets must exist on the s3 bucket. Format is YYYY-MM-DD.
+        required: true
+
+env:
+  BUILD_NAME: ${{ github.event.inputs.build_name }}
+  DATE: ${{ github.event.inputs.date }}
+
+jobs:
+  revert:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup
+      run: ./scripts/setup-github-workflow
+
+    - name: Revert build
+      run: |
+        ./scripts/revert "$BUILD_NAME" "$DATE"
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/scripts/revert
+++ b/scripts/revert
@@ -1,0 +1,20 @@
+#!/bin/bash
+# build to revert. "gisaid" or "open".
+build=$1
+# date to revert to e.g. yesterday in "+%Y-%m-%d" format.
+date=$2
+
+regions=" \
+global \
+africa \
+asia \
+europe \
+north-america \
+oceania \
+south-america \
+"
+
+for region in $regions; do
+    aws s3 cp "s3://nextstrain-data/ncov_${build}_${region}_${date}.json" "s3://nextstrain-data/ncov_${build}_${region}.json" \
+    aws s3 cp "s3://nextstrain-data/ncov_${build}_${region}_${date}_tip-frequencies.json" "s3://nextstrain-data/ncov_${build}_${region}_tip-frequencies.json" \
+done


### PR DESCRIPTION
## Description of proposed changes

Creates a github action that allows those with permissions to run GH actions on this repository to revert either gisaid or open builds (all regions) to a given date-stamped set of builds on s3. Must be run through the github interface similar to how trial builds workflows work in this repo.

One thing I am not sure will work is running `aws s3` cli, since i'm not sure whether this gets installed as a dependency of `nextstrain-cli` in the setup step. We could use `nextstrain-cli` to perform the overwriting of datasets but I couldn't find a good analog for `aws s3 cp` in https://docs.nextstrain.org/projects/cli/en/stable/commands/; I guess we could do it by `nextstrain remote download`ing the desired date-stamped datasets and `nextstrain remote upload`ing them over the live datasets.

## Related issue(s)
This will be helpful once https://github.com/nextstrain/ncov-ingest/pull/212 and #730 are in place in case we don't catch problematic data in quality controls steps in the ncov workflow or need to revert to an old set of datasets on nextstrain.org for any reason.

## Testing

Untested. Could test running the script that the workflow runs but the workflow cannot be triggered until merged, unless we want to try triggering it by `push` and hardcoding some of the `input` values. 