### PR TITLE
Update GISAID guide URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We maintain a number of publicly-available builds, visible at [nextstrain.org/nc
 
 The hCoV-19 / SARS-CoV-2 genomes were generously shared via GISAID. We gratefully acknowledge the Authors, Originating and Submitting laboratories of the genetic sequence and metadata made available through GISAID on which this research is based.
 
-In order to download the GISAID data to run the analysis yourself, please see [this guide](https://nextstrain.github.io/ncov/data-prep).
+In order to download the GISAID data to run the analysis yourself, please see [this guide](https://docs.nextstrain.org/projects/ncov/en/latest/analysis/data-prep.html).
 > Please note that `data/metadata.tsv` is no longer included as part of this repo. However, we provide continually-updated, pre-formatted metadata & fasta files for download through GISAID.
 
 ## Read previous Situation Reports


### PR DESCRIPTION
https://nextstrain.github.io/ncov/data-prep now redirects to https://docs.nextstrain.org/projects/ncov/en/latest/analysis/data-prep.html
