### PR TITLE
Reduce frequencies bandwidth slightly

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -143,7 +143,8 @@ frequencies:
   pivot_interval_units: "weeks"
 
   # KDE bandwidths in proportion of a year to use per strain.
-  narrow_bandwidth: 0.05
+  # using 15 day bandwidth
+  narrow_bandwidth: 0.041
   proportion_wide: 0.0
 
   # Diffusion frequency settings


### PR DESCRIPTION
## Description of proposed changes

Omicron's rise in frequency has been extraordinarily swift. The existing frequency estimates used an 18 day (0.05 year) bandwidth. This was wide enough that Delta samples bleed forward and look to be at higher frequency at present than is accurate.

This commit reduces bandwidth to 14 days (0.041 year). This was chosen to capture speed of variant dynamics in a few geographies, while trying to avoid overly noisy estimates due to sample count.

From testing, I believe a 15 day bandwidth is the better compromise than an 18 day bandwidth.

I had initially wanted to go with 12 day bandwidth to capture Omicron, but this created enough noise that I pushed it back up to 15 days.

## Testing

A few direct comparisons.

### "north-america" dataset, filtered to USA

Reducing bandwidth drops Delta's current frequency from 7% to 4% at Jan 22 timepoint. Using all sequences from the US, [we estimate that Delta frequency is 0.6% on this day](https://github.com/blab/rt-from-frequency-dynamics/blob/master/estimates/omicron-countries/omicron-countries_freq-combined-GARW.tsv#L7769). So 4% is more accurate.

#### Existing

<img width="1091" alt="Screen Shot 2022-02-03 at 9 22 28 PM" src="https://user-images.githubusercontent.com/1176109/152476608-a22ecac3-909d-4385-b44b-83753bcf7ccd.png">

#### PR

<img width="1091" alt="usa-pr" src="https://user-images.githubusercontent.com/1176109/152478782-454416c6-23c6-4f8c-9bff-5081457a3dda.png">

### "europe" dataset, filtered to UK

Like the US example, takes Delta frequency at latest timepoint from 9% to 5%, which is an improvement.

#### Existing

<img width="1091" alt="Screen Shot 2022-02-03 at 9 33 45 PM" src="https://user-images.githubusercontent.com/1176109/152477693-22f0c9a8-3db2-4ea7-9d49-03327d9233d7.png">

#### PR

<img width="1091" alt="uk-pr" src="https://user-images.githubusercontent.com/1176109/152478808-0440aac7-39ed-43f7-9e57-2a2974a061d1.png">

### "south-america" dataset, filtered to Peru

Chosen because Peru has had interesting variant circulation in 2021. The narrower bandwidth definitely makes the plot more dynamic / noisy, but I don't think overly so.

#### Existing

<img width="1091" alt="Screen Shot 2022-02-03 at 9 25 53 PM" src="https://user-images.githubusercontent.com/1176109/152476901-4214a310-cbc8-440e-9588-e9c91eb013dc.png">

#### PR

<img width="1091" alt="peru-pr" src="https://user-images.githubusercontent.com/1176109/152478820-87a96a8b-6e7c-4f34-8e2f-60aa0bbd5e99.png">



