### PR TITLE
Add 21M (Omicron) clade, add (Omicron) to 21L

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -141,9 +141,13 @@ clade	gene	site	alt
 21K (Omicron)	nuc	24424	T
 21K (Omicron)	nuc	27259	C
 
-21L	nuc	21618	T
-21L	nuc	22775	A
-21L	nuc	23525	T
-21L	nuc	23599	G
-21L	nuc	24424	T
-21L	nuc	27259	C
+21L (Omicron)	nuc	21618	T
+21L (Omicron)	nuc	22775	A
+21L (Omicron)	nuc	23525	T
+21L (Omicron)	nuc	23599	G
+21L (Omicron)	nuc	24424	T
+21L (Omicron)	nuc	27259	C
+
+21M (Omicron)	nuc	23525	T
+21M (Omicron)	nuc	23599	G
+21M (Omicron)	nuc	27259	C


### PR DESCRIPTION
## Description of proposed changes

Adds `21M (Omicron)` clade - corresponding to pango lineage B.1.1.529

Adds `(Omicron)` to `21L` in line with WHO/pango convention.

The clade defining mutations are those that are shared between 21K and 21L which means the clades are guaranteed to nest correctly.

The defining mutations do not occur in the Nextclade reference tree other than in Omicron, so specificity is ensured. Sensitivity is also great, since the set of defining mutations is a subset of 21K and 21L.

```
21M (Omicron)	nuc	23525	T
21M (Omicron)	nuc	23599	G
21M (Omicron)	nuc	27259	C
```

![image](https://user-images.githubusercontent.com/25161793/146266442-bb84dade-1eb8-4008-b4d6-d59f72c73d0f.png)

