### PR TITLE
Set correct mode when opening temp file

### DIFF
--- a/scripts/sanitize_metadata.py
+++ b/scripts/sanitize_metadata.py
@@ -193,7 +193,7 @@ def get_database_ids_by_strain(metadata_file, metadata_id_columns, database_id_c
         observed_strains = set()
         duplicate_strains = set()
 
-    with NamedTemporaryFile(delete=False) as mapping_file:
+    with NamedTemporaryFile(delete=False, mode="wt", newline='') as mapping_file:
         mapping_path = mapping_file.name
         for metadata in metadata_reader:
             # Check for database id columns.


### PR DESCRIPTION
Fixes a bug I ran into where NamedTemporaryFile [1] was opened in the
default mode ("w+b") which resulted in an error when pandas attempted to
write to it (TypeError: a bytes-like object is required, not 'str').

[1] https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile


## Testing

  - [x] Tested with CI profile (`snakemake --profile nextstrain_profiles/nextstrain-ci/ --forceall -j 4`) 
  - [x] Tested with functional tests (`cram --shell=/bin/bash tests/sanitize-metadata.t`)