### PR TITLE
Re-enable Bash's "strict mode" for shell commands run via Snakemake

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -13,8 +13,9 @@ import textwrap
 import time
 
 # Set the maximum recursion limit globally for all shell commands, to avoid
-# issues with large trees crashing the workflow.
-shell.prefix("export AUGUR_RECURSION_LIMIT=10000; ")
+# issues with large trees crashing the workflow.  Preserve Snakemake's default
+# use of Bash's "strict mode", as we rely on that behaviour.
+shell.prefix("set -euo pipefail; export AUGUR_RECURSION_LIMIT=10000; ")
 
 # Store the user's configuration prior to loading defaults, so we can check for
 # reused subsampling scheme names in the user's config. We need to make a deep


### PR DESCRIPTION
The introduction of a custom shell.prefix() in "Set global recursion
limit for shell commands" (06aaf0ca) inadvertently unset Snakemake's
default prefix of "set -euo pipefail".

The lack of strict mode (in particular pipefail) meant that workflow
rules were succeeding when we expected them to fail.

Resolves #748.

