### PR TITLE
Sanitize tar-based sequences with TextIOWrapper

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,3 +1,4 @@
+from io import TextIOWrapper
 import lzma
 from pathlib import Path
 import sys
@@ -119,7 +120,7 @@ def stream_tar_file_contents(filename, filetype):
             elif extension == ".fasta":
                 # For sequence data, handle decoding of the binary stream prior
                 # to passing the data back to the caller.
-                internal_file = (line.decode("utf-8") for line in internal_file)
+                internal_file = TextIOWrapper(internal_file)
 
             break
 


### PR DESCRIPTION
## Description of proposed changes

Replaces a generator that decodes the tarfile's binary io.BufferedReader stream with [Python's TextIOWrapper](https://docs.python.org/3/library/io.html#io.TextIOWrapper). This wrapper is Python's high-level interface to consume buffered binary streams like the io.BufferedReader. It provides a standard file-like interface including `read` and `peek` methods, etc.

This change simplifies FASTA-file handling for tar inputs, but it also fixes a bug that appears when using BioPython 1.79. Until recently, we have pinned BioPython to 1.76 or earlier, meaning our latest BioPython code dates back to December 2019. Since then, BioPython has rewritten its file handling interface to include more sophisticated error handling like [checking whether files are opened in text mode or not](https://github.com/biopython/biopython/blob/d72560fd78c8953f28c9add4f7bbbf8bd34293d2/Bio/SeqIO/Interfaces.py#L49). This error handling depends on the presence of a `read` method in the input source. The original implementation of the tarfile reader in this ncov script passed a generator to BioPython that then caused a `TypeError` when looking for the generator's nonexistent `read` method.

## Related issue(s)

Fixes #760

## Testing

 - [x] Tested locally with BioPython 1.76 and 1.79 on the full GISAID sequences file, GISAID search tar file, compressed non-tar files, and uncompressed non-tar files.
 - [x] Tested by CI
 - [x] Tested by cram