### PR TITLE
Fix subsampling_scheme min-date and max-date parameters bug.

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -191,6 +191,10 @@ def _get_specific_subsampling_setting(setting, optional=False):
                     value = f"--exclude-ambiguous-dates-by {value}"
                 elif setting == 'group_by':
                     value = f"--group-by {value}"
+                elif setting == 'min_date':        # FIXED by Anna Battenhouse
+                    value = f"--min-date {value}"
+                elif setting == 'max_date': 
+                    value = f"--max-date {value}"  
         elif value is not None:
             # If is 'seq_per_group' or 'max_sequences' build subsampling setting,
             # need to return the 'argument' for augur


### PR DESCRIPTION
## Description of proposed changes
The min-date and max-date subsampling_scheme parameters do not work properly. This 4-line addition to the _get_setting fundtion in the main_workflow.smk file fixes the problem.

## Related issue(s)
None that I know of.

## Testing
I ran into the problem when I specified a min-date parameter in one of my custom Nextstrain builds. After I made this proposed change it works fine.

## Release checklist
Should not introduce backward incompatible changes since this functionality did not work before.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
