### PR TITLE
Resolve duplicate records with ambiguous ids

### DIFF
--- a/tests/sanitize-metadata.t
+++ b/tests/sanitize-metadata.t
@@ -3,7 +3,7 @@ Test script to sanitize metadata.
   $ pushd "$TESTDIR" > /dev/null
 
 Deduplicate metadata by strain name.
-Out of three records, two are duplicates, so only two records plus the header should be retained.
+Out of 6 records, 2 are duplicates, so only 4 records plus the header should be retained.
 Use a small chunk size to ensure sanitizing works over multiple loops through the metadata.
 
   $ python3 ../scripts/sanitize_metadata.py \
@@ -13,7 +13,7 @@ Use a small chunk size to ensure sanitizing works over multiple loops through th
   >  --metadata-chunk-size 2 \
   >  --output "$TMP/metadata.tsv"
   $ wc -l "$TMP/metadata.tsv"
-  \s*3 .* (re)
+  \s*5 .* (re)
 
 Confirm that the duplicate record that we retained has the latest GISAID accession.
 
@@ -53,9 +53,10 @@ This should produce a warning about skipping duplicate resolution, an error abou
   >  --database-id-columns genbank_accession \
   >  --output "$TMP/metadata.tsv"
   WARNING: Skipping deduplication of metadata records. None of the possible database id columns (['genbank_accession']) were found in the metadata's columns ('Virus name', 'gender', 'date', 'gisaid_epi_isl')
-  ERROR: 1 strains have duplicate records. See 'unsanitized_metadata.tsv.duplicates.txt' for more details.
+  ERROR: 2 strains have duplicate records. See 'unsanitized_metadata.tsv.duplicates.txt' for more details.
   [1]
-  $ cat unsanitized_metadata.tsv.duplicates.txt
+  $ sort unsanitized_metadata.tsv.duplicates.txt
+  hCoV-19/LocalVirus/2/2021
   hCoV-19/OneVirus/1/2020
   $ rm -f unsanitized_metadata.tsv.duplicates.txt
 
@@ -67,9 +68,10 @@ Throw an error when metadata contain duplicates.
   >  --database-id-columns gisaid_epi_isl genbank_accession \
   >  --error-on-duplicate-strains \
   >  --output "$TMP/metadata.tsv"
-  ERROR: 1 strains have duplicate records. See 'unsanitized_metadata.tsv.duplicates.txt' for more details.
+  ERROR: 2 strains have duplicate records. See 'unsanitized_metadata.tsv.duplicates.txt' for more details.
   [1]
-  $ cat unsanitized_metadata.tsv.duplicates.txt
+  $ sort unsanitized_metadata.tsv.duplicates.txt
+  hCoV-19/LocalVirus/2/2021
   hCoV-19/OneVirus/1/2020
   $ rm -f unsanitized_metadata.tsv.duplicates.txt
 
@@ -78,7 +80,7 @@ Rename fields and strip prefixes.
   $ head -n 1 "unsanitized_metadata.tsv"
   Virus name\tgender\tdate\tgisaid_epi_isl (esc)
   $ grep "hCoV-19" "unsanitized_metadata.tsv" | wc -l
-  \s*2 (re)
+  \s*5 (re)
   $ grep "SARS-CoV-2" "unsanitized_metadata.tsv" | wc -l
   \s*1 (re)
   $ python3 ../scripts/sanitize_metadata.py \

--- a/tests/unsanitized_metadata.tsv
+++ b/tests/unsanitized_metadata.tsv
@@ -2,3 +2,6 @@ Virus name	gender	date	gisaid_epi_isl
 hCoV-19/OneVirus/1/2020	male	2020-10-01	EPI_ISL_1
 hCoV-19/OneVirus/1/2020	male	2020-10-01	EPI_ISL_2
 SARS-CoV-2/AnotherVirus/1/2021	female	2021-01-01	EPI_ISL_3
+hCoV-19/LocalVirus/2/2021	?	2021-12-01	?
+hCoV-19/LocalVirus/2/2021	?	2021-12-01	?
+hCoV-19/LocalVirus/3/2021	?	2021-12-02	?


### PR DESCRIPTION
## Description of proposed changes

Resolves two edge case bugs with duplicate resolution and a related bug
caused by metadata with unexpected newlines. The two edge cases that
were not previously handled were:

1. multiple strains have the same values in the given database id
fields (as when strains have the same missing values placeholder like
"?")

2. the same strain appears in the metadata multiple times with the same
database ids (as when a record was accidentally duplicated with
ambiguous database ids like "?")

This commit adds examples of these edge cases to the functional tests
metadata, updates the tests to match expectations for new records, and
corrects the sanitize metadata script's logic to handle these edge
cases. The solution includes three parts:

1. Merge mapping of "records to keep" with metadata on the strain name
field in addition to the database ids fields. This change handles the
case where multiple strains have the same ambiguous id(s).

2. Allow merge of mapping of "records to keep" with metadata to be
many-to-many and drop any remaining duplicate records by strain name.
This change handles the case when the same strain appears multiple times
in the same metadata chunk with ambiguous database ids.

3. Write out a new mapping of "records to keep" with each pass through
the `filter_duplicates` function, omitting all strains that were
processed in the current metadata chunk. This change allows the script
to drop duplicate records that appear in different metadata chunks.
The script could not know about these records from a single metadata
chunk and would otherwise emit duplicates that span multiple chunks.
This approach removes all processed strains when there are any
duplicates or the number of mappings doesn't match the number of strains
in the current chunk.

As a side effect of resolving these previously undocumented bugs, these
fixes also resolve #799 where unexpected newlines cause the "originating
lab" to appear in the strain name field with the same ambiguous database
id values.

## Related issue(s)

Fixes #799
Supersedes #800

## Testing

 - [x] Tested by CI
 - [x] Tested locally with Omicron metadata from GISAID
 - [x] Tested locally with full GISAID metadata from Nextstrain
 - [x] Tested locally with full open metadata from Nextstrain