### PR TITLE
Run `xz` with threads

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -103,7 +103,7 @@ rule align:
             --output-basename {params.basename} \
             --output-fasta {params.uncompressed_alignment} \
             --output-insertions {output.insertions} > {log} 2>&1;
-        xz -2 {params.uncompressed_alignment};
+        xz -2 -T {threads} {params.uncompressed_alignment};
         xz -2 {params.outdir}/{params.basename}*.fasta
         """
 


### PR DESCRIPTION
## Description of proposed changes

This should confer a minor speedup by running `xz` with as many threads as is specified (in this case, 8).

## Related issue(s)

(none)

## Testing

I will find a way to test this and report the results back to you. If anyone else wants to give this a try, be my guest.

## Release checklist

This is not anticipated to be backwards-incompatible. End users should not be substantially affected, other than a minor speedup in the `align` rule (for each input).

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->

---

<sup>Sent with the [GitHub CLI](https://cli.github.com/).</sup>