### PR TITLE
Upgrade Python and the toolchain in GitHub Actions workflows

### DIFF
--- a/.github/workflows/preprocess-gisaid.yml
+++ b/.github/workflows/preprocess-gisaid.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
 
     - name: Setup
       run: ./scripts/setup-github-workflow

--- a/.github/workflows/preprocess-open.yml
+++ b/.github/workflows/preprocess-open.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
 
     - name: Setup
       run: ./scripts/setup-github-workflow

--- a/.github/workflows/rebuild-gisaid.yml
+++ b/.github/workflows/rebuild-gisaid.yml
@@ -26,6 +26,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
 
     - name: Setup
       run: ./scripts/setup-github-workflow

--- a/.github/workflows/rebuild-open.yml
+++ b/.github/workflows/rebuild-open.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
 
     - name: Setup
       run: ./scripts/setup-github-workflow

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
 
     - name: Setup
       run: ./scripts/setup-github-workflow

--- a/scripts/setup-github-workflow
+++ b/scripts/setup-github-workflow
@@ -4,6 +4,10 @@ set -euo pipefail
 # Adds $HOME/.local/bin to PATH for subsequent workflow steps (but not this one!).
 echo "$HOME/.local/bin" | tee -a "$GITHUB_PATH"
 
+echo "::group::Upgrade Python toolchain"
+python3 -m pip install --upgrade pip setuptools wheel
+echo "::endgroup::"
+
 echo "::group::Install nextstrain-cli"
 python3 -m pip install nextstrain-cli
 echo "::endgroup::"


### PR DESCRIPTION
Rationale the same as the corresponding change for Travis addressing the
same issue: "CI: Upgrade Python environment" (6a167de).

For good measure, also always ensure that the Python toolchain (pip,
setuptools, and wheel) are up-to-date before installing packages.