### PR TITLE
Shell quote user-provided subsampling options

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -160,9 +160,9 @@ def get_priority_argument(wildcards):
         return ""
 
     if subsampling_settings["priorities"]["type"] == "proximity":
-        return "--priority " + get_priorities(wildcards)
+        return "--priority " + shquote(get_priorities(wildcards))
     elif subsampling_settings["priorities"]["type"] == "file" and "file" in subsampling_settings["priorities"]:
-        return "--priority " + subsampling_settings["priorities"]["file"]
+        return "--priority " + shquote(subsampling_settings["priorities"]["file"])
     else:
         return ""
 
@@ -199,7 +199,7 @@ def _get_specific_subsampling_setting(setting, optional=False):
             elif setting == 'max_sequences':
                 value = f"--subsample-max-sequences {value}"
 
-            return value
+            return shquotewords(value)
         else:
             value = ""
 
@@ -207,7 +207,7 @@ def _get_specific_subsampling_setting(setting, optional=False):
         if re.search(r'\{.+\}', value):
             raise Exception(f"The parameters for the subsampling scheme '{wildcards.subsample}' of build '{wildcards.build_name}' reference build attributes that are not defined in the configuration file: '{value}'. Add these build attributes to the appropriate configuration file and try again.")
 
-        return value
+        return shquotewords(value)
 
     return _get_setting
 


### PR DESCRIPTION
## Description of proposed changes

Many (most?) of the subsampling config a user can specify takes the form
of command-line options to `augur filter`.  Previously the values were
passed through unmodified, leaving shell features like variable
interpolation and command substitution as tripping hazards for the user,
who would have to know to escape those in their YAML build config.  This
change preserves the shell-like semantics of single and double quotes
and backslashes in subsampling values, but renders the tripping hazards
inert by re-quoting each word in the value.

This assumes that we don't need to support those shell features within
subsampling config values (e.g. a user subsampling config doesn't need
to refer to an environment variable), or at least that their cost in
complexity for all users outweighs their benefit to a few users.

There are many other places in the workflow which blindly interpolate,
without quoting, user-provided values into shell commands.  This change
demonstrates a pattern we can use to handle them more robustly if we
choose.

Relatedly, we should consider a) explicitly using Snakemake's built in
{foo:q} interpolation syntax by default for single-word values, or b)
coercing Snakemake to always apply quoting unless asked otherwise with
{foo:u} (currently requires a monkeypatch).

## Related issue(s)

Motivated by [discussion in Slack](https://bedfordlab.slack.com/archives/C02Q4Q5S85A/p1646963342491219).

## Testing

- [ ] Test this doesn't break existing configs

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
