### PR TITLE
Revert "Swap open builds starting points from S3 bucket to data.nextstrain.org"

### DIFF
--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -18,8 +18,8 @@ upload:
 # as we re-align everything after subsampling.
 inputs:
   - name: open
-    metadata: "https://data.nextstrain.org/files/ncov/open/metadata.tsv.gz"
-    aligned: "https://data.nextstrain.org/files/ncov/open/sequences.fasta.xz"
+    metadata: "s3://nextstrain-data/files/ncov/open/metadata.tsv.gz"
+    aligned: "s3://nextstrain-data/files/ncov/open/sequences.fasta.xz"
     skip_sanitize_metadata: true
 
 # Define locations for which builds should be created.


### PR DESCRIPTION
This reverts commit 18cb66a75aa65b0302f3e0904c980c8f681846a3.¹

I expect fetching through CloudFront in our builds to be both slower and more
expensive for us.  As our docs² say:

> If you’re running workflows on AWS or GCP compute that fetch this data,
> please use the S3 or GS URLs, respectively, for cheaper (for us) and
> faster (for you) data transfers. Otherwise, please use the
> https://data.nextstrain.org URLs.

¹ https://github.com/nextstrain/ncov/pull/895
² https://docs.nextstrain.org/projects/ncov/en/latest/reference/remote_inputs.html

