### PR TITLE
Update Omicron clade definitions to be robust to BA.4 and BA.5

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -137,6 +137,7 @@ clade	gene	site	alt
 
 21K (Omicron)	nuc	8782	C
 21K (Omicron)	nuc	14408	T
+21K (Omicron)	nuc	18163	G
 21K (Omicron)	nuc	23403	G
 21K (Omicron)	nuc	28881	A
 21K (Omicron)	nuc	28882	A
@@ -148,6 +149,7 @@ clade	gene	site	alt
 
 21L (Omicron)	nuc	8782	C
 21L (Omicron)	nuc	14408	T
+21L (Omicron)	nuc	18163	G
 21L (Omicron)	nuc	23403	G
 21L (Omicron)	nuc	28881	A
 21L (Omicron)	nuc	28882	A
@@ -156,8 +158,8 @@ clade	gene	site	alt
 21L (Omicron)	nuc	23599	G
 
 21M (Omicron)	nuc	8782	C
-21M (Omicron)	nuc	10449	A
 21M (Omicron)	nuc	14408	T
+21M (Omicron)	nuc	18163	G
 21M (Omicron)	nuc	23403	G
 21M (Omicron)	nuc	28881	A
 21M (Omicron)	nuc	28882	A

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -144,7 +144,6 @@ clade	gene	site	alt
 21K (Omicron)	nuc	23202	A
 21K (Omicron)	nuc	23525	T
 21K (Omicron)	nuc	23599	G
-21K (Omicron)	nuc	24424	T
 21K (Omicron)	nuc	27259	C
 
 21L (Omicron)	nuc	8782	C
@@ -154,16 +153,12 @@ clade	gene	site	alt
 21L (Omicron)	nuc	28882	A
 21L (Omicron)	nuc	21618	T
 21L (Omicron)	nuc	22775	A
-21L (Omicron)	nuc	23525	T
 21L (Omicron)	nuc	23599	G
-21L (Omicron)	nuc	24424	T
-21L (Omicron)	nuc	27259	C
 
 21M (Omicron)	nuc	8782	C
+21M (Omicron)	nuc	10449	A
 21M (Omicron)	nuc	14408	T
 21M (Omicron)	nuc	23403	G
 21M (Omicron)	nuc	28881	A
 21M (Omicron)	nuc	28882	A
-21M (Omicron)	nuc	23525	T
 21M (Omicron)	nuc	23599	G
-21M (Omicron)	nuc	27259	C

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -7,8 +7,8 @@ We also use this change log to document new features that maintain backward comp
 
 - 11 February 2022: Add colors to default Auspice config for Nextclade quality control columns and a filter for overall Nextclade QC status. [PR #861](https://github.com/nextstrain/ncov/pull/861).
 - 8 Mar 2022: Support disabling clock filters in the refine step by setting `clock_filter_iqd: 0` in the `refine` section. [PR #884](https://github.com/nextstrain/ncov/pull/884), [Issue #852](https://github.com/nextstrain/ncov/issues/852).
-
-- 17 March 2022: Add Nextclade_pango column to metadata [PR 892](https://github.com/nextstrain/ncov/pull/892)
+- 17 March 2022: Add `Nextclade_pango` column to metadata [PR 892](https://github.com/nextstrain/ncov/pull/892)
+- 11 April 2022: Update clade definitions to be robust to presence of lineage BA.4 and BA.5 viruses. [PR #913](https://github.com/nextstrain/ncov/pull/913)
 
 ## v11 (3 February 2022)
 


### PR DESCRIPTION
## Description of proposed changes

Including BA.4 and BA.5 sequences can alter tree topology and change clade placement. These clade updates should make existing 21K, 21L and 21M clades robust to these tree topology changes. Existing non-artifactual genomes should receive the same clade label as previously. For the moment, this groups BA.4 and BA.5 into 21L along with BA.2. This was chosen to be robust to stochastic differences in phylogenetic reconstruction.

Here, I walked through my build with the spiked in BA.4 and BA.5 genomes that showed stochastically different topologies for different regional build targets (global, Africa, Asia, etc...).

Iterated to remove homoplasic sites from the clades list and supplement with unique sites. With these changes BA.2, BA.4 and BA.5 consistently group together into a single 21L clade, BA.1 groups into its own 21K clade and BA.3 as well as other non-specific Omicron sequences fall into basal 21M clade.

This update should really be the least impactful to our designations and if BA.4 and/or BA.5 grow they can be given their own clade labels to distinguish from BA.2.

In the linked builds I've highlighted mutations G12160A and G27788T as together these are quite specific for BA.4 and BA.5.

- https://nextstrain.org/staging/21M-update/ncov/gisaid/global?c=gt-nuc_12160,27788&m=div
- https://nextstrain.org/staging/21M-update/ncov/gisaid/africa?c=gt-nuc_12160,27788&m=div
- https://nextstrain.org/staging/21M-update/ncov/gisaid/asia?c=gt-nuc_12160,27788&m=div
- https://nextstrain.org/staging/21M-update/ncov/gisaid/europe?c=gt-nuc_12160,27788&m=div
- https://nextstrain.org/staging/21M-update/ncov/gisaid/north-america?c=gt-nuc_12160,27788&m=div
- https://nextstrain.org/staging/21M-update/ncov/gisaid/oceania?c=gt-nuc_12160,27788&m=div
- https://nextstrain.org/staging/21M-update/ncov/gisaid/south-america?c=gt-nuc_12160,27788&m=div

You can see three primary topologies.

- BA.4 and BA.5 form sublineages within BA.2 (global, Europe)

![global](https://user-images.githubusercontent.com/1176109/162852954-a6eb3e80-fd0a-4e6b-8a13-2b4ddabbb1b4.png)

- BA.4 and BA.5 form a shared sublineage within BA.2 (Africa)

![africa](https://user-images.githubusercontent.com/1176109/162852964-ee7567a2-6f9d-4caa-b49e-0aee0c560626.png)

- BA.4 and BA.5 outgroup relative to BA.2 (North America, Oceania)

![north-america](https://user-images.githubusercontent.com/1176109/162852977-caeca771-572e-4fc6-b259-03d85056c7ec.png)

- One of BA.4/5 as sublineage and one of BA.4/5 as outgroup (Asia, South America)

![asia](https://user-images.githubusercontent.com/1176109/162853335-49c39deb-ca59-4e00-9e30-449aa52dfc0f.png)

Clade labels are now robust with regards to topology in this test dataset with BA.4 and BA.5 spiked-in.

I'll do a trial run to make sure we get consistent behavior on the normal subsampled dataset, but I'd think that this is unlikely to fail.

## Related issue(s)

This PR supersedes #908 and #912. 

## Testing

I've tested fairly extensively locally. Following up with trial builds.

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.
