### PR TITLE
Only emit a header for sanitized metadata once

### DIFF
--- a/scripts/sanitize_metadata.py
+++ b/scripts/sanitize_metadata.py
@@ -359,6 +359,7 @@ if __name__ == '__main__':
         id_columns=metadata_id_columns,
         chunk_size=args.metadata_chunk_size,
     )
+    emit_header = True
 
     with open_file(args.output, "w") as output_file_handle:
         for metadata in metadata_reader:
@@ -414,7 +415,9 @@ if __name__ == '__main__':
                 output_file_handle,
                 sep="\t",
                 index=False,
+                header=emit_header,
             )
+            emit_header = False
 
     # Delete the database/strain id mapping.
     os.unlink(database_ids_by_strain)

--- a/tests/sanitize-metadata.t
+++ b/tests/sanitize-metadata.t
@@ -4,11 +4,13 @@ Test script to sanitize metadata.
 
 Deduplicate metadata by strain name.
 Out of three records, two are duplicates, so only two records plus the header should be retained.
+Use a small chunk size to ensure sanitizing works over multiple loops through the metadata.
 
   $ python3 ../scripts/sanitize_metadata.py \
   >  --metadata unsanitized_metadata.tsv \
   >  --metadata-id-columns 'Virus name' strain \
   >  --database-id-columns gisaid_epi_isl genbank_accession \
+  >  --metadata-chunk-size 2 \
   >  --output "$TMP/metadata.tsv"
   $ wc -l "$TMP/metadata.tsv"
   \s*3 .* (re)


### PR DESCRIPTION
## Description of proposed changes

Track whether the header has already been emitted for the sanitized metadata, so subsequent calls to `to_csv` do not add headers to existing content.

## Related issue(s)

Fixes #750

## Testing

  - [x] Added a functional test that confirmed the original issue with test data.
  - [x] Tested fixed code on recent full GISAID metadata and confirmed the issue did not occur.
