### PR TITLE
fix rebuild workflows: quote build_date string

### DIFF
--- a/.github/workflows/rebuild-gisaid.yml
+++ b/.github/workflows/rebuild-gisaid.yml
@@ -38,7 +38,7 @@ jobs:
         set -x
 
         declare -a config
-        config+=(build_date=$(date +'%Y-%m-%d'))
+        config+=(build_date=\'$(date +'%Y-%m-%d')\')
         if [[ "$TRIAL_NAME" ]]; then
           config+=(
             S3_DST_BUCKET=nextstrain-ncov-private/trial/"$TRIAL_NAME"

--- a/.github/workflows/rebuild-open.yml
+++ b/.github/workflows/rebuild-open.yml
@@ -39,7 +39,7 @@ jobs:
         set -x
 
         declare -a config
-        config+=(build_date=$(date +'%Y-%m-%d'))
+        config+=(build_date=\'$(date +'%Y-%m-%d')\')
         if [[ "$TRIAL_NAME" ]]; then
           config+=(
             S3_DST_BUCKET=nextstrain-staging/files/ncov/open/trial/"$TRIAL_NAME"

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -31,9 +31,9 @@ def get_todays_date():
 rule all_regions:
     input:
         auspice_json = expand("auspice/{prefix}_{build_name}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
-        tip_frequencies_json = expand("auspice/{prefix}_{build_name}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES)
-        #dated_auspice_json = expand("auspice/{prefix}_{build_name}_{date}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date())),
-        #dated_tip_frequencies_json = expand("auspice/{prefix}_{build_name}_{date}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date()))
+        tip_frequencies_json = expand("auspice/{prefix}_{build_name}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
+        dated_auspice_json = expand("auspice/{prefix}_{build_name}_{date}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date())),
+        dated_tip_frequencies_json = expand("auspice/{prefix}_{build_name}_{date}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date()))
 
 # This cleans out files to allow re-run of 'normal' run with `export`
 # to check lat-longs & orderings


### PR DESCRIPTION
The date string is being interpreted as integers when passed through
the `nextstrain build` command to snakemake. Use double quotes and
escaped single quotes to ensure that the date string gets passed as a
proper string to the snakemake config.