### PR TITLE
Surface Nextclade QC metrics as color-bys

### DIFF
--- a/defaults/auspice_config.json
+++ b/defaults/auspice_config.json
@@ -41,6 +41,21 @@
       "type": "continuous"
     },
     {
+      "key": "reversion_mutations",
+      "title": "Reversion mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "potential_contaminants",
+      "title": "Potential contaminants",
+      "type": "continuous"
+    },
+    {
+      "key": "rare_mutations",
+      "title": "Rare mutations",
+      "type": "continuous"
+    },
+    {
       "key": "location",
       "title": "Location",
       "type": "categorical"


### PR DESCRIPTION
## Description of proposed changes

Updates Auspice config(s) to include colors for Nextclade QC information that now gets passed through metadata to augur export. When these columns are present in the metadata, users can color their trees by reversions, potential contaminants, and rare mutations. Users can now skip the diagnostic filters in the workflow, to keep as much data in the tree as possible, but still identify the strains that would be have been filtered by diagnostics.

**Note: This PR only updates the default Auspice config at the moment. It will update all configs once we agree on the fields to include.**

## Testing

 - [ ] Test by CI
 - [ ] Test with full Nextstrain builds

## Release checklist

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.