### PR TITLE
Include Nextclade_pango as coloring / filter in Nextstrain profiles

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/africa_auspice_config.json
@@ -17,7 +17,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GISAID)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -121,6 +126,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-gisaid/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/asia_auspice_config.json
@@ -17,7 +17,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GISAID)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -121,6 +126,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-gisaid/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/europe_auspice_config.json
@@ -17,7 +17,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GISAID)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -121,6 +126,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-gisaid/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/global_auspice_config.json
@@ -17,7 +17,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GISAID)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -121,6 +126,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-gisaid/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/north-america_auspice_config.json
@@ -17,7 +17,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GISAID)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -121,6 +126,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-gisaid/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/oceania_auspice_config.json
@@ -17,7 +17,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GISAID)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -121,6 +126,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-gisaid/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-gisaid/south-america_auspice_config.json
@@ -17,7 +17,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GISAID)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -121,6 +126,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/africa_auspice_config.json
@@ -20,7 +20,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GenBank)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -110,6 +115,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/asia_auspice_config.json
@@ -20,7 +20,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GenBank)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -110,6 +115,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/europe_auspice_config.json
@@ -20,7 +20,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GenBank)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -110,6 +115,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-open/global_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/global_auspice_config.json
@@ -20,7 +20,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GenBank)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -110,6 +115,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/north-america_auspice_config.json
@@ -20,7 +20,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GenBank)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -110,6 +115,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/oceania_auspice_config.json
@@ -20,7 +20,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GenBank)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -110,6 +115,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",

--- a/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
+++ b/nextstrain_profiles/nextstrain-open/south-america_auspice_config.json
@@ -20,7 +20,12 @@
     },
     {
       "key": "pango_lineage",
-      "title": "Pango Lineage",
+      "title": "Pango Lineage (GenBank)",
+      "type": "categorical"
+    },
+    {
+      "key": "Nextclade_pango",
+      "title": "Pango Lineage (Nextclade)",
       "type": "categorical"
     },
     {
@@ -110,6 +115,7 @@
     "clade_membership",
     "emerging_lineage",
     "pango_lineage",
+    "Nextclade_pango",
     "region",
     "country",
     "division",


### PR DESCRIPTION
## Description of proposed changes

This updates both Nextstrain GISAID and Nextstrain open profiles to include `Nextclade_pango` as a coloring and filter in addition to the existing `pango_lineage` coloring and filter.

`Nextclade_pango` calls are run by the Nextstrain team directly on sequences from GenBank / GISAID. `pango_lineage` calls are taken verbatim from GenBank / GISAID.

There is worry that that having multiple versions of Pango calls will create user confusion, but the Pango calls are inherently messy and so surfacing the fact that different methods give different results may not be a bad thing.

## Testing

I've done limited testing with this so far. Will spin out a trial build to test with.

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

