### PR TITLE
docs: Replace orientation file tables with lists

### DIFF
--- a/docs/src/analysis/orientation-files.md
+++ b/docs/src/analysis/orientation-files.md
@@ -1,62 +1,47 @@
 # Overview of this repository (i.e., what do these files do?)
 
-The files in this repository fall into one of these categories:  
-* Input files  
-* Output files and directories  
-* Workflow configuration files we might want to customize  
-* Workflow configuration files we don't need to touch  
-* Documentation  
+The files in this repository fall into one of these categories:
+* Input files
+* Output files and directories
+* Workflow configuration files we might want to customize
+* Workflow configuration files we don't need to touch
+* Documentation
 
-We'll walk through all of the files one by one, but here are the most important ones for your reference:  
+We'll walk through all of the files one by one, but here are the most important ones for your reference:
 
-|Category| Directory | File | Description | Configuration|  
-|-----|-----|-----|------|-----|
-|Input file|`./data/`|`sequences.fasta`|**Genomic sequences; IDs must match `strain` column in `metadata.tsv`**| See ['Preparing your data'](data-prep.md)
-|Input file|`./data/`|`metadata.tsv`|**Tab-delimited description of strain (i.e., sample) attributes**|See ['Preparing your data'](data-prep.md)|
-|Output file|`./auspice/`|`buildName.json`|**Output file for visualization in auspice**||
-|Customizable workflow file|`./my_profiles/<mybuildname>/`|`builds.yaml`|**Define and parameterize all the builds you'd like to run**|See our [customization guide](customizing-analysis.md)|
+  * Input files
+    * `data/metadata.tsv`: tab-delimited description of strain (i.e., sample) attributes
+    * `data/sequences.fasta`: genomic sequences whose ids must match the `strain` column in `metadata.tsv`. [See the data preparation guide](data-prep.md).
+    * `my_profiles/<your_profile>/builds.yaml`: workflow configuration file where you can define and parameterize the builds you want to run. The directory name `your_profile` is the name of your custom analysis profile where you store this configuration and other custom files for the analysis. [See the customization guide](customizing-analysis.md).
+  * Output files
+    * `auspice/<build_name>.json`: output file for visualization in Auspice where `<build_name>` is the name of a build defined in the workflow configuration file.
 
+## Input files
 
------
+  * `data/metadata.tsv`: tab-delimited description of strain (i.e., sample) attributes
+  * `data/sequences.fasta`: genomic sequences whose ids must match the `strain` column in `metadata.tsv`. [See the data preparation guide](data-prep.md).
+  * `defaults/include.txt`: list of strain names to _include_ during subsampling and filtering (one strain name per line)
+  * `defaults/exclude.txt`: list of strain names to _exclude_ during subsampling and filtering (one strain name per line)
 
+## Output files and directories
 
-## Input files  
+  * `auspice/<build_name>.json`: output file for visualization in Auspice where `<build_name>` is the name of your build in the workflow configuration file.
+  * `results/aligned.fasta`, `results/masked.fasta`, etc.: raw results files (dependencies) that are shared across all builds.
+  * `results/<build_name>/`: raw results files (dependencies) that are specific to a single build.
+  * `logs/`: Log files with error messages and other information about the run.
+  * `benchmarks/`: Run-times (and memory usage on Linux systems) for each rule in the workflow.
 
-| Directory | File | Description | Configuration|  
-|-----|-----|-----|------|
-|`./data/`|`sequences.fasta`|**Genomic sequences; IDs must match `strain` column in `metadata.tsv`**| See ['Preparing your data'](data-prep.md)
-|`./data/`|`metadata.tsv`|**Tab-delimited description of strain (i.e., sample) attributes**|See ['Preparing your data'](data-prep.md)|
-|`./defaults/`|`include.txt`| List of strain names to _include_ during subsampling and filtering | One strain name per line|  
-|`./defaults/`|`exclude.txt`|List of strain names to _exclude_ during subsampling and filtering|One strain name per line|
+## Workflow configuration files we might want to customize
 
-
-## Output files and directories  
-
-| Directory | File | Description |
-|-----|-----|-----|
-|`./auspice/`|`buildName.json`|**Output file for visualization in auspice**|
-|`./results/`|`aligned.fasta`, `sequence-disagnostics.tsv`, etc.|Raw results files (dependencies) that are shared across all `builds`|
-|`./results/<buildName>/`|`tree.nwk`, `aa_mutations.json`, etc.|Raw results files (dependencies) that are specific to a single `build`|
-|`./logs/`|`.log` files|Error messages and other information about the run|
-
-
-## Workflow configuration files we might want to customize  
-
-| Directory | File | Description | Configuration |
-|-----|-----|-----|----|
-|`./my_profiles/<mybuildname>/builds.yaml`|**Define and configure all the builds you'd like to run**|See our [customization guide](customizing-analysis.md)|
-|`./my_profiles/<mybuildname>/config.yaml`|**Workflow configuration file; set the number of cores, etc.**|See our [customization guide](customizing-analysis.md)|
-|`./defaults/`|`parameters.yaml`|**Default analysis configuration file**|Override these settings in `./my_profiles/.../builds.yaml`|
-|`./defaults/`|`auspice_config.json`|**Default visualization configuration file**|Override these settings in `./my_profiles/.../auspice_config.yaml`|See our [customization guide](customizing-visualization.md)|
-
+  * `my_profiles/<your_profile>/builds.yaml`: workflow configuration file where you can define and configure all the builds you'd like to run. [See the customization guide](customizing-analysis.md).
+  * `my_profiles/<your_profile>/config.yaml`: [Snakemake profile configuration](https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles) where you can define the number of cores to use at once, etc. [See the customization guide](customizing-analysis.md).
+  * `defaults/parameters.yaml`: default workflow configuration parameters. Override these settings in the workflow configuration file (`builds.yaml`) above.
+  * `defaults/auspice_config.json`: default visualization configuration file. Override these settings in `my_profiles/<your_profile>/auspice_config.json`. [See the customization guide for visualizations](customizing-visualization.md).
 
 ## Workflow configuration files we don't need to touch
 
-| Directory | File | Description | Configuration|
-|-----|-----|-----|-----|
-|`./`|`Snakefile`|Entry point for `snakemake` commands; validates input.|No modification needed|
-|`./workflow/snakemake_rules/`|`main_workflow.smk`|Defines rules for running each step in the analysis|Modify your `builds.yaml` file, rather than hardcode changes into the snakemake file itself|
-|`./workflow/envs/`|`nextstrain.yaml`|Specifies computing environment needed to run workflow with the `--use-conda` flag|No modification needed|
-|`./workflow/schemas/`|`config.schema.yaml`|Defines format (e.g., required fields and types) for  `config.yaml` files.|Useful reference, but no modification needed.|
-|`./scripts/`| `add_priorities_to_meta.py`, etc.| Helper scripts for common tasks | No modification needed |
-
+  * `Snakefile`: entry point for Snakemake commands that also validates inputs. No modification needed.
+  * `workflow/snakemake_rules/main_workflow.smk`: defines rules for running each step in the analysis. Modify your `builds.yaml` file, rather than hardcode changes into the snakemake file itself.
+  * `workflow/envs/nextstrain.yaml`: specifies computing environment needed to run workflow with the `--use-conda` flag. No modification needed.
+  * `workflow/schemas/config.schema.yaml`: defines format (e.g., required fields and types) for  `builds.yaml` files. This can be a useful reference, but no modification needed.
+  * `scripts/`: helper scripts for common tasks. No modification needed.


### PR DESCRIPTION
## Description of proposed changes

Replaces tables of input, output, and other files with lists in the file orientation docs. In addition to fixing broken links that were not being properly rendered in Markdown, this change allows the user to see all of the content without scrolling. In the previous implementation, much of the table content was hidden on narrow displays and there was no visual indication that users should scroll.

This commit also corrects the content of this page, fixing some typos and adding links to external resources.

## Related issue(s)

Fixes #734 

## Testing

[RTD build by CI](https://nextstrain--744.org.readthedocs.build/projects/ncov/en/744/analysis/orientation-files.html).