### PR TITLE
CI: Upgrade setuptools suite prior to installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 language: python
 python:
   - "3.9"
+before_install:
+  - python3 -m pip install --upgrade pip setuptools wheel
 install:
   - if [[ -n "${DOCKERHUB_TOKEN:-}" ]]; then docker login -u nextstrainbot --password-stdin <<<"$DOCKERHUB_TOKEN"; fi
   - pip3 install git+https://github.com/nextstrain/cli


### PR DESCRIPTION
## Description of proposed changes

Follows [recommended practice for new Python installations to ensure that pip, setuptools, and wheel are always upgraded](https://packaging.python.org/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date) regardless of the system-wide Python version.
