### PR TITLE
Fix ambiguous date filtering for epiweeks

### DIFF
--- a/scripts/calculate_epiweek.py
+++ b/scripts/calculate_epiweek.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
 
     # Find records with unambiguous dates. These must be complete date-like
     # records in YYYY-MM-DD format.
-    date_pattern = re.compile(r"\d{4}-\d{2}-\d{2}")
+    date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}$")
     has_complete_date = metadata["date"].astype(str).apply(lambda date: date_pattern.match(date) is not None)
     metadata_with_dates = metadata.loc[has_complete_date, ["date"]].copy()
 

--- a/scripts/calculate_epiweek.py
+++ b/scripts/calculate_epiweek.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import argparse
+from augur.io import read_metadata
 from augur.utils import write_json
 import epiweeks
 import pandas as pd
+import re
 
 
 if __name__ == '__main__':
@@ -11,26 +13,22 @@ if __name__ == '__main__':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("--metadata", required=True, help="metadata with a 'date' column")
+    parser.add_argument("--metadata-id-columns", default=["strain", "name", "Virus name"], nargs="+", help="names of valid metadata columns containing identifier information like 'strain' or 'name'")
     parser.add_argument("--attribute-name", default="epiweek", help="name to store annotations of epiweeks in JSON output")
     parser.add_argument("--output-node-data", required=True, help="node data JSON with epiweek annotations")
 
     args = parser.parse_args()
 
-    # Read metadata with pandas because Augur's read_metadata utility does not
-    # support metadata without a "strain" or "name" field.
-    metadata = pd.read_csv(
+    metadata = read_metadata(
         args.metadata,
-        sep=None,
-        engine="python",
-        skipinitialspace=True,
-        dtype={
-            "strain": "string",
-            "name": "string",
-        }
-    ).fillna("")
+        id_columns=args.metadata_id_columns,
+    )
 
-    # Find records with unambiguous dates.
-    metadata_with_dates = metadata.loc[~metadata["date"].str.contains("X"), ["strain", "date"]].copy()
+    # Find records with unambiguous dates. These must be complete date-like
+    # records in YYYY-MM-DD format.
+    date_pattern = re.compile(r"\d{4}-\d{2}-\d{2}")
+    has_complete_date = metadata["date"].astype(str).apply(lambda date: date_pattern.match(date) is not None)
+    metadata_with_dates = metadata.loc[has_complete_date, ["date"]].copy()
 
     # Convert date strings to timestamps.
     metadata_with_dates["date"] = pd.to_datetime(metadata_with_dates["date"])
@@ -40,8 +38,8 @@ if __name__ == '__main__':
 
     # Create a node data object with epiweeks.
     node_data = {}
-    for record in metadata_with_dates.to_dict(orient="records"):
-        node_data[record["strain"]] = {
+    for index, record in metadata_with_dates.iterrows():
+        node_data[index] = {
             args.attribute_name: record["epiweek"],
         }
 

--- a/tests/unsanitized_metadata.tsv
+++ b/tests/unsanitized_metadata.tsv
@@ -4,4 +4,4 @@ hCoV-19/OneVirus/1/2020	male	2020-10-01	EPI_ISL_2
 SARS-CoV-2/AnotherVirus/1/2021	female	2021-01-01	EPI_ISL_3
 hCoV-19/LocalVirus/2/2021	?	2021-12-01	?
 hCoV-19/LocalVirus/2/2021	?	2021-12-01	?
-hCoV-19/LocalVirus/3/2021	?	2021-12-02	?
+hCoV-19/LocalVirus/3/2021	?	?	?

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1224,10 +1224,13 @@ rule calculate_epiweeks:
         config["conda_environment"],
     log:
         "logs/calculate_epiweeks_{build_name}.txt",
+    params:
+        metadata_id_columns=config["sanitize_metadata"]["metadata_id_columns"],
     shell:
         """
         python3 scripts/calculate_epiweek.py \
             --metadata {input.metadata} \
+            --metadata-id-columns {params.metadata_id_columns:q} \
             --output-node-data {output.node_data} 2>&1 | tee {log}
         """
 


### PR DESCRIPTION
## Description of proposed changes

Replaces check for "X" ambiguous characters in dates with a more conservative definition of a valid date based on a regular expression applied to the string representation of the date column. This should filter most incomplete date values including the original "2020-XX-XX" type of date that we had previously filtered. These filters should avoid errors in datetime conversion with pandas or epiweek conversion.

## Related issue(s)

Fixes #845

## Testing

 - [x] Added incomplete functional test data entry in unsanitized metadata and tested locally
 - [x] Tested by CI