### PR TITLE
Update open profile to use default clade colorby

### DIFF
--- a/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
@@ -24,11 +24,6 @@
       "type": "categorical"
     },
     {
-      "key": "clade_membership",
-      "title": "Clade",
-      "type": "categorical"
-    },
-    {
       "key": "S1_mutations",
       "title": "S1 mutations",
       "type": "continuous"
@@ -47,7 +42,7 @@
       "key": "mutational_fitness",
       "title": "Mutational fitness",
       "type": "continuous"
-    },    
+    },
     {
       "key": "division",
       "title": "Admin Division",

--- a/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
@@ -24,11 +24,6 @@
       "type": "categorical"
     },
     {
-      "key": "clade_membership",
-      "title": "Clade",
-      "type": "categorical"
-    },
-    {
       "key": "S1_mutations",
       "title": "S1 mutations",
       "type": "continuous"
@@ -47,7 +42,7 @@
       "key": "mutational_fitness",
       "title": "Mutational fitness",
       "type": "continuous"
-    },    
+    },
     {
       "key": "division",
       "title": "Admin Division",

--- a/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
@@ -24,11 +24,6 @@
       "type": "categorical"
     },
     {
-      "key": "clade_membership",
-      "title": "Clade",
-      "type": "categorical"
-    },
-    {
       "key": "S1_mutations",
       "title": "S1 mutations",
       "type": "continuous"
@@ -47,7 +42,7 @@
       "key": "mutational_fitness",
       "title": "Mutational fitness",
       "type": "continuous"
-    },  
+    },
     {
       "key": "division",
       "title": "Admin Division",

--- a/nextstrain_profiles/nextstrain-open/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/global_auspice_config.json
@@ -24,11 +24,6 @@
       "type": "categorical"
     },
     {
-      "key": "clade_membership",
-      "title": "Clade",
-      "type": "categorical"
-    },
-    {
       "key": "S1_mutations",
       "title": "S1 mutations",
       "type": "continuous"
@@ -47,7 +42,7 @@
       "key": "mutational_fitness",
       "title": "Mutational fitness",
       "type": "continuous"
-    },    
+    },
     {
       "key": "division",
       "title": "Admin Division",

--- a/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
@@ -24,11 +24,6 @@
       "type": "categorical"
     },
     {
-      "key": "clade_membership",
-      "title": "Clade",
-      "type": "categorical"
-    },
-    {
       "key": "S1_mutations",
       "title": "S1 mutations",
       "type": "continuous"
@@ -47,7 +42,7 @@
       "key": "mutational_fitness",
       "title": "Mutational fitness",
       "type": "continuous"
-    },    
+    },
     {
       "key": "division",
       "title": "Admin Division",

--- a/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
@@ -24,11 +24,6 @@
       "type": "categorical"
     },
     {
-      "key": "clade_membership",
-      "title": "Clade",
-      "type": "categorical"
-    },
-    {
       "key": "S1_mutations",
       "title": "S1 mutations",
       "type": "continuous"
@@ -47,7 +42,7 @@
       "key": "mutational_fitness",
       "title": "Mutational fitness",
       "type": "continuous"
-    },    
+    },
     {
       "key": "division",
       "title": "Admin Division",

--- a/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
@@ -24,11 +24,6 @@
       "type": "categorical"
     },
     {
-      "key": "clade_membership",
-      "title": "Clade",
-      "type": "categorical"
-    },
-    {
       "key": "S1_mutations",
       "title": "S1 mutations",
       "type": "continuous"
@@ -47,7 +42,7 @@
       "key": "mutational_fitness",
       "title": "Mutational fitness",
       "type": "continuous"
-    },    
+    },
     {
       "key": "division",
       "title": "Admin Division",


### PR DESCRIPTION
## Description of proposed changes

The Nextstrain GISAID profiles do not include an explicit `colorings` entry for `clade_membership`. But by specifying `clade_membership` as default `color_by` this cause "Clade" to be placed at the top of the Color By dropdown selection menu. 

In the current open builds, the default option of clade coloring is sorted to 5th entry from the top. 

This commit is intended to add consistency between GISAID and open builds and to place the default coloring at the top of the dropdown list.

Here is current open color by dropdown:

![open](https://user-images.githubusercontent.com/1176109/160674681-3a98d051-c9f4-4b1d-a811-40339ce755e7.png)

Here is current GISAID color by dropdown that this PR seeks to emulate:

![gisaid](https://user-images.githubusercontent.com/1176109/160674738-58e05340-5863-4a45-a8b2-5adbd28bd10f.png)

## Testing

Trial build deployed to [nextstrain.org/staging/ncov/open/trial/default-clade-colorby/global](https://nextstrain.org/staging/ncov/open/trial/default-clade-colorby/global). This looks to have run as expected and the colorby dropdown is now in the preferred order.

## Release checklist

Nothing required in the release checklist for this change.