### PR TITLE
Fix slack message sending in deploy rule

### DIFF
--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -167,21 +167,9 @@ rule deploy:
         deploy_url = config["deploy_url"]
     benchmark:
         "benchmarks/deploy.txt"
-    conda: config["conda_environment"]
-    shell:
-        """
-        nextstrain deploy {params.deploy_url:q} {input:q}
-
-        if [[ -n "$SLACK_TOKEN" && -n "$SLACK_CHANNEL" ]]; then
-            curl https://slack.com/api/chat.postMessage \
-                --header "Authorization: Bearer $SLACK_TOKEN" \
-                --form-string channel="$SLACK_CHANNEL" \
-                --form-string text={params.slack_message:q} \
-                --fail --silent --show-error \
-                --include
-        fi
-        """
-
+    run:
+        shell("nextstrain deploy {params.deploy_url:q} {input:q}")
+        send_slack_message(params.slack_message)
 
 rule upload:
     message: "Uploading intermediate files for specified origins to {params.s3_bucket}"


### PR DESCRIPTION
PR #782 implemented a `send_slack_message` function but forgot to
update `rule deploy` to use it. (It failed as the environment
variables it relied upon are are no longer surfaced by snakemake.)

