### PR TITLE
Stream sequences from tar archives

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,3 +1,4 @@
+import lzma
 from pathlib import Path
 import sys
 import tarfile
@@ -71,3 +72,59 @@ def extract_tar_file_contents(filename, filetype):
     # the temporary directory when its object is destroyed. For more details, see
     # https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory
     return temporary_dir, extracted_file_path
+
+
+def stream_tar_file_contents(filename, filetype):
+    """Try to extract the contents of a given file type (e.g., metadata or
+    sequences) from the given tar filename.
+
+    Parameters
+    ----------
+    filename : str or Path-like
+        Path to the tar archive to search for the given file type.
+    filetype : str
+        Type of file to search for in the given tar archive based on the
+        associated file extension.
+
+    Returns
+    -------
+    io.BufferedReader :
+        A stream of the requested file from the tar archive.
+    TarFile :
+        A handle to the original tar archive to be closed when the stream has
+        been read.
+
+    Raises
+    ------
+    FileNotFoundError :
+        When a file with the the requested file type's extension could not be
+        found in the given tar archive.
+
+    """
+    extension = EXTENSION_BY_FILETYPE[filetype]
+
+    tar = tarfile.open(filename)
+    internal_file = None
+    for member in tar.getmembers():
+        suffixes = Path(member.name).suffixes
+
+        if extension in suffixes:
+            # By default, return the binary stream for the member file.
+            internal_file = tar.extractfile(member.name)
+
+            if ".xz" in suffixes:
+                # Check for LZMA-compressed data and open these with the
+                # corresponding library.
+                internal_file = lzma.open(internal_file, "rt")
+            elif extension == ".fasta":
+                # For sequence data, handle decoding of the binary stream prior
+                # to passing the data back to the caller.
+                internal_file = (line.decode("utf-8") for line in internal_file)
+
+            break
+
+    if internal_file is None:
+        tar.close()
+        raise FileNotFoundError(f"Could not find a {filetype} file in '{filename}'")
+
+    return internal_file, tar


### PR DESCRIPTION
## Description of proposed changes

I recently modified how we read files from tar archives, extracting files to a temporary directory instead of streaming them from the archive. This approach allowed us to make multiple reads of the same input file for cases like metadata deduplication.

However, this approach also broke a key use case where users use a tar archive of GISAID sequences as an input to their workflows. Specifically, when users download the full GISAID sequence data, they receive a compressed tar archive of an uncompressed `sequences.fasta` file. If users pass this as input to the workflow, the sanitize sequences script will extract the entire uncompressed GISAID sequence file to the user's temporary directory. This is suboptimal, when the user only needs to stream the contents of the sequences into nextalign.

This commit effectively reverts the most recent change to `scripts/sanitize_sequences.py` by adding a function to `utils.py`, `stream_tar_file_contents`, that replicates the older behavior of streaming data from the tar archive. This function accompanies the newer version of `extract_tar_file_contents` that extracts the tar contents to a temporary directory, an approach we still need for metadata processing.

## Related issue(s)

Fixes #754

## Testing

 - [x] CI
 - [x] Functional tests locally
 - [x] Manual run of sanitize sequence script on recent GISAID tar archive of sequences
 - [x] Test with GISAID search and nextregions sequences
 - [x] Test with Nextstrain open build