### PR TITLE
wrap in conditional, provide extra else step

### DIFF
--- a/scripts/diagnostic.py
+++ b/scripts/diagnostic.py
@@ -78,11 +78,15 @@ if __name__ == '__main__':
     to_exclude |= np.abs(clock_deviation)>args.clock_filter_recent
     if check_recency:
         to_exclude |= (np.abs(clock_deviation)>args.clock_filter)&(~recent_sequences)
+        to_exclude |= (rare_mutations>args.rare_mutations)&(~recent_sequences)
+        to_exclude |= (np.abs(clock_deviation+rare_mutations)>args.clock_plus_rare)&(~recent_sequences)
+    else:
+        to_exclude |= (rare_mutations>args.rare_mutations)
+        to_exclude |= (np.abs(clock_deviation+rare_mutations)>args.clock_plus_rare)
     if check_clade_dates:
         to_exclude |= dates<clade_dates
     to_exclude |= snp_clusters>args.snp_clusters
-    to_exclude |= (rare_mutations>args.rare_mutations)&(~recent_sequences)
-    to_exclude |= (np.abs(clock_deviation+rare_mutations)>args.clock_plus_rare)&(~recent_sequences)
+
 
     if "QC_mixed_sites" in metadata.columns:
         to_exclude |= metadata.QC_mixed_sites=='bad'


### PR DESCRIPTION
## Description of proposed changes

Wrap in a conditional: 

```
if check_recency:
  to_exclude |= (rare_mutations>args.rare_mutations)&(~recent_sequences)
  to_exclude |= (np.abs(clock_deviation+rare_mutations)>args.clock_plus_rare)&(~recent_sequences)
```

Added an extra else statement. Someone, please let me know if I should delete the extra:

```
else:
  to_exclude |= (rare_mutations>args.rare_mutations)
  to_exclude |= (np.abs(clock_deviation+rare_mutations)>args.clock_plus_rare)
```

## Related issue(s)

Fixes #796 

## Testing

* Run a metadata file without the "date_submitted" column
* Let me know if I misunderstood the purpose of this diagnostic. It's possible we don't need the "else" section.
