### PR TITLE
#463 Check if subsampling rule is supported and raise a meaningful error if it is not

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -39,6 +39,9 @@ shell.prefix("set -euo pipefail; export AUGUR_RECURSION_LIMIT=10000; ")
 # [5] https://github.com/snakemake/snakemake/blob/a7ac40c96d6e2af47102563d0478a2220e2a2ab7/snakemake/utils.py#L455-L476
 user_subsampling = copy.deepcopy(config.get("subsampling", {}))
 
+# List of currently supported subsampling flags
+supported_subsampling = ["--group-by", "--sequences-per-group", "--subsample-max-sequences", "--probabilistic-sampling", "--no-probabilistic-sampling", "--priority", "--subsample-seed"]
+
 configfile: "defaults/parameters.yaml"
 
 # Check config file for errors
@@ -68,6 +71,16 @@ if len(overlapping_schemes) > 0:
     logger.warning("  In future versions of this workflow, overlapping subsampling scheme names will produce an error.")
     logger.warning("")
     time.sleep(5)
+
+# Check for unsupported subsampling schemes in user and default
+# configurations. Returns a helpful error message and exits.
+for scheme_name, scheme in user_subsampling.items():
+    if scheme_name not in supported_subsampling:
+        error_string = "The inputted subsampling rule {} is not supported at this time. Please use one of the following supported subsampling rules: ".format(user_subsampling)
+        for i in supported_subsampling:
+            error_string = error_string + i + ", "
+        logger.error(error_string)
+        sys.exit(1)
 
 # Assign a default build if none are specified in the config. Users can define a
 # `default_build_name` in their builds config without assigning any other build

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -500,7 +500,7 @@ rule combine_samples:
         augur filter \
             --sequences {input.sequences} \
             --sequence-index {input.sequence_index} \
-            --metadata {input.metadata} \
+            --metadata ({input.metadata}{references_metadata.tsv}) \
             --exclude-all \
             --include {input.include} \
             --output-sequences {output.sequences} \

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -500,7 +500,7 @@ rule combine_samples:
         augur filter \
             --sequences {input.sequences} \
             --sequence-index {input.sequence_index} \
-            --metadata ({input.metadata}{references_metadata.tsv}) \
+            --metadata {input.metadata} \
             --exclude-all \
             --include {input.include} \
             --output-sequences {output.sequences} \


### PR DESCRIPTION
## Description of proposed changes

What is the goal of this pull request? What does this pull request change?
This attempts to fix issue 463 and check if the user inputted subsampling rules are supported and raises a meaningful error that lists the supported subsampling schemes if not.

## Related issue(s)

<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Fixes #
Related to #463 

## Testing

What steps should be taken to test the changes you've proposed?
Test to see if, when an unsupported subsampling rule is inputted, the system raises a meaningful error that also displays the supported subsampling rules the user can chose from.

If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?
Yes, my partner and I changed the codebase but did not updated the tests. We would need help with this.

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
