### PR TITLE
export_for_nextstrain: Use a config "build_date"

### DIFF
--- a/.github/workflows/rebuild-gisaid.yml
+++ b/.github/workflows/rebuild-gisaid.yml
@@ -38,6 +38,7 @@ jobs:
         set -x
 
         declare -a config
+        config+=(build_date=$(date +'%Y-%m-%d'))
         if [[ "$TRIAL_NAME" ]]; then
           config+=(
             S3_DST_BUCKET=nextstrain-ncov-private/trial/"$TRIAL_NAME"

--- a/.github/workflows/rebuild-open.yml
+++ b/.github/workflows/rebuild-open.yml
@@ -39,6 +39,7 @@ jobs:
         set -x
 
         declare -a config
+        config+=(build_date=$(date +'%Y-%m-%d'))
         if [[ "$TRIAL_NAME" ]]; then
           config+=(
             S3_DST_BUCKET=nextstrain-staging/files/ncov/open/trial/"$TRIAL_NAME"

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -32,8 +32,8 @@ rule all_regions:
     input:
         auspice_json = expand("auspice/{prefix}_{build_name}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
         tip_frequencies_json = expand("auspice/{prefix}_{build_name}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
-        dated_auspice_json = expand("auspice/{prefix}_{build_name}_{date}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=get_todays_date()),
-        dated_tip_frequencies_json = expand("auspice/{prefix}_{build_name}_{date}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=get_todays_date())
+        dated_auspice_json = expand("auspice/{prefix}_{build_name}_{date}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date())),
+        dated_tip_frequencies_json = expand("auspice/{prefix}_{build_name}_{date}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date()))
 
 # This cleans out files to allow re-run of 'normal' run with `export`
 # to check lat-longs & orderings


### PR DESCRIPTION
~Use a config "build_date" instead of running a function within the
expand function to get the current date. This puts more burden on the
user to declare a build date but it ensures that the build date is
stable for the entire run of the build. This shouldn't be too much of a
burden on our normal operations since we add the "build_date" config to
the rebuild GitHub workflows.~

Use a config "build_date" if it's available, with the default being the
old behavior of running a function within the expand function to get the
current date. This allows users to define build date that is stable for
the entire run of the build. We add the "build_date" config to
the rebuild GitHub workflows to ensure that we don't run into missing
input file errors if a build runs over multiple days.

Fixes #788 