### PR TITLE
Update clades with 22A, 22B and 22C

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -139,3 +139,42 @@ clade	gene	site	alt
 21M (Omicron)	clade	20B
 21M (Omicron)	nuc	18163	G
 21M (Omicron)	nuc	23599	G
+
+22A (Omicron)	nuc	8782	C
+22A (Omicron)	nuc	14408	T
+22A (Omicron)	nuc	18163	G
+22A (Omicron)	nuc	23403	G
+22A (Omicron)	nuc	28881	A
+22A (Omicron)	nuc	28882	A
+22A (Omicron)	nuc	21618	T
+22A (Omicron)	nuc	22775	A
+22A (Omicron)	nuc	23599	G
+22A (Omicron)	nuc	12160	A
+22A (Omicron)	nuc	9866	C
+22A (Omicron)	nuc	27788	T
+
+22B (Omicron)	nuc	8782	C
+22B (Omicron)	nuc	14408	T
+22B (Omicron)	nuc	18163	G
+22B (Omicron)	nuc	23403	G
+22B (Omicron)	nuc	28881	A
+22B (Omicron)	nuc	28882	A
+22B (Omicron)	nuc	21618	T
+22B (Omicron)	nuc	22775	A
+22B (Omicron)	nuc	23599	G
+22B (Omicron)	nuc	12160	A
+22B (Omicron)	nuc	9866	C
+22B (Omicron)	nuc	27259	A
+
+22C (Omicron)	nuc	8782	C
+22C (Omicron)	nuc	14408	T
+22C (Omicron)	nuc	18163	G
+22C (Omicron)	nuc	23403	G
+22C (Omicron)	nuc	28881	A
+22C (Omicron)	nuc	28882	A
+22C (Omicron)	nuc	21618	T
+22C (Omicron)	nuc	22775	A
+22C (Omicron)	nuc	23599	G
+22C (Omicron)	nuc	22917	A
+22C (Omicron)	nuc	11674	T
+22C (Omicron)	nuc	21721	T

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -140,41 +140,17 @@ clade	gene	site	alt
 21M (Omicron)	nuc	18163	G
 21M (Omicron)	nuc	23599	G
 
-22A (Omicron)	nuc	8782	C
-22A (Omicron)	nuc	14408	T
-22A (Omicron)	nuc	18163	G
-22A (Omicron)	nuc	23403	G
-22A (Omicron)	nuc	28881	A
-22A (Omicron)	nuc	28882	A
-22A (Omicron)	nuc	21618	T
-22A (Omicron)	nuc	22775	A
-22A (Omicron)	nuc	23599	G
+22A (Omicron)	clade	21L (Omicron)
 22A (Omicron)	nuc	12160	A
 22A (Omicron)	nuc	9866	C
 22A (Omicron)	nuc	27788	T
 
-22B (Omicron)	nuc	8782	C
-22B (Omicron)	nuc	14408	T
-22B (Omicron)	nuc	18163	G
-22B (Omicron)	nuc	23403	G
-22B (Omicron)	nuc	28881	A
-22B (Omicron)	nuc	28882	A
-22B (Omicron)	nuc	21618	T
-22B (Omicron)	nuc	22775	A
-22B (Omicron)	nuc	23599	G
+22B (Omicron)	clade	21L (Omicron)
 22B (Omicron)	nuc	12160	A
 22B (Omicron)	nuc	9866	C
 22B (Omicron)	nuc	27259	A
 
-22C (Omicron)	nuc	8782	C
-22C (Omicron)	nuc	14408	T
-22C (Omicron)	nuc	18163	G
-22C (Omicron)	nuc	23403	G
-22C (Omicron)	nuc	28881	A
-22C (Omicron)	nuc	28882	A
-22C (Omicron)	nuc	21618	T
-22C (Omicron)	nuc	22775	A
-22C (Omicron)	nuc	23599	G
+22C (Omicron)	clade	21L (Omicron)
 22C (Omicron)	nuc	22917	A
 22C (Omicron)	nuc	11674	T
 22C (Omicron)	nuc	21721	T

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -6,30 +6,30 @@ clade	gene	site	alt
 19B	nuc	8782	T
 19B	nuc	28144	C
 
-20A	clade	19A	
+20A	clade	19A
 20A	nuc	14408	T
 20A	nuc	23403	G
 
-20B	clade	20A	
+20B	clade	20A
 20B	nuc	28881	A
 20B	nuc	28882	A
 
-20C	clade	20A	
+20C	clade	20A
 20C	nuc	1059	T
 20C	nuc	25563	T
 
-20D	clade	20B	
+20D	clade	20B
 20D	nuc	4002	T
 20D	nuc	10097	A
 20D	nuc	13536	T
 20D	nuc	23731	T
 
-20E (EU1)	clade	20A	
+20E (EU1)	clade	20A
 20E (EU1)	nuc	22227	T
 20E (EU1)	nuc	28932	T
 20E (EU1)	nuc	29645	T
 
-20F	clade	20B	
+20F	clade	20B
 20F	nuc	1163	T
 20F	nuc	7540	C
 20F	nuc	16647	T
@@ -37,7 +37,7 @@ clade	gene	site	alt
 20F	nuc	22992	A
 20F	nuc	23401	A
 
-20G	clade	20C	
+20G	clade	20C
 20G	nuc	10319	T
 20G	nuc	18424	G
 20G	nuc	25907	T
@@ -45,18 +45,18 @@ clade	gene	site	alt
 20G	nuc	28472	T
 20G	nuc	28869	T
 
-20H (Beta, V2)	clade	20C	
+20H (Beta, V2)	clade	20C
 20H (Beta, V2)	nuc	23012	A
 20H (Beta, V2)	nuc	23063	T
 20H (Beta, V2)	nuc	23403	G
 20H (Beta, V2)	nuc	26456	T
 
-20I (Alpha, V1)	clade	20B	
+20I (Alpha, V1)	clade	20B
 20I (Alpha, V1)	nuc	14676	T
 20I (Alpha, V1)	nuc	15279	T
 20I (Alpha, V1)	nuc	23063	T
 
-20J (Gamma, V3)	clade	20B	
+20J (Gamma, V3)	clade	20B
 20J (Gamma, V3)	nuc	733	C
 20J (Gamma, V3)	nuc	2749	T
 20J (Gamma, V3)	nuc	3828	T
@@ -64,12 +64,12 @@ clade	gene	site	alt
 20J (Gamma, V3)	nuc	12778	T
 20J (Gamma, V3)	nuc	13860	T
 
-21A (Delta)	clade	20A	
+21A (Delta)	clade	20A
 21A (Delta)	nuc	21618	G
 21A (Delta)	nuc	26767	C
 21A (Delta)	nuc	28461	G
 
-21B (Kappa)	clade	20A	
+21B (Kappa)	clade	20A
 21B (Kappa)	nuc	17523	T
 21B (Kappa)	nuc	22917	G
 21B (Kappa)	nuc	23012	C
@@ -77,33 +77,33 @@ clade	gene	site	alt
 21B (Kappa)	nuc	28881	T
 21B (Kappa)	nuc	29402	T
 
-21C (Epsilon)	clade	20C	
+21C (Epsilon)	clade	20C
 21C (Epsilon)	nuc	17014	T
 21C (Epsilon)	nuc	21600	T
 21C (Epsilon)	nuc	22018	T
 21C (Epsilon)	nuc	22917	G
 
-21D (Eta)	clade	20A	
+21D (Eta)	clade	20A
 21D (Eta)	nuc	14407	T
 21D (Eta)	nuc	20724	G
 21D (Eta)	nuc	23593	C
 21D (Eta)	nuc	24224	C
 21D (Eta)	nuc	24748	T
 
-21E (Theta)	clade	20B	
+21E (Theta)	clade	20B
 21E (Theta)	nuc	12049	T
 21E (Theta)	nuc	23341	C
 21E (Theta)	nuc	23604	A
 21E (Theta)	nuc	24187	A
 21E (Theta)	nuc	24836	A
 
-21F (Iota)	clade	20C	
+21F (Iota)	clade	20C
 21F (Iota)	nuc	16500	C
 21F (Iota)	nuc	20262	G
 21F (Iota)	nuc	21575	T
 21F (Iota)	nuc	22320	G
 
-21G (Lambda)	clade	20D	
+21G (Lambda)	clade	20D
 21G (Lambda)	nuc	21786	T
 21G (Lambda)	nuc	21789	T
 21G (Lambda)	nuc	22917	A
@@ -117,22 +117,22 @@ clade	gene	site	alt
 21H (Mu)	nuc	17491	T
 21H (Mu)	nuc	27925	A
 
-21I (Delta)	clade	21A (Delta)	
+21I (Delta)	clade	21A (Delta)
 21I (Delta)	nuc	5184	T
 21I (Delta)	nuc	9891	T
 21I (Delta)	nuc	22227	T
 
-21J (Delta)	clade	21A (Delta)	
+21J (Delta)	clade	21A (Delta)
 21J (Delta)	nuc	11332	G
 21J (Delta)	nuc	19220	T
 
-21K (Omicron)	clade	21M (Omicron)	
+21K (Omicron)	clade	21M (Omicron)
 21K (Omicron)	nuc	15240	T
 21K (Omicron)	nuc	23202	A
 21K (Omicron)	nuc	23525	T
 21K (Omicron)	nuc	27259	C
 
-21L (Omicron)	clade	21M (Omicron)	
+21L (Omicron)	clade	21M (Omicron)
 21L (Omicron)	nuc	21618	T
 21L (Omicron)	nuc	22775	A
 

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -27805,6 +27805,9 @@ clade_membership	21H (Mu)
 clade_membership	21K (Omicron)
 clade_membership	21L (Omicron)
 clade_membership	21M (Omicron)
+clade_membership	22A (Omicron)
+clade_membership	22B (Omicron)
+clade_membership	22C (Omicron)
 
 ################
 

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 27 April 2022: Include new clades 22A, 22B and 22C, where 22A corresponds to Pango lineage BA.4, 22B corresponds to Pango lineage BA.5 and 22C corresponds to Pango lineage BA.2.12.1. Please see [PR 933](https://github.com/nextstrain/ncov/pull/933) for rationale behind these clade updates.
+
 - 27 April 2022: Convert to hierarchical clade definitions. This streamlines clade definitions significantly and makes it easier to understand clade relationships. Changes can be seen in `defaults/clades.tsv` and in [PR 855](https://github.com/nextstrain/ncov/pull/855). **This feature requires Augur v14.0 or above.** To upgrade Augur follow the installation guide at [docs.nextstrain.org](https://docs.nextstrain.org/en/latest/install.html).
 
 - 12 April 2022: Add support for numbers in build names. [PR 524](https://github.com/nextstrain/ncov/pull/524)


### PR DESCRIPTION
### Overview

This elevates the following Pango lineages as labeled clades:
- BA.4 as 22A
- BA.5 as 22B
- BA.2.12.1 as 22C

Each of these still has the parenthetical "(Omicron)" designation as these are all still considered to be the Omicron variant by the WHO.

Here, we are following updated Nextclade designation rules that call for a clade to labeled if any of the following are met:
1. A VOC or VOI is recognized by the WHO and given a Greek letter label
2. A clade reaches >20% global frequency for 2 or more months
3. A clade reaches >30% regional frequency for 2 or more months
4. A clade shows consistent >0.05 per day growth in frequency where it's circulating and has reached >5% regional frequency

with additionally (2,3,4) requiring the clade to show multiple mutations in S1 or particular mutations of known biological relevance

Evidence of each of the three clades hitting these criteria is provided below:

### BA.4 as 22A

- Current view of BA.4 suggests consistent growth in Gauteng (0.09 per day) with it reaching 78% frequency on April 7, but not yet enough data in KwaZulu-Natal.
- We place BA.4 at [14% regional frequency in Africa](https://nextstrain.org/ncov/gisaid/africa?c=emerging_lineage&f_region=Africa).
- BA.4 possesses spike mutations L452R, F486V and R493Q relative to BA.1 and BA.2 and additionally posses del69/70 relative to BA2.

![omicron-south-africa-ba4-ba5_logistic-growth-transformed-axis-ba4](https://user-images.githubusercontent.com/1176109/165597422-cb8798aa-06ec-4901-870a-3cc926853f88.png)

### BA.5 as 22B

- Current view of BA.5 suggests consistent growth in Gauteng (0.07 per day) with it reaching 11% frequency on April 7 and consistent growth in KwaZulu-Natal (0.11 per day) with it reaching 56% frequency on April 7.
- We place BA.5 at [6% regional frequency in Africa](https://nextstrain.org/ncov/gisaid/africa?c=emerging_lineage&f_region=Africa).
- BA.5 possesses spike mutations L452R, F486V and R493Q relative to BA.1 and BA.2 and additionally posses del69/70 relative to BA2.

![omicron-south-africa-ba4-ba5_logistic-growth-transformed-axis-ba5](https://user-images.githubusercontent.com/1176109/165597757-92acea6e-9557-412c-bce5-bb1f11c11cca.png)

### BA.2.12.1 as 22C

- Current view of BA.2.12.1 suggests consistent growth in multiple US states (generally around 0.1 per day, but CA may be faster at 0.15 and NY may be slower at 0.06). Its frequencies are greater than 20% in a number of states as of April 7.
- We place BA.2.12.1 at [6% regional frequency in North America](https://nextstrain.org/ncov/gisaid/north-america?c=emerging_lineage&f_region=North%20America).
- BA.2.12.1 possesses L452Q and S704L relative to BA.2.

![omicron-us-ba2 12 1_logistic-growth-transformed-axis](https://user-images.githubusercontent.com/1176109/165598408-a802d913-ed29-4061-a9c8-730a4f28f653.png)


