### PR TITLE
feat: add overallScore and overallStatus QC columns to metadata.tsv

### DIFF
--- a/scripts/join-metadata-and-clades.py
+++ b/scripts/join-metadata-and-clades.py
@@ -30,6 +30,8 @@ column_map = {
     "qc.snpClusters.status": "QC_snp_clusters",
     "qc.frameShifts.status": "QC_frame_shifts",
     "qc.stopCodons.status": "QC_stop_codons",
+    "qc.overallScore": "QC_overall_score",
+    "qc.overallStatus": "QC_overall_status",
     "frameShifts": "frame_shifts",
     "deletions": "deletions",
     "insertions": "insertions",


### PR DESCRIPTION
## Description of proposed changes

This adds the copying of the following columns from `nextclade.tsv` to `metadata.tsv`:

```
    "qc.overallScore": "QC_overall_score",
    "qc.overallStatus": "QC_overall_status",
```

## Related issue(s)

Addresses the metadata portion of https://github.com/nextstrain/ncov/pull/861

See the symmetrical PR in ncov-igest: https://github.com/nextstrain/ncov-ingest/pull/283


## Testing

...


## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
