### PR TITLE
Only notify slack on non-trial preprocessing actions

### DIFF
--- a/.github/workflows/preprocess-gisaid.yml
+++ b/.github/workflows/preprocess-gisaid.yml
@@ -40,7 +40,7 @@ jobs:
             --profile nextstrain_profiles/nextstrain-gisaid-preprocess \
             --config \
               S3_DST_BUCKET=${S3_DST_BUCKET} \
-              slack_token=${SLACK_TOKEN} \
+              ${{ github.event.inputs.trial_name && format('slack_token={0}', env.SLACK_TOKEN) || '' }} \
         |& tee build-launch.log
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/preprocess-open.yml
+++ b/.github/workflows/preprocess-open.yml
@@ -40,7 +40,7 @@ jobs:
             --profile nextstrain_profiles/nextstrain-open-preprocess \
             --config \
               S3_DST_BUCKET=${S3_DST_BUCKET} \
-              slack_token=${SLACK_TOKEN} \
+              ${{ github.event.inputs.trial_name && format('slack_token={0}', env.SLACK_TOKEN) || '' }} \
         |& tee build-launch.log
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
GitHub actions should not notify slack for trial runs where
the results won't update the "official" data locations.
