### PR TITLE
update: change Omicron clade muts to include outliers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,10 @@ ehthumbs.db
 Thumbs.db
 *~
 
+# IDE generated files #
+######################
+.vscode/
+
 narratives/*pdf
 
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "restructuredtext.languageServer.disabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "restructuredtext.languageServer.disabled": true
-}

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -133,9 +133,7 @@ clade	gene	site	alt
 21J (Delta)	nuc	19220	T
 21J (Delta)	nuc	27874	T
 
-21K (Omicron)	nuc	8393	A
-21K (Omicron)	nuc	13195	C
-21K (Omicron)	nuc	18163	G
-21K (Omicron)	nuc	25000	T
+21K (Omicron)	nuc	23525	T
+21K (Omicron)	nuc	23599	G
+21K (Omicron)	nuc	24424	T
 21K (Omicron)	nuc	27259	C
-

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -146,3 +146,4 @@ clade	gene	site	alt
 21L	nuc	23599	G
 21L	nuc	24424	T
 21L	nuc	27259	C
+

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -133,7 +133,16 @@ clade	gene	site	alt
 21J (Delta)	nuc	19220	T
 21J (Delta)	nuc	27874	T
 
+21K (Omicron)	nuc	15240	T
+21K (Omicron)	nuc	23202	A
 21K (Omicron)	nuc	23525	T
 21K (Omicron)	nuc	23599	G
 21K (Omicron)	nuc	24424	T
 21K (Omicron)	nuc	27259	C
+
+21L	nuc	21618	T
+21L	nuc	22775	A
+21L	nuc	23525	T
+21L	nuc	23599	G
+21L	nuc	24424	T
+21L	nuc	27259	C

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -21987,6 +21987,7 @@ clade_membership	21E (Theta)
 clade_membership	21F (Iota)
 clade_membership	21G (Lambda)
 clade_membership	21H (Mu)
+clade_membership	21L
 clade_membership	21K (Omicron)
 
 ################


### PR DESCRIPTION
Recently, 3 nearly identical sequences have been uploaded that are similar to Omicron but differ by about 10 mutations. These sequences have been discussed in detail in a pango designation issue. https://github.com/cov-lineages/pango-designation/issues/359

The current ncov clade definition is so that the 3 sequences (let's call them Omicron outliers) are not classified as Omicron as can be seen here:
![image](https://user-images.githubusercontent.com/25161793/144924600-e77d6a8c-3d28-4e66-ae2d-1552d5675c77.png)

https://nextstrain.org/groups/neherlab/ncov/nextclade-reference/2021-12-06-draft

This PR proposes to change `21K (Omicron)` defining mutations so that the outliers _are_ classified as 21K.

Mutations were chosen by looking for mutations that lie on the common branch of outliers and main Omicron and using covSpectrum to narrow down the selection to mutations that are very common (>99%) across all Omicrons and if possible also highly specific (using Jaccard similarity).

This process yielded 4 mutations:
```
27259C
24424T
23525T
23599G
```

In a global diversity tree (nextclade reference) two mutations were only seen in Omicron. One mutation is only also observed in Gamma. And another one sporadically on the tree.

So this definition should be both specific and sensitive.

One can check occurence of these mutations on the tree here: https://nextstrain.org/groups/neherlab/ncov/nextclade-reference/2021-12-06-draft?c=gt-nuc_24424,23525,23599,27259

![image](https://user-images.githubusercontent.com/25161793/144925182-c1a96786-6d35-4533-927e-98c4d9583632.png)