### PR TITLE
Support skipping metadata sanitization

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -23,6 +23,7 @@ inputs:
   - name: gisaid
     metadata: "s3://nextstrain-ncov-private/metadata.tsv.gz"
     aligned: "s3://nextstrain-ncov-private/sequences.fasta.xz"
+    skip_sanitize_metadata: true
 
 # Define locations for which builds should be created.
 # For each build we specify a subsampling scheme via an explicit key.

--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -20,6 +20,7 @@ inputs:
   - name: open
     metadata: "s3://nextstrain-data/files/ncov/open/metadata.tsv.gz"
     aligned: "s3://nextstrain-data/files/ncov/open/sequences.fasta.xz"
+    skip_sanitize_metadata: true
 
 # Define locations for which builds should be created.
 # For each build we specify a subsampling scheme via an explicit key.

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -31,6 +31,8 @@ properties:
         aligned:
           type: string
           minLength: 1
+        skip_sanitize_metadata:
+          type: boolean
       additionalProperties: false
 
   builds:

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -115,7 +115,12 @@ def _get_unified_metadata(wildcards):
     `combine_input_metadata` rule (and `sanitize_metadata` rule) to make it.
     """
     if len(list(config["inputs"].keys()))==1:
-        return "results/sanitized_metadata_{origin}.tsv.xz".format(origin=list(config["inputs"].keys())[0])
+        input_name, input_record = list(config["inputs"].items())[0]
+        if input_record.get("skip_sanitize_metadata"):
+            return _get_path_for_input("metadata", input_name)
+        else:
+            return "results/sanitized_metadata_{origin}.tsv.xz".format(origin=input_name)
+
     return "results/combined_metadata.tsv.xz"
 
 def _get_unified_alignment(wildcards):

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -39,7 +39,10 @@ rule combine_input_metadata:
         Combining metadata files {input.metadata} -> {output.metadata} and adding columns to represent origin
         """
     input:
-        metadata=expand("results/sanitized_metadata_{origin}.tsv.xz", origin=config.get("inputs")),
+        metadata=[
+            _get_path_for_input("metadata", input_name) if input_record.get("skip_sanitize_metadata") else "results/sanitized_metadata_{origin}.tsv.xz".format(origin=input_name)
+            for input_name, input_record in config.get("inputs", {}).items()
+        ],
     output:
         metadata = "results/combined_metadata.tsv.xz"
     params:


### PR DESCRIPTION
## Description of proposed changes

For the rare case when input metadata have already been sanitized (e.g., Nextstrain builds run from ncov-ingest data), allows the workflow to skip running the sanitize metadata step by the addition of a `skip_sanitize_metadata` attribute for each input.

Enables the `skip_sanitize_metadata` for Nextstrain GISAID and open builds which should remove at least an hour of unnecessary preprocessing from the start of GISAID-based Nextstrain builds on AWS Batch.

## Testing

 - [x] [Run open rebuild action and confirm skipped sanitize metadata step](https://github.com/nextstrain/ncov/actions/runs/1665524104)
 - [x] [Run GISAID rebuild action](https://github.com/nextstrain/ncov/actions/runs/1668611792) (after including reduced memory requirements for subsampling) and benchmark