### PR TITLE
Bump Augur to 15.0.0

### DIFF
--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - augur=14.0.0
+  - augur=15.0.0
   - epiweeks=2.1.2
   - iqtree=2.2.0_beta
   - nextalign=1.11.0


### PR DESCRIPTION
## Description of proposed changes

Bumps Augur to 15.0.0 in the Conda environment. This version of Augur adds support for relative dates in augur filter and frequencies commands.

## Testing

- [x] Tested locally with CI profile
- [x] Tested with CI