### PR TITLE
Omicron only

### DIFF
--- a/docs/src/reference/configuration.rst
+++ b/docs/src/reference/configuration.rst
@@ -470,9 +470,17 @@ include
 ~~~~~~~
 
 -  type: string
--  description: Path to a file with list of strains (one name per line) to include in the analysis regardless of priorities or subsampling during filtering.
+-  description: Path to a file with list of strains (one name per line) to include in the analysis regardless of priorities or subsampling during both the subsampling and filtering steps.
 -  default: ``defaults/include.txt``
 -  used in rules: ``subsample``, ``filter``
+
+include_for_subsampling
+~~~~~~~~~~~~~~~~~~~~~~~
+
+-  type: string
+-  description: Use this if you wish to force-include different strains in the subsampling vs. filter stages. This file is used preferentially to ``files["include"]`` for the subsampling rule only.
+-  default: defaults to ``files["include"]`` if not set.
+-  used in rules: ``subsample``
 
 exclude
 ~~~~~~~

--- a/my_profiles/omicron_gisaid/README.md
+++ b/my_profiles/omicron_gisaid/README.md
@@ -1,0 +1,18 @@
+## Omicron only GISAID build
+
+### Prerequisites:
+
+Appropriate AWS credentials
+
+### How to run
+
+**locally**
+```
+snakemake --cores 4 --configfile my_profiles/omicron_gisaid/config.yaml -p -f auspice/ncov_omicron.json
+```
+
+**AWS**
+
+```
+nextstrain build --aws-batch --cpus 16 --memory 14GiB --detach . --configfile my_profiles/omicron_gisaid/config.yaml -p -f auspice/ncov_omicron.json
+```

--- a/my_profiles/omicron_gisaid/config.yaml
+++ b/my_profiles/omicron_gisaid/config.yaml
@@ -1,0 +1,23 @@
+inputs:
+  - name: gisaid
+    metadata: "s3://nextstrain-ncov-private/metadata.tsv.gz"
+    aligned: "s3://nextstrain-ncov-private/sequences.fasta.xz"
+    skip_sanitize_metadata: true
+builds:
+  omicron:
+    subsampling_scheme: omisampling
+    title: "Genomic epidemiology of SARS-CoV-2 Omicron strains"
+subsampling:
+  omisampling:
+    single:
+      query: --query "(Nextstrain_clade == '21K (Omicron)' | Nextstrain_clade == '21L (Omicron)' | Nextstrain_clade == '21M (Omicron)')"
+      group_by: "region year month"
+      max_sequences: 4000
+refine:
+  root: best
+files:
+  # we force-include the reference at subsampling times 
+  include_for_subsampling: "my_profiles/omicron_gisaid/references.txt"
+  # at filter-time (post alignment, pre IQ-TREE) we remove the references so we have an omicron-only tree
+  exclude: "my_profiles/omicron_gisaid/references.txt"
+  include: "my_profiles/omicron_gisaid/empty.txt"

--- a/my_profiles/omicron_gisaid/references.txt
+++ b/my_profiles/omicron_gisaid/references.txt
@@ -1,0 +1,3 @@
+Wuhan/Hu-1/2019
+Wuhan-Hu-1/2019
+Wuhan/WH01/2019

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -277,7 +277,7 @@ rule subsample:
         """
     input:
         metadata = _get_unified_metadata,
-        include = config["files"]["include"],
+        include = lambda w: config["files"]["include_for_subsampling"] if "include_for_subsampling" in config["files"] else config["files"]["include"],
         priorities = get_priorities,
         exclude = config["files"]["exclude"]
     output:


### PR DESCRIPTION

This PR adds an example which produces an omicron-only build. Viewable here: https://nextstrain.org/staging/ncov/omicron/2022-04-20

![image](https://user-images.githubusercontent.com/8350992/164126581-327d86e9-ab68-4c51-b3af-dd872c672992.png)


To do this we have to modify the rules and add an extra (optional) parameter `config["files"]["include_for_subsampling"]` so that we can include a set of strains for the alignment and subsequently exclude them for the tree building stage.

The resulting build has mutations in the correct co-ordinate system, but note that the ancestral state is the inferred omicron ancestral state, not the canonical Wuhan state. For instance, the root has [S:501Y](https://nextstrain.org/staging/ncov/omicron/2022-04-20?c=gt-S_501). 

One limitation of the implementation here is that you cannot have an omicron-only build within the larger (core) Nextstrain builds because the choice of which files to include is per-workflow, not per-build. 


