### PR TITLE
fix: gff parser was using old non-standard gff convention

### DIFF
--- a/scripts/mutation_summary.py
+++ b/scripts/mutation_summary.py
@@ -21,7 +21,7 @@ def read_reference(fname, genemap):
             start = int(entries[3])
             end = int(entries[4])
             strand = entries[6]
-            attributes = {x.split()[0]:' '.join(x.split()[1:]) for x in entries[8].split(';')}
+            attributes = {x.split()[0]:'='.join(x.split('=')[1:]) for x in entries[8].split(';')}
             if 'gene_name' in attributes:
                 name = attributes['gene_name'].strip('"')
             else:


### PR DESCRIPTION
The GFF in defaults was non-standard prior to the merge of the translation PR. The official GFF parser in biopython is broken atm. 
https://github.com/chapmanb/bcbb/issues/134

This should fix the parsing in mutation_summary.py -- but this is brittle and hacky
