### PR TITLE
Escape input names in length filter query

### DIFF
--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -68,7 +68,15 @@ def _get_filter_min_length_query(wildcards):
         # We only annotate input-specific columns on metadata when there are
         # multiple inputs.
         if len(inputs) > 1:
-            query_parts.append(f"({input_name} == 'yes' & _length >= {min_length})")
+            # Input names can contain characters that make them invalid Python
+            # variable names. As such, we escape the column names with backticks
+            # as recommended by pandas:
+            #
+            # https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.query.html
+            #
+            # We escape the backticks with backslashes to prevent the bash shell
+            # from expanding the contents between the backticks as a subprocess.
+            query_parts.append(f"(\`{input_name}\` == 'yes' & _length >= {min_length})")
         else:
             query_parts.append(f"(_length >= {min_length})")
 


### PR DESCRIPTION
## Description of proposed changes

Fixes a bug in the new dynamic min-length filter query when there are multiple inputs and one of the inputs has characters that are not allowed in Python variable names (e.g., hypens as in "north-america").

In this case, the workflow dynamically builds a min length filter query for each input. This query is written in [pandas query syntax](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.query.html) and uses the columns added for each input by the `combine_metadata.py` script to support different length filters per input.

Thanks to @BryanTegomoh for reporting this bug!

## Testing

 - [x] Tested with CI profile
 - [x] Tested with example multiple inputs profile after changing the input named `aus` to `aus-data`

Local test command for the last item above:

```
snakemake \
  results/multiple-inputs/filtered.fasta \
  --use-conda \
  --conda-frontend mamba \
  -p \
  -j 4 \
  --configfile my_profiles/example_multiple_inputs/builds.yaml
```