### PR TITLE
Support disabling the `--clock-filter-iqd` parameter for augur refine

### DIFF
--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -6,6 +6,7 @@ We also use this change log to document new features that maintain backward comp
 ## New features since last version update
 
 - 11 February 2022: Add colors to default Auspice config for Nextclade quality control columns and a filter for overall Nextclade QC status. [PR #861](https://github.com/nextstrain/ncov/pull/861).
+- 8 Mar 2022: Support disabling clock filters in the refine step by setting `clock_filter_iqd: 0` in the `refine` section. [PR #884](https://github.com/nextstrain/ncov/pull/884), [Issue #852](https://github.com/nextstrain/ncov/issues/852).
 
 ## v11 (3 February 2022)
 

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -449,7 +449,7 @@ Valid attributes for list entries in `inputs` are provided below.
 
 ### clock_filter_iqd
 * type: integer
-* description: Remove tips that deviate more than this number of interquartile ranges from the root-to-tip by time regression.
+* description: Remove tips that deviate more than this number of interquartile ranges from the root-to-tip by time regression. Disable clock filtering by specifying `0`
 * default: `4`
 
 ### keep_polytomies

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -450,7 +450,7 @@ Valid attributes for list entries in `inputs` are provided below.
 ### clock_filter_iqd
 * type: integer
 * description: Remove tips that deviate more than this number of interquartile ranges from the root-to-tip by time regression. Disable clock filtering by specifying `0`
-* default: `4`
+* default: `8`
 
 ### keep_polytomies
 * type: boolean

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -834,7 +834,7 @@ rule refine:
         coalescent = config["refine"]["coalescent"],
         date_inference = config["refine"]["date_inference"],
         divergence_unit = config["refine"]["divergence_unit"],
-        clock_filter_iqd = config["refine"]["clock_filter_iqd"],
+        clock_filter_iqd=f"--clock-filter-iqd {config['refine']['clock_filter_iqd']}" if config["refine"].get("clock_filter_iqd") else "",
         keep_polytomies = "--keep-polytomies" if config["refine"].get("keep_polytomies", False) else "",
         timetree = "" if config["refine"].get("no_timetree", False) else "--timetree"
     conda: config["conda_environment"]
@@ -856,7 +856,7 @@ rule refine:
             --divergence-unit {params.divergence_unit} \
             --date-confidence \
             --no-covariance \
-            --clock-filter-iqd {params.clock_filter_iqd} 2>&1 | tee {log}
+            {params.clock_filter_iqd} 2>&1 | tee {log}
         """
 
 rule ancestral:


### PR DESCRIPTION
## Description of proposed changes

Support disabling the `--clock-filter-iqd` parameter for `augur refine`. Since `--clock-filter-iqd 0` doesn't make sense, we can assume that setting the value to 0 (or even false) should disable it.

## Related issue(s)

<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Fixes #852
Related to #

## Testing

For a very simple test config:
```yaml
inputs:
  - name: "root_ref"
    metadata: "data/references_metadata.tsv"
    sequences: "data/references_sequences.fasta"
  - name: "example_data"
    metadata: "data/example_metadata_aus.tsv.xz"
    sequences: "data/example_sequences_aus.fasta.xz"

builds:
  test:
    subsampling_scheme: test_subsampling
    title: test tree

refine:
  keep_polytomies: True
  clock_filter_iqd: 0
  
subsampling:
  test_subsampling:
    test:
      group_by: "division year month"
      max_sequences: 10
      exclude: "--exclude-where 'region=europe'"
```

```
~/ncov# grep clock_filter_iqd my_profiles/builds.yaml
  clock_filter_iqd: 5
~/ncov# rm results/test/tree.nwk && snakemake --printshellcmds auspice/ncov_test.json --profile /tmp/ncov/my_profiles/ --until refine 2>&1 | grep 'augur refine'
        augur refine             --tree results/test/tree_raw.nwk             --alignment results/test/filtered.fasta
             --metadata results/test/metadata_adjusted.tsv.xz             --output-tree results/test/tree.nwk
             --output-node-data results/test/branch_lengths.json             --root Wuhan/Hu-1/2019
             --timetree             --keep-polytomies             --clock-rate 0.0008
             --clock-std-dev 0.0004             --coalescent opt             --date-inference marginal 
            --divergence-unit mutations             --date-confidence
             --no-covariance             --clock-filter-iqd 5 2>&1 | tee logs/refine_test.txt

~/ncov# sed -i 's/filter_iqd:.*/filter_iqd: 0/' my_profiles/builds.yaml
~/ncov# grep clock_filter_iqd my_profiles/builds.yaml
  clock_filter_iqd: 0
~/ncov# rm results/test/tree.nwk && snakemake --printshellcmds auspice/ncov_test.json --profile /tmp/ncov/my_profiles/ --until refine 2>&1 | grep 'augur refine'
        augur refine             --tree results/test/tree_raw.nwk             --alignment results/test/filtered.fasta
             --metadata results/test/metadata_adjusted.tsv.xz             --output-tree results/test/tree.nwk
             --output-node-data results/test/branch_lengths.json             --root Wuhan/Hu-1/2019
             --timetree             --keep-polytomies             --clock-rate 0.0008
             --clock-std-dev 0.0004             --coalescent opt             --date-inference marginal
             --divergence-unit mutations             --date-confidence
             --no-covariance              2>&1 | tee logs/refine_test.txt
```

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
