### PR TITLE
docs: update conda environment

### DIFF
--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -1,6 +1,6 @@
 name: ncov-docs
 channels:
-  - defaults
+  - conda-forge
 dependencies:
   - make
   - recommonmark

--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -10,5 +10,6 @@ dependencies:
   - sphinx-argparse
   - sphinx-tabs
   - pip
+  - docutils<0.17 # https://github.com/nextstrain/ncov/issues/891
   - pip:
     - nextstrain-sphinx-theme>=2020.2

--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -6,9 +6,9 @@ dependencies:
   - recommonmark
   - requests
   - sphinx
+  - sphinx-markdown-tables
+  - sphinx-argparse
+  - sphinx-tabs
   - pip
   - pip:
     - nextstrain-sphinx-theme>=2020.2
-    - sphinx-markdown-tables
-    - sphinx-argparse
-    - sphinx-tabs


### PR DESCRIPTION
- Use conda-forge channel
    - defaults channel does not have sphinx extensions.
- Install sphinx extensions using conda
- Install docutils<0.17 
    - docutils=0.17 has issues rendering lists: https://stackoverflow.com/q/67542699
    - This forces an older version of `sphinx-tabs`. See https://github.com/nextstrain/ncov/issues/891#issuecomment-1067588006

Fixes #891.