### PR TITLE
Use datetime.date.today() in finding Max Freq Date

### DIFF
--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -186,7 +186,7 @@ def _get_max_date_for_frequencies(wildcards):
         offset = datetime.timedelta(days=recent_days_to_censor)
 
         return numeric_date(
-            date.today() - offset
+            datetime.date.today() - offset
         )
 
 def _get_upload_inputs(wildcards):


### PR DESCRIPTION
I ran into this today while trying to copy this function to another build - seems like we need to use datetime.date.today() rather than just date.today()? At least, I couldn't get it to work otherwise - but maybe am missing something?
