### PR TITLE
Remove top-level sequences/metadata from config schema

### DIFF
--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -5,10 +5,6 @@ description: snakemake configuration file
 type: object
 
 properties:
-  sequences:
-    type: string
-  metadata:
-    type: string
   inputs:
     type:
       - array


### PR DESCRIPTION
## Description of proposed changes

Support for these were dropped in [v5][1]:

> Drop support for old sequence/metadata inputs. This change removes support for the config["sequences"] and config["metadata"] starting points for the workflow in favor of the more flexible config["inputs"] format.

[1]: https://github.com/nextstrain/ncov/blob/master/docs/src/reference/change_log.md#v5-7-may-2021

## Related issue(s)

_N/A_

## Testing

_N/A_

## Release checklist

_N/A_, this is more of a documentation change.