### PR TITLE
Swap open builds starting points from S3 bucket to data.nextstrain.org

### DIFF
--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -18,8 +18,8 @@ upload:
 # as we re-align everything after subsampling.
 inputs:
   - name: open
-    metadata: "s3://nextstrain-data/files/ncov/open/metadata.tsv.gz"
-    aligned: "s3://nextstrain-data/files/ncov/open/sequences.fasta.xz"
+    metadata: "https://data.nextstrain.org/files/ncov/open/metadata.tsv.gz"
+    aligned: "https://data.nextstrain.org/files/ncov/open/sequences.fasta.xz"
     skip_sanitize_metadata: true
 
 # Define locations for which builds should be created.


### PR DESCRIPTION
## Description of proposed changes

This change accomplishes a couple things:
1. The `data.nextstrain.org/files` URLs are what are advertised in our docs and in the page footer. This makes it more obvious how the build is working.
2. The data.nextstrain.org URLs are backed by CloudFront and should be more performant than direct S3 bucket downloads.

## Testing

I've tested locally.

## Release checklist

I don't believe this change necessitates anything in the release checklist.
