### PR TITLE
Improve log output for sanitized metadata errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 language: python
 python:
-  - "3.6"
+  - "3.9"
 install:
   - if [[ -n "${DOCKERHUB_TOKEN:-}" ]]; then docker login -u nextstrainbot --password-stdin <<<"$DOCKERHUB_TOKEN"; fi
   - pip3 install git+https://github.com/nextstrain/cli


### PR DESCRIPTION
## Description of proposed changes

Augur's `read_metadata` function can throw a generic Exception when the input is missing id columns. This exception is not easily distinguished from any other error, so we check the contents of the error message and raise a more specific error for better handling of unexpected errors. Specifically, when an unexpected error occurs, the user will get a full Python traceback in the log file instead of a generic "ERROR" with the exception message.

## Related issue(s)

Related to [this post on the Nextstrain discussion forum](https://discussion.nextstrain.org/t/sanitize-metadata-py-error-error-expected-after/807/5).

## Testing

- [x] Tested by CI
- [x] Tested with full GISAID metadata