### PR TITLE
Color trees by clade by default

### DIFF
--- a/defaults/auspice_config.json
+++ b/defaults/auspice_config.json
@@ -141,7 +141,7 @@
     "region"
   ],
   "display_defaults": {
-    "color_by": "country",
+    "color_by": "clade_membership",
     "distance_measure": "num_date",
     "geo_resolution": "country",
     "map_triplicate": true,


### PR DESCRIPTION
## Description of proposed changes

Updates the default Auspice config JSON to color by clade, to match what we usually want.

We will leverage this in new tutorials (#894).

## Related issue(s)

_N/A_

## Testing

_N/A_

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
