### PR TITLE
Bump versions in conda environment

### DIFF
--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -4,11 +4,11 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - augur=13.0.0
+  - augur=13.0.4
   - epiweeks=2.1.2
-  - iqtree=2.1.2
+  - iqtree=2.1.4-beta
   - mafft=7.475
-  - nextalign=0.2.0
-  - pangolin=2.3.8
-  - pangolearn=2021.04.01
+  - nextalign=1.7.0
+  - pangolin=3.1.16
+  - pangolearn=2021-11-25
   - python>=3.7*


### PR DESCRIPTION
## Description of proposed changes

Update to latest versions of tools available in Bioconda. Some tools
like Augur, nextalign, and pangolin have recently been updated in
Bioconda but these versions haven't been pushed to the Bioconda package
servers yet.

## Related issue(s)

Fixes #758

## Testing

 - [x] Tested with CI
 - [x] Tested with full Nextstrain builds on SLURM cluster