### PR TITLE
Replace 27259 as 21M defining mut as reverted in BA.5

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -144,7 +144,7 @@ clade	gene	site	alt
 21K (Omicron)	nuc	10449	A
 21K (Omicron)	nuc	23525	T
 21K (Omicron)	nuc	23599	G
-# 21K mutations
+# 21K mutations			
 21K (Omicron)	nuc	15240	T
 21K (Omicron)	nuc	23202	A
 21K (Omicron)	nuc	24424	T

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -154,7 +154,7 @@ clade	gene	site	alt
 21L (Omicron)	nuc	28882	A
 21L (Omicron)	nuc	21618	T
 21L (Omicron)	nuc	22775	A
-# To distinguish from BA.4/5
+# To distinguish from BA.4/5			
 21L (Omicron)	nuc	12160	G
 21L (Omicron)	nuc	22917	T
 

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -162,9 +162,6 @@ clade	gene	site	alt
 21L (Omicron)	nuc	21618	T
 21L (Omicron)	nuc	22775	A
 21L (Omicron)	nuc	24424	T
-# To distinguish from BA.4/5			
-21L (Omicron)	nuc	12160	G
-21L (Omicron)	nuc	22917	T
 
 21M (Omicron)	nuc	8782	C
 21M (Omicron)	nuc	14408	T

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -152,8 +152,10 @@ clade	gene	site	alt
 21L (Omicron)	nuc	23403	G
 21L (Omicron)	nuc	28881	A
 21L (Omicron)	nuc	28882	A
+21L (Omicron)	nuc	9866	T
 21L (Omicron)	nuc	21618	T
 21L (Omicron)	nuc	22775	A
+21L (Omicron)	nuc	23040	A
 21L (Omicron)	nuc	23525	T
 21L (Omicron)	nuc	23599	G
 21L (Omicron)	nuc	24424	T

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -140,34 +140,38 @@ clade	gene	site	alt
 21K (Omicron)	nuc	23403	G
 21K (Omicron)	nuc	28881	A
 21K (Omicron)	nuc	28882	A
-21K (Omicron)	nuc	15240	T
-21K (Omicron)	nuc	23202	A
+# 21M mutations			
+21K (Omicron)	nuc	10449	A
 21K (Omicron)	nuc	23525	T
 21K (Omicron)	nuc	23599	G
+# 21K mutations
+21K (Omicron)	nuc	15240	T
+21K (Omicron)	nuc	23202	A
 21K (Omicron)	nuc	24424	T
-21K (Omicron)	nuc	27259	C
 
 21L (Omicron)	nuc	8782	C
 21L (Omicron)	nuc	14408	T
 21L (Omicron)	nuc	23403	G
 21L (Omicron)	nuc	28881	A
 21L (Omicron)	nuc	28882	A
+# 21M mutations			
+21L (Omicron)	nuc	10449	A
+21L (Omicron)	nuc	23525	T
+21L (Omicron)	nuc	23599	G
+# 21L mutations			
 21L (Omicron)	nuc	21618	T
 21L (Omicron)	nuc	22775	A
+21L (Omicron)	nuc	24424	T
 # To distinguish from BA.4/5			
 21L (Omicron)	nuc	12160	G
 21L (Omicron)	nuc	22917	T
-
-21L (Omicron)	nuc	23525	T
-21L (Omicron)	nuc	23599	G
-21L (Omicron)	nuc	24424	T
-21L (Omicron)	nuc	27259	C
 
 21M (Omicron)	nuc	8782	C
 21M (Omicron)	nuc	14408	T
 21M (Omicron)	nuc	23403	G
 21M (Omicron)	nuc	28881	A
 21M (Omicron)	nuc	28882	A
+# 21M mutations			
+21M (Omicron)	nuc	10449	A
 21M (Omicron)	nuc	23525	T
 21M (Omicron)	nuc	23599	G
-21M (Omicron)	nuc	27259	C

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -152,10 +152,12 @@ clade	gene	site	alt
 21L (Omicron)	nuc	23403	G
 21L (Omicron)	nuc	28881	A
 21L (Omicron)	nuc	28882	A
-21L (Omicron)	nuc	9866	T
 21L (Omicron)	nuc	21618	T
 21L (Omicron)	nuc	22775	A
-21L (Omicron)	nuc	23040	A
+# To distinguish from BA.4/5
+21L (Omicron)	nuc	12160	G
+21L (Omicron)	nuc	22917	T
+
 21L (Omicron)	nuc	23525	T
 21L (Omicron)	nuc	23599	G
 21L (Omicron)	nuc	24424	T


### PR DESCRIPTION
- fix: replace 27259 in clades.tsv as reverted in BA.5

@trvrb This PR contains the other commits, but let's just rebase on merge then they disappear.