### PR TITLE
Remove redundant include strains

### DIFF
--- a/defaults/include.txt
+++ b/defaults/include.txt
@@ -1,3 +1,1 @@
 Wuhan/Hu-1/2019
-Wuhan-Hu-1/2019
-Wuhan/WH01/2019


### PR DESCRIPTION
## Description of proposed changes

Removes older references from the list of strains to force include in
analyses. We use the single Wuhan/Hu-1/2019 strains as the reference for
alignment and time tree rooting, so the other two strains are not
required. Importantly, these additional strains get used in proximity
calculations with priority-based subsampling leading to the unexpected
inclusion of contextual strains that look like these redundant root
sequences. We try to avoid this problem in [the proximity calculations by
defining a list of strains to ignore](https://github.com/nextstrain/ncov/blob/51ac8143761057c14de3841e46b82e08f7fef4b6/workflow/snakemake_rules/main_workflow.smk#L372), but this list only includes
the strain used to root the time tree. Rather than updating this list to
include more strains, we can just remove the strains from the include
file.

## Testing

 - [ ] Tested by CI
