### PR TITLE
Fix multiple inputs with one or more remotes

### DIFF
--- a/workflow/snakemake_rules/remote_files.smk
+++ b/workflow/snakemake_rules/remote_files.smk
@@ -100,8 +100,15 @@ def path_or_url(path_or_url, stay_on_remote = False, keep_local = False):
     # fragment (including their leading delimiters) if they're empty.
     schemeless_url = urljoin(url.netloc + url.path, f"?{url.query}#{url.fragment}")
 
-    return SCHEME_REMOTES[url.scheme]()(
+    url = SCHEME_REMOTES[url.scheme]()(
         schemeless_url,
         stay_on_remote = stay_on_remote,
         keep_local     = keep_local,
     )
+
+    # Remote files may be returned as lists with a single item, so we need to
+    # flatten to a scalar.
+    if isinstance(url, list):
+        url = url[0]
+
+    return url


### PR DESCRIPTION
## Description of proposed changes

Fixes a bug where a build with multiple inputs including at least one
remote file produced an invalid return argument for Snakemake in the
`combined_sequences_for_subsampling` rule. The issue was caused when the
remote URLs returned by `path_or_url` were lists instead of scalars. The
input function for the Snakemake rule performed a naive list
comprehension across all inputs that would produce a list with at least
one list for each remote file in it. This list of lists is not a valid
Snakemake input.

## Related issue(s)

Fixes #838

## Testing

- [x] Tested with CI
- [x] Tested locally with the build from the original issue