### PR TITLE
Fix missing Conda environment declaration for new prepare_nextclade rule

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1225,8 +1225,6 @@ rule mutational_fitness:
         node_data = "results/{build_name}/mutational_fitness.json"
     benchmark:
         "benchmarks/mutational_fitness_{build_name}.txt"
-    conda:
-        config["conda_environment"]
     log:
         "logs/mutational_fitness_{build_name}.txt"
     params:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -453,6 +453,7 @@ rule prepare_nextclade:
         nextclade_dataset = directory("data/sars-cov-2-nextclade-defaults"),
     params:
         name = "sars-cov-2",
+    conda: config["conda_environment"]
     shell:
         """
         nextclade dataset get --name {params.name} --output-dir {output.nextclade_dataset}


### PR DESCRIPTION
## Description of proposed changes
Fix missing Conda environment declaration for new prepare_nextclade rule

Resolves https://github.com/nextstrain/ncov/issues/857.  Thanks to @ktmeaton for reporting the issue and fix.

## Testing
Have not tested myself, but appears correct by inspection and will look at CI results.
