### PR TITLE
fix: 21I (Delta) must contain S:222V

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -123,6 +123,7 @@ clade	gene	site	alt
 21I (Delta)	nuc	5184	T
 21I (Delta)	nuc	9891	T
 21I (Delta)	nuc	21618	G
+21I (Delta)	nuc	22227	T
 21I (Delta)	nuc	23403	G
 21I (Delta)	nuc	26767	C
 21I (Delta)	nuc	28461	G


### PR DESCRIPTION
Adds nuc mutation C22227T (S:222V) back into 21I (Delta)

I'm using this branch for the newest nextclade build, should work as test