### PR TITLE
Sanitize sequences prior to nextclade run

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -478,7 +478,9 @@ rule build_align:
     params:
         outdir = "results/{build_name}/translations",
         genes = ','.join(config.get('genes', ['S'])),
-        basename = "aligned"
+        basename = "aligned",
+        strain_prefixes=config["strip_strain_prefixes"],
+        sanitize_log="logs/sanitize_sequences_before_nextclade_{build_name}.txt",
     log:
         "logs/align_{build_name}.txt"
     benchmark:
@@ -489,7 +491,11 @@ rule build_align:
         mem_mb=3000
     shell:
         """
-        xz -c -d {input.sequences} |  nextclade run \
+        python3 scripts/sanitize_sequences.py \
+            --sequences {input.sequences} \
+            --strip-prefixes {params.strain_prefixes:q} \
+            --output /dev/stdout 2> {params.sanitize_log} \
+            | nextclade run \
             --jobs {threads} \
             --input-fasta /dev/stdin \
             --reference {input.reference} \

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -252,10 +252,17 @@ rule index_sequences:
     benchmark:
         "benchmarks/index_sequences.txt"
     conda: config["conda_environment"]
+    params:
+        strain_prefixes=config["strip_strain_prefixes"],
+        sanitize_log="logs/sanitize_sequences_before_index.txt",
     shell:
         """
-        augur index \
+        python3 scripts/sanitize_sequences.py \
             --sequences {input.sequences} \
+            --strip-prefixes {params.strain_prefixes:q} \
+            --output /dev/stdout 2> {params.sanitize_log} \
+            | augur index \
+            --sequences /dev/stdin \
             --output {output.sequence_index} 2>&1 | tee {log}
         """
 


### PR DESCRIPTION
## Description of proposed changes

Sanitizes sequences, removing any duplicate sequences, prior to running nextclade on subsampled data. This additional check should not add too much to the runtime of the workflow, but it will allow the workflow to continue running when input data contain duplicates and were not sanitized by earlier steps in the workflow (e.g., full alignment or multiple combined input sequences).

## Related issue(s)

Related to https://github.com/nextstrain/ncov-ingest/issues/281 and [this discussion board post](https://discussion.nextstrain.org/t/error-in-augur-tree-duplicated-sequence-name/970/7).

## Testing

 - [x] Tested by CI
 - [x] Tested with duplicate sequences