### PR TITLE
Use `ncov/` as a standalone directory

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -53,21 +53,21 @@ reference_node_name: "USA/WA1/2020"
 # align sequences to, colors for strain attributes in auspice, and auspice
 # configuration files.
 files:
-  include: "ncov/defaults/include.txt"
-  exclude: "ncov/defaults/exclude.txt"
-  reference: "ncov/defaults/reference_seq.gb"
-  alignment_reference: "ncov/defaults/reference_seq.fasta"
-  annotation: "ncov/defaults/annotation.gff"
-  outgroup: "ncov/defaults/outgroup.fasta" # is this arg still used? file doesn't exist in gh repo
-  ordering: "ncov/defaults/color_ordering.tsv"
-  color_schemes: "ncov/defaults/color_schemes.tsv"
-  auspice_config: "ncov/defaults/auspice_config.json"
-  lat_longs: "ncov/defaults/lat_longs.tsv"
-  description: "ncov/defaults/description.md"
-  clades: "ncov/defaults/clades.tsv"
-  emerging_lineages: "ncov/defaults/emerging_lineages.tsv"
-  mutational_fitness_distance_map: "ncov/defaults/mutational_fitness_distance_map.json"
-  sites_to_mask: "ncov/defaults/sites_ignored_for_tree_topology.txt"
+  include: "defaults/include.txt"
+  exclude: "defaults/exclude.txt"
+  reference: "defaults/reference_seq.gb"
+  alignment_reference: "defaults/reference_seq.fasta"
+  annotation: "defaults/annotation.gff"
+  outgroup: "defaults/outgroup.fasta" # is this arg still used? file doesn't exist in gh repo
+  ordering: "defaults/color_ordering.tsv"
+  color_schemes: "defaults/color_schemes.tsv"
+  auspice_config: "defaults/auspice_config.json"
+  lat_longs: "defaults/lat_longs.tsv"
+  description: "defaults/description.md"
+  clades: "defaults/clades.tsv"
+  emerging_lineages: "defaults/emerging_lineages.tsv"
+  mutational_fitness_distance_map: "defaults/mutational_fitness_distance_map.json"
+  sites_to_mask: "defaults/sites_ignored_for_tree_topology.txt"
 
 # Define genes to translate during alignment by nextalign.
 genes: ["ORF1a", "ORF1b", "S", "ORF3a", "E", "M", "ORF6", "ORF7a", "ORF7b", "ORF8", "N", "ORF9b"]

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -53,21 +53,21 @@ reference_node_name: "USA/WA1/2020"
 # align sequences to, colors for strain attributes in auspice, and auspice
 # configuration files.
 files:
-  include: "defaults/include.txt"
-  exclude: "defaults/exclude.txt"
-  reference: "defaults/reference_seq.gb"
-  alignment_reference: "defaults/reference_seq.fasta"
-  annotation: "defaults/annotation.gff"
-  outgroup: "defaults/outgroup.fasta" # is this arg still used? file doesn't exist in gh repo
-  ordering: "defaults/color_ordering.tsv"
-  color_schemes: "defaults/color_schemes.tsv"
-  auspice_config: "defaults/auspice_config.json"
-  lat_longs: "defaults/lat_longs.tsv"
-  description: "defaults/description.md"
-  clades: "defaults/clades.tsv"
-  emerging_lineages: "defaults/emerging_lineages.tsv"
-  mutational_fitness_distance_map: "defaults/mutational_fitness_distance_map.json"
-  sites_to_mask: "defaults/sites_ignored_for_tree_topology.txt"
+  include: "ncov/defaults/include.txt"
+  exclude: "ncov/defaults/exclude.txt"
+  reference: "ncov/defaults/reference_seq.gb"
+  alignment_reference: "ncov/defaults/reference_seq.fasta"
+  annotation: "ncov/defaults/annotation.gff"
+  outgroup: "ncov/defaults/outgroup.fasta" # is this arg still used? file doesn't exist in gh repo
+  ordering: "ncov/defaults/color_ordering.tsv"
+  color_schemes: "ncov/defaults/color_schemes.tsv"
+  auspice_config: "ncov/defaults/auspice_config.json"
+  lat_longs: "ncov/defaults/lat_longs.tsv"
+  description: "ncov/defaults/description.md"
+  clades: "ncov/defaults/clades.tsv"
+  emerging_lineages: "ncov/defaults/emerging_lineages.tsv"
+  mutational_fitness_distance_map: "ncov/defaults/mutational_fitness_distance_map.json"
+  sites_to_mask: "ncov/defaults/sites_ignored_for_tree_topology.txt"
 
 # Define genes to translate during alignment by nextalign.
 genes: ["ORF1a", "ORF1b", "S", "ORF3a", "E", "M", "ORF6", "ORF7a", "ORF7b", "ORF8", "N", "ORF9b"]

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -58,7 +58,6 @@ files:
   reference: "defaults/reference_seq.gb"
   alignment_reference: "defaults/reference_seq.fasta"
   annotation: "defaults/annotation.gff"
-  outgroup: "defaults/outgroup.fasta" # is this arg still used? file doesn't exist in gh repo
   ordering: "defaults/color_ordering.tsv"
   color_schemes: "defaults/color_schemes.tsv"
   auspice_config: "defaults/auspice_config.json"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# placeholder for relative imports

--- a/scripts/sanitize_metadata.py
+++ b/scripts/sanitize_metadata.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 from tempfile import NamedTemporaryFile
 
-from utils import extract_tar_file_contents
+from .utils import extract_tar_file_contents
 
 # Define all possible geographic scales we could expect in the GISAID location
 # field.

--- a/scripts/sanitize_sequences.py
+++ b/scripts/sanitize_sequences.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import re
 import sys
 
-from utils import stream_tar_file_contents
+from .utils import stream_tar_file_contents
 
 
 class DuplicateSequenceError(ValueError):

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1,3 +1,7 @@
+for key, path in config["files"].items():
+    if path.startswith('defaults/'):
+        config["files"][key] = workflow.source_path("../../" + path)
+
 rule sanitize_metadata:
     input:
         metadata=lambda wildcards: _get_path_for_input("metadata", wildcards.origin)


### PR DESCRIPTION
## Description of proposed changes

Expanding some thoughts from https://github.com/nextstrain/ncov/pull/894#discussion_r843096418 and [Slack thread](https://bedfordlab.slack.com/archives/C02Q4Q5S85A/p1646334170382399).

This is intended to be more of a discussion, but created as a draft PR to have some tangible changes.

### Current usage of `ncov/`:

```
ncov/
├─ data/
│  ├─ metadata.tsv
│  ├─ sequences.fasta
├─ my_profiles/
│  ├─ analysis1/
│  │  ├─ config.yaml
│  │  ├─ builds.yaml
│  │  ├─ auspice_config.json
│  ├─ analysis2/
│  │  ├─ config.yaml
│  │  ├─ builds.yaml
│  │  ├─ auspice_config.json
├─ auspice/
│  ├─ global_dataset.json
│  ├─ country_dataset.json
├─ <internal ncov files>
├─ <other Snakemake intermediate files>
/
```

1. `git clone https://github.com/nextstrain/ncov`
2. Customize workflow:
    1. Add custom data in `ncov/data/`
    2. Define a Snakemake profile:
        1. `ncov/my_profiles/<profile>/builds.yaml`
        2. `ncov/my_profiles/<profile>/config.yaml`
        3. `ncov/my_profiles/<your_profile>/auspice_config.json`
        4. Other defaults overrides
3. Run `snakemake`/`nextstrain build` from `ncov/` directory.
    - This produces several directories:
        - `ncov/.snakemake/`
        - `ncov/auspice/`
        - `ncov/benchmarks/`
        - `ncov/logs/`
        - `ncov/results/`
4. View `ncov/auspice/` with `auspice`/`nextstrain view`.
5. Update/set workflow version with `git pull`/`git switch`.

Cons:

1. Using Snakemake profiles is an extra complication and we plan to get rid of `my_profiles/` in #894.
2. File paths in `ncov/my_profiles/<profile>/builds.yaml` must be relative to `ncov/`.
3. This places user files within `ncov/`, a `git` version-controlled directory. `.gitignore` helps, but having users work directly in `ncov/` can lead to potential merge problems during the update step.

### An alternative user story:

```
my-ncov-analyses/
├─ data/
│  ├─ metadata.tsv
│  ├─ sequences.fasta
├─ config/
│  │  ├─ analysis1.yaml
│  │  ├─ analysis2.yaml
│  │  ├─ auspice_config.json
│  │  ├─ <other config files>
├─ ncov/
│  ├─ auspice/
│  │  ├─ global_dataset.json
│  │  ├─ country_dataset.json
│  ├─ <internal ncov files>
│  ├─ <other Snakemake intermediate files>
/
```

1. Create a personal repo from the [ncov-tutorial template repo](https://github.com/nextstrain/ncov-tutorial), for example named `my-ncov-analyses`.
2. `git clone https://github.com/user/my-ncov-analyses`
3. `cd my-ncov-analyses`
4. `git clone https://github.com/nextstrain/ncov`
5. Customize workflow:
    1. Add custom data in `my-ncov-analyses/data/`.
    2. Add a custom workflow config file anywhere within `my-ncov-analyses/`.
    3. Add defaults overrides files anywhere within `my-ncov-analyses/`.
6. Run `snakemake`/`nextstrain build` from `my-ncov-analyses/` directory.
7. View `my-ncov-analyses/ncov/auspice/` with `auspice`/`nextstrain view`.

Pros:

1. Working directory is `my-ncov-analyses/`.
    - File paths in the workflow config file (`builds.yaml`) can be relative to `my-ncov-analyses/`.
2. This uses `ncov/` as a standalone directory, similar to an executable.
    - Compare to current usage, where scripts and other workflow internals are exposed to users.
3. Enables easier sharing of customization files across workflow config files (e.g. use the same `auspice_config.json` in both `analysis1.yaml` and `analysis2.yaml`)

Cons:

1. Requires some workflow changes to get this working (see notes in next section).
2. No strict requirements/guidelines for organizing config files. Maybe Snakemake profiles is a good way to organize these files?
3. Requires the following in `my-ncov-analyses/`:
    1. Ignore `ncov/` from version control: nextstrain/ncov-tutorial@dfc2a6e0e81d6d1a07e5d746e65deb9f98bb11fa
    2. Add a modular `Snakefile` pointing to `ncov/Snakefile`: nextstrain/ncov-tutorial@6125006aa2ddcd01b9e8e8d830ffac02f7c47968

Notes while trying this implementation:

1. There is a base workflow config file `defaults/parameters.yaml` which has `defaults/` paths relative to `ncov/`.
2. Using [`workdir`](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html#configure-working-directory) would scope everything as relative to `ncov/`, including paths intended to be relative to `my-ncov-analyses/`. This defeats the purpose of having `ncov/` as a subdirectory. [`workflow.source_path()`](https://snakemake.readthedocs.io/en/v6.5.5/api_reference/internal/snakemake.html#snakemake.workflow.Workflow.source_path) accomplishes the same thing but can be applied to specific paths only.
    - Example using `workflow.source_path()` to properly scope all `files:` config paths starting with `defaults/`: f4ffc85e
    - Scripts in `ncov/scripts/` also must be properly scoped (this is where I got a bit stuck): 4709e567

## Related issue(s)

## Testing

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
