### PR TITLE
Update default masking from end to 200 bases

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -101,7 +101,7 @@ mask:
   # Number of bases to mask from the beginning and end of the alignment. These regions of the genome
   # are difficult to sequence accurately.
   mask_from_beginning: 100
-  mask_from_end: 50
+  mask_from_end: 200
 
   # Specific sites to mask in the reference genome's coordinates.
   # These are 1-indexed coordinates of sites that have been identified as prone to sequencing errors.

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 29 April 2022: Update default mask parameters to mask 200 bases from the end of the genome rather than the existing 50. This was necessary because there is a large deletion in this region in circulating 21L viruses. This deletion is causing problems with alignment and the resulting mis-alignment appears as excess mutations in the tree. [PR 939](https://github.com/nextstrain/ncov/pull/939).
+
 - 27 April 2022: Include new clades 22A, 22B and 22C, where 22A corresponds to Pango lineage BA.4, 22B corresponds to Pango lineage BA.5 and 22C corresponds to Pango lineage BA.2.12.1. Please see [PR 933](https://github.com/nextstrain/ncov/pull/933) for rationale behind these clade updates.
 
 - 27 April 2022: Convert to hierarchical clade definitions. This streamlines clade definitions significantly and makes it easier to understand clade relationships. Changes can be seen in `defaults/clades.tsv` and in [PR 855](https://github.com/nextstrain/ncov/pull/855). **This feature requires Augur v14.0 or above.** To upgrade Augur follow the installation guide at [docs.nextstrain.org](https://docs.nextstrain.org/en/latest/install.html).


### PR DESCRIPTION
## Description of proposed changes

Update default mask parameters to mask 200 bases from the end of the genome rather than the existing 50. This was necessary because there is a large deletion in this region in circulating 21L viruses. This deletion is causing problems with alignment and the resulting mis-alignment appears as excess mutations in the tree.

The issue can be currently seen at https://nextstrain.org/ncov/gisaid/global?c=gt-nuc_29765,29766,29767,29768,29760&m=div.

<img width="1235" alt="mutations" src="https://user-images.githubusercontent.com/1176109/166066718-b221785c-1521-405e-99bb-7a3a1ca2c1b0.png">

## Testing

Testing has been fairly extensive with @corneliusroemer's https://nextstrain.org/groups/neherlab builds using https://github.com/neherlab/ncov-simple.

## Release checklist

 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.
