### PR TITLE
hotfix: disable dated builds

### DIFF
--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -31,9 +31,9 @@ def get_todays_date():
 rule all_regions:
     input:
         auspice_json = expand("auspice/{prefix}_{build_name}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
-        tip_frequencies_json = expand("auspice/{prefix}_{build_name}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
-        dated_auspice_json = expand("auspice/{prefix}_{build_name}_{date}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date())),
-        dated_tip_frequencies_json = expand("auspice/{prefix}_{build_name}_{date}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date()))
+        tip_frequencies_json = expand("auspice/{prefix}_{build_name}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES)
+        #dated_auspice_json = expand("auspice/{prefix}_{build_name}_{date}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date())),
+        #dated_tip_frequencies_json = expand("auspice/{prefix}_{build_name}_{date}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date()))
 
 # This cleans out files to allow re-run of 'normal' run with `export`
 # to check lat-longs & orderings
@@ -271,7 +271,7 @@ onstart:
     message.append("Further results will appear in this 🧵.")
     send_slack_message(". ".join(message))
 
-# onsuccess handler is executed if the workflow finished without error. 
+# onsuccess handler is executed if the workflow finished without error.
 onsuccess:
     message = "✅ This pipeline has successfully finished 🎉"
     send_slack_message(message)


### PR DESCRIPTION
Something went wrong with @joverlee521 fix...

```
[batch] MissingInputException in line 162 of /nextstrain/build/workflow/snakemake_rules/export_for_nextstrain.smk:
[batch] Missing input files for rule deploy:
[batch] auspice/ncov_gisaid_asia_1985.json
[batch] auspice/ncov_gisaid_north-america_1985_tip-frequencies.json
[batch] auspice/ncov_gisaid_asia_1985_tip-frequencies.json
[batch] auspice/ncov_gisaid_africa_1985.json
[batch] auspice/ncov_gisaid_south-america_1985.json
[batch] auspice/ncov_gisaid_europe_1985_tip-frequencies.json
[batch] auspice/ncov_gisaid_oceania_1985.json
[batch] auspice/ncov_gisaid_oceania_1985_tip-frequencies.json
[batch] auspice/ncov_gisaid_europe_1985.json
[batch] auspice/ncov_gisaid_global_1985_tip-frequencies.json
[batch] auspice/ncov_gisaid_south-america_1985_tip-frequencies.json
[batch] auspice/ncov_gisaid_north-america_1985.json
[batch] auspice/ncov_gisaid_global_1985.json
[batch] auspice/ncov_gisaid_africa_1985_tip-frequencies.json
[batch] + exited=1
```

i disabled the dated builds for now. 