### PR TITLE
Add parameter to enable overriding tree args

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -115,7 +115,8 @@ combine_sequences_for_subsampling:
   warn_about_duplicates: true
 
 tree:
-  tree-builder-args: "'-ninit 10 -n 4'"
+  tree-builder-args: "'-ninit 10 -n 4 -me 0.05'"
+  override_default_args: true
 
 # TreeTime settings
 refine:

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -3,6 +3,10 @@
 As of April 2021, we use major version numbers (e.g. v2) to reflect backward incompatible changes to the workflow that likely require you to update your Nextstrain installation.
 We also use this change log to document new features that maintain backward compatibility, indicating these features by the date they were added.
 
+## v12 (? February 2022)
+
+ - Add a new workflow parameter in the `tree` config named [`override_default_args`](https://docs.nextstrain.org/projects/ncov/en/latest/reference/configuration.html#override_default_args) that enables overriding default tree builder arguments with the values defined by [`tree-builder-args`](https://docs.nextstrain.org/projects/ncov/en/latest/reference/configuration.html#tree-builder-args). This release of the workflow sets this parameter to `true` by default, which may be a breaking change for users who have modified the default tree builder arguments. Upgrade to [Augur 14.0.0](https://github.com/nextstrain/augur/blob/master/CHANGES.md#1400-8-february-2022) and run `augur tree -h` to see the default arguments for the tree builder you use. [See the original Augur pull request](https://github.com/nextstrain/augur/pull/839), for more details.
+
 ## New features since last version update
 
 - 11 February 2022: Add colors to default Auspice config for Nextclade quality control columns and a filter for overall Nextclade QC status. [PR #861](https://github.com/nextstrain/ncov/pull/861).

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -724,7 +724,12 @@ Each named traits configuration (`default` or build-named) supports the followin
 ### tree-builder-args
 * type: string
 * description: Arguments specific to the tree method (`iqtree`) to be passed through to the tree builder command run by `augur tree`.
-* default: `'-ninit 10 -n 4'`
+* default: `'-ninit 10 -n 4 -me 0.05'`
+
+### override_default_args
+* type: boolean
+* description: Override default tree builder arguments with the values provided by the user in `tree-builder-args` instead of augmenting the existing defaults.
+* default: `true`
 
 ## auspice_json_prefix
 * type: string

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -780,6 +780,7 @@ rule tree:
         tree = "results/{build_name}/tree_raw.nwk"
     params:
         args = lambda w: config["tree"].get("tree-builder-args","") if "tree" in config else "",
+        override_default_args = lambda wildcards: "--override-default-args" if config["tree"].get("override_default_args", False) else "",
         exclude_sites = lambda w: f"--exclude-sites {config['files']['sites_to_mask']}" if "sites_to_mask" in config["files"] else ""
     log:
         "logs/tree_{build_name}.txt"
@@ -797,6 +798,7 @@ rule tree:
         augur tree \
             --alignment {input.alignment} \
             --tree-builder-args {params.args} \
+            {params.override_default_args} \
             {params.exclude_sites} \
             --output {output.tree} \
             --nthreads {threads} 2>&1 | tee {log}


### PR DESCRIPTION
## Description of proposed changes

Adds a configuration parameter to the workflow, `override_default_args`,
in the `tree` section that allows users to toggle the corresponding new
flag in `augur tree` on or off. Sets the default value to `true`, since
the custom tree builder arguments we define in defaults are redundant
with previously hardcoded defaults in augur tree. This change should fix
a related segmentation fault on some systems, but it also allows users
to define more flexible tree builder arguments that conflict with the
defaults (e.g., bootstrap mode in IQ-TREE).

## Related issue(s)

Related to https://github.com/nextstrain/augur/issues/780

## Testing

 - [ ] Tested by CI
 - [ ] Tested with full Nextstrain builds

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [x] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.