### PR TITLE
feat: add 20B muts to all Omicron clade defs

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -159,11 +159,11 @@ clade	gene	site	alt
 21L (Omicron)	nuc	24424	T
 21L (Omicron)	nuc	27259	C
 
-21L (Omicron)	nuc	8782	C
-21L (Omicron)	nuc	14408	T
-21L (Omicron)	nuc	23403	G
-21L (Omicron)	nuc	28881	A
-21L (Omicron)	nuc	28882	A
+21M (Omicron)	nuc	8782	C
+21M (Omicron)	nuc	14408	T
+21M (Omicron)	nuc	23403	G
+21M (Omicron)	nuc	28881	A
+21M (Omicron)	nuc	28882	A
 21M (Omicron)	nuc	23525	T
 21M (Omicron)	nuc	23599	G
 21M (Omicron)	nuc	27259	C

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -135,6 +135,11 @@ clade	gene	site	alt
 21J (Delta)	nuc	26767	C
 21J (Delta)	nuc	28461	G
 
+21K (Omicron)	nuc	8782	C
+21K (Omicron)	nuc	14408	T
+21K (Omicron)	nuc	23403	G
+21K (Omicron)	nuc	28881	A
+21K (Omicron)	nuc	28882	A
 21K (Omicron)	nuc	15240	T
 21K (Omicron)	nuc	23202	A
 21K (Omicron)	nuc	23525	T
@@ -142,6 +147,11 @@ clade	gene	site	alt
 21K (Omicron)	nuc	24424	T
 21K (Omicron)	nuc	27259	C
 
+21L (Omicron)	nuc	8782	C
+21L (Omicron)	nuc	14408	T
+21L (Omicron)	nuc	23403	G
+21L (Omicron)	nuc	28881	A
+21L (Omicron)	nuc	28882	A
 21L (Omicron)	nuc	21618	T
 21L (Omicron)	nuc	22775	A
 21L (Omicron)	nuc	23525	T
@@ -149,6 +159,11 @@ clade	gene	site	alt
 21L (Omicron)	nuc	24424	T
 21L (Omicron)	nuc	27259	C
 
+21L (Omicron)	nuc	8782	C
+21L (Omicron)	nuc	14408	T
+21L (Omicron)	nuc	23403	G
+21L (Omicron)	nuc	28881	A
+21L (Omicron)	nuc	28882	A
 21M (Omicron)	nuc	23525	T
 21M (Omicron)	nuc	23599	G
 21M (Omicron)	nuc	27259	C


### PR DESCRIPTION
## Description of proposed changes

Omicron clades are descendants of 20B. Yet this is not encoded in the current clades.tsv.

This causes problems. When Omicron is not placed within 20B but pulled together with Delta for contamination reasons, it can happen that there are two large branches that 20B could attach to. When Omicron is bigger than the non-Omicron-20B-part, which will happen increasingly, then 20B can get nested under Omicron which is problematic.

This has happened in a number of recent Neherlab builds, but not (yet) in ncov builds. Reasons may be that contaminations happen more in certain countries and that that there's less sampling done for distant past when 20B made up a larger share.

This PR simply adds all 20B mutations to all Omicrons, which should prevent the clade inversion problem and thus partially address the issue seen in some ncov-simple builds.

Illustration of the problem: (may change with new build): https://nextstrain.org/groups/neherlab/ncov/italy?c=clade_membership&f_country=Italy&p=grid&r=division
![image (7)](https://user-images.githubusercontent.com/25161793/149376227-25a59747-14c3-4441-a550-821315cbb7de.png)

