### PR TITLE
Use a literal path for Nextclade data input

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -469,7 +469,7 @@ rule build_align:
         sequences = rules.combine_samples.output.sequences,
         genemap = config["files"]["annotation"],
         reference = config["files"]["alignment_reference"],
-        nextclade_dataset = rules.prepare_nextclade.output.nextclade_dataset,
+        nextclade_dataset = "data/sars-cov-2-nextclade-defaults",
     output:
         alignment = "results/{build_name}/aligned.fasta",
         insertions = "results/{build_name}/insertions.tsv",


### PR DESCRIPTION
## Description of proposed changes

Replaces a reference to the _rule_ that produces Nextclade data needed for alignment with the _literal path_ to the corresponding output. This approach allows users to define custom rules that generate the same output and override the workflow's default rules. This kind of functionality is important, as it allows users to easily modify the workflow DAG from their custom build configuration and avoid maintaining a fork of the main workflow that can get outdated easily.

## Related issue(s)

Related to #875

## Testing

 - [x] Tested by CI