### PR TITLE
Update emerging lineages for Omicron

### DIFF
--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -25077,6 +25077,8 @@ emerging_lineage	AY.34 (Delta)
 emerging_lineage	AY.36 (Delta)
 emerging_lineage	AY.39 + S:1073N (Delta)
 emerging_lineage	B.1.1.529 (Omicron)
+emerging_lineage	BA.1 (Omicron)
+emerging_lineage	BA.2 (Omicron)
 
 ################
 

--- a/defaults/emerging_lineages.tsv
+++ b/defaults/emerging_lineages.tsv
@@ -35,11 +35,38 @@ AY.39 + S:1073N (Delta)	nuc	28881	T
 AY.39 + S:1073N (Delta)	nuc	27604	A
 AY.39 + S:1073N (Delta)	S	1073	N
 
-B.1.1.529 (Omicron)	nuc	25000	T
-B.1.1.529 (Omicron)	nuc	25584	T
+B.1.1.529 (Omicron)	nuc	8782	C
+B.1.1.529 (Omicron)	nuc	14408	T
+B.1.1.529 (Omicron)	nuc	23403	G
+B.1.1.529 (Omicron)	nuc	28881	A
+B.1.1.529 (Omicron)	nuc	28882	A
+B.1.1.529 (Omicron)	nuc	23525	T
+B.1.1.529 (Omicron)	nuc	23599	G
 B.1.1.529 (Omicron)	nuc	27259	C
-B.1.1.529 (Omicron)	nuc	8393	A
-B.1.1.529 (Omicron)	nuc	13195	C
+
+BA.2 (Omicron)	nuc	8782	C
+BA.2 (Omicron)	nuc	14408	T
+BA.2 (Omicron)	nuc	23403	G
+BA.2 (Omicron)	nuc	28881	A
+BA.2 (Omicron)	nuc	28882	A
+BA.2 (Omicron)	nuc	21618	T
+BA.2 (Omicron)	nuc	22775	A
+BA.2 (Omicron)	nuc	23525	T
+BA.2 (Omicron)	nuc	23599	G
+BA.2 (Omicron)	nuc	24424	T
+BA.2 (Omicron)	nuc	27259	C
+
+BA.1 (Omicron)	nuc	8782	C
+BA.1 (Omicron)	nuc	14408	T
+BA.1 (Omicron)	nuc	23403	G
+BA.1 (Omicron)	nuc	28881	A
+BA.1 (Omicron)	nuc	28882	A
+BA.1 (Omicron)	nuc	15240	T
+BA.1 (Omicron)	nuc	23202	A
+BA.1 (Omicron)	nuc	23525	T
+BA.1 (Omicron)	nuc	23599	G
+BA.1 (Omicron)	nuc	24424	T
+BA.1 (Omicron)	nuc	27259	C
 
 19A	nuc	8782	C
 19A	nuc	14408	C


### PR DESCRIPTION
Currently clade 21M and 21L genomes get assigned 20B as the emerging lineage, as the emerging lineage definitions haven't been updated.

Current situation (branch labels show clade, not emerging lineage):

![image](https://user-images.githubusercontent.com/8350992/153981035-4032a3ba-d85a-4cf1-9ffd-b52a14967265.png)

This updates adds the defining mutations for 3 nextstrain clades 21M, 21L and 21K to correspond to emerging lineages B.1.1.529, BA.1 and BA.2, respectively. While B.1.1.529 was there previously, the defining mutations are here updated.

## Testing

Trial build https://github.com/nextstrain/ncov/runs/5194049893, when completed, should produce test datasets at  https://nextstrain.org/staging/ncov/gisaid/trial/update-emerging-lineages-2022-02-15/global etc.

