### PR TITLE
Upload rule fails if the underlying script fails

### DIFF
--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -195,7 +195,7 @@ rule upload:
         "benchmarks/upload.txt"
     run:
         for remote, local in input.items():
-            shell("./scripts/upload-to-s3 {local:q} s3://{params.s3_bucket:q}/{remote:q} | tee -a {log:q}")
+            shell("set -o pipefail; ./scripts/upload-to-s3 {local:q} s3://{params.s3_bucket:q}/{remote:q} | tee -a {log:q}")
 
 onstart:
     slack_message = f"{BUILD_DESCRIPTION} {deploy_origin} started."


### PR DESCRIPTION
If the underlying script (upload-to-s3) failed, this exit code was
not being passed onto snakemake, instead we were getting the exit
code of `tee` (i.e. 0). This resulted in workflows appearing to succeed
but when looking deeper, the actual uploading failed.

This behaviour surprised me as the docs state that "shell commands in
Snakemake use the bash shell in strict mode by default." [1,2]

[1] https://snakemake.readthedocs.io/en/stable/project_info/faq.html?highlight=strict%20mode#id11
[2] https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html

This is in response to #748, however the problem may be more widespread than just this rule (snakemake rules use the shell throughout our workflows), so this PR may not close that issue.