### PR TITLE
Add author-lab credit to auspice jsons

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/africa_auspice_config.json
@@ -131,7 +131,9 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/asia_auspice_config.json
@@ -131,7 +131,9 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/europe_auspice_config.json
@@ -131,7 +131,9 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/global_auspice_config.json
@@ -131,7 +131,9 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/north-america_auspice_config.json
@@ -132,7 +132,9 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/oceania_auspice_config.json
@@ -131,7 +131,9 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-gisaid/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/south-america_auspice_config.json
@@ -131,7 +131,9 @@
     "division",
     "location",
     "host",
-    "pango_lineage"
+    "pango_lineage",
+    "originating_lab",
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
@@ -114,7 +114,7 @@
     "country",
     "division",
     "host",
-    "authors"
+    "author"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
@@ -113,7 +113,8 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "authors"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
@@ -114,7 +114,7 @@
     "country",
     "division",
     "host",
-    "authors"
+    "author"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
@@ -113,7 +113,8 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "authors"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
@@ -114,7 +114,7 @@
     "country",
     "division",
     "host",
-    "authors"
+    "author"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
@@ -113,7 +113,8 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "authors"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/global_auspice_config.json
@@ -114,7 +114,7 @@
     "country",
     "division",
     "host",
-    "authors"
+    "author"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/global_auspice_config.json
@@ -113,7 +113,8 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "authors"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
@@ -114,7 +114,7 @@
     "country",
     "division",
     "host",
-    "authors"
+    "author"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
@@ -113,7 +113,8 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "authors"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
@@ -114,7 +114,7 @@
     "country",
     "division",
     "host",
-    "authors"
+    "author"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
@@ -113,7 +113,8 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "authors"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
@@ -114,7 +114,7 @@
     "country",
     "division",
     "host",
-    "authors"
+    "author"
   ],
   "panels": [
     "tree",

--- a/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
@@ -113,7 +113,8 @@
     "region",
     "country",
     "division",
-    "host"
+    "host",
+    "authors"
   ],
   "panels": [
     "tree",


### PR DESCRIPTION
## Description of proposed changes

This adds `originating_lab` and `submitting_lab` (in this order) to the auspice `json` files for GISAID builds, and `authors` to the same for the open builds.

This should allow us to stop tweeting credits from the builds, which is very time-consuming.

## Testing
This has not been tested.
