### PR TITLE
Rebuilds are no longer watched by actions

### DIFF
--- a/.github/workflows/rebuild-gisaid.yml
+++ b/.github/workflows/rebuild-gisaid.yml
@@ -50,6 +50,7 @@ jobs:
 
         nextstrain build \
           --aws-batch \
+          --detach \
           --cpus 36 \
           --memory 70GiB \
           . \
@@ -69,17 +70,21 @@ jobs:
         if [[ "$TRIAL_NAME" ]]; then
           echo "--> Trial name is: $TRIAL_NAME"
           echo
-          echo "--> Upload prefixes"
+          echo "--> When completed, the following will be available:"
           echo "build files: s3://nextstrain-ncov-private/trial/$TRIAL_NAME/"
           echo "nextstrain URLs: https://nextstrain.org/staging/ncov/gisaid/trial/$TRIAL_NAME/REGION_NAME"
         else
-          echo "--> GISAID phylogenetic analysis successfully rebuilt"
+          echo "--> GISAID phylogenetic analysis rebuilding on AWS"
           echo
-          echo "--> Uploaded data"
+          echo "--> When completed, the following will be updated:"
           echo "build files: s3://nextstrain-ncov-private/REGION_NAME/"
           echo "nextstrain URLs: https://nextstrain.org/ncov/gisaid/REGION_NAME"
         fi
         echo
-        echo "--> You can aso download assets from this (completed) AWS run via"
+        echo "--> You can attach to this AWS job via:"
         tail -n1 build-launch.log
+        echo
+        JOBID=$( tail -n1 build-launch.log | sed -E 's/.+attach ([-a-f0-9]+).+/\1/' )
+        echo "--> View this job in the AWS console via"
+        echo "    https://console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/${JOBID}"
         echo

--- a/.github/workflows/rebuild-open.yml
+++ b/.github/workflows/rebuild-open.yml
@@ -51,6 +51,7 @@ jobs:
 
         nextstrain build \
           --aws-batch \
+          --detach \
           --cpus 36 \
           --memory 70GiB \
           . \
@@ -70,17 +71,21 @@ jobs:
         if [[ "$TRIAL_NAME" ]]; then
           echo "--> Trial name is: $TRIAL_NAME"
           echo
-          echo "--> Upload prefixes"
+          echo "--> When completed, the following will be available:"
           echo "build files: s3://nextstrain-staging/files/ncov/open/trial/$TRIAL_NAME/"
           echo "nextstrain URLs: https://nextstrain.org/staging/ncov/open/trial/$TRIAL_NAME/REGION_NAME"
         else
-          echo "--> Open (GenBank) phylogenetic analysis successfully rebuilt"
+          echo "--> Open (GenBank) phylogenetic analysis rebuilding on AWS"
           echo
-          echo "--> Uploaded data"
+          echo "--> When completed, the following will be updated:"
           echo "build files: s3://nextstrain-data/files/ncov/open/REGION_NAME/"
           echo "nextstrain URLs: https://nextstrain.org/ncov/open/REGION_NAME"
         fi
         echo
-        echo "--> You can aso download assets from this (completed) AWS run via"
+        echo "--> You can attach to this AWS job via:"
         tail -n1 build-launch.log
+        echo
+        JOBID=$( tail -n1 build-launch.log | sed -E 's/.+attach ([-a-f0-9]+).+/\1/' )
+        echo "--> View this job in the AWS console via"
+        echo "    https://console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/${JOBID}"
         echo


### PR DESCRIPTION
We were running into the 6 hour timelimit for GitHub actions.
We now use the action to trigger the AWS job, and provide information
on how to attach to that / view it in the AWS console. This is the
same as the preprocessing jobs, which also exceed the time limits.

Here are the (GISAID) actions for the last two days which have exceeded 6 hours and thus been killed:
https://github.com/nextstrain/ncov/actions/runs/1440638013
https://github.com/nextstrain/ncov/actions/runs/1445459246

GenBank builds are only taking ~4 hours, but I think it's simpler if the behavior of each is the same.

## Testing

I'll trigger a GitHub action for GISAID now, which (if successful) will rebuild the canonical datasets.
Update: [this action](https://github.com/nextstrain/ncov/actions/runs/1447258764) completed successfully, and farmed the job out to AWS - [AWS console link](https://console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/4d33e4a3-79fe-4bb2-812c-74168bed16b1).

## Release checklist

Nothing needed

---

@joverlee521 / @victorlin would you take a look at this if possible - it should fix we observed on today's call. Thanks 🙏 
