### PR TITLE
Add nextalign to install instructions

### DIFF
--- a/docs/src/analysis/setup.rst
+++ b/docs/src/analysis/setup.rst
@@ -14,7 +14,7 @@ Follow instructions to install Nextstrain components :doc:`here <docs.nextstrain
 
    .. code:: bash
 
-      mamba install -c conda-forge -c bioconda epiweeks nextclade pangolin pangolearn
+      mamba install -c conda-forge -c bioconda epiweeks nextclade nextalign pangolin pangolearn
 
 2. Download the ncov workflow
 -----------------------------


### PR DESCRIPTION
Fixes error with `rule align` when using native runtime:

```
cat logs/align_reference-data.txt
/bin/bash: nextalign: command not found
```