### PR TITLE
Remove whitespace indents from large Auspice JSONs

### DIFF
--- a/scripts/fix-colorings.py
+++ b/scripts/fix-colorings.py
@@ -86,4 +86,4 @@ if __name__ == '__main__':
     adjust_coloring_for_epiweeks(input_json)
 
     with open(args.output, 'w') as f:
-        json.dump(input_json, f, indent=2)
+        json.dump(input_json, f, indent=0)


### PR DESCRIPTION
## Description of proposed changes

This PR reduces the size of the main Auspice JSONs by removing all horizontal indentation from them.

## Related issue(s)

<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
No related issues.

## Testing

I tested this with two local builds on my machine (called `ohio` and `usa`). For a fair side-by-side comparison, I used Python's `json.tool` module to delete the indentation:

```text
$ python3.10 -m json.tool --indent 0 auspice/ncov_ohio.json auspice/ncov_ohio_test.json
$ python3.10 -m json.tool --indent 0 auspice/ncov_usa.json auspice/ncov_usa_test.json
```

This resulted in the following space savings (give or take a trailing newline):

```text
$ ls -l auspice/
total 57768
-rw-r--r-- 1 fanninpm fanninpm  2857736 May  8 02:57 ncov_ohio.json
-rw-r--r-- 1 fanninpm fanninpm    39894 May  8 02:57 ncov_ohio_root-sequence.json
-rw-r--r-- 1 fanninpm fanninpm   641215 May  8 15:07 ncov_ohio_test.json
-rw-r--r-- 1 fanninpm fanninpm   197365 May  8 02:57 ncov_ohio_tip-frequencies.json
-rw-r--r-- 1 fanninpm fanninpm 47854799 May  8 02:45 ncov_usa.json
-rw-r--r-- 1 fanninpm fanninpm    39894 May  8 02:45 ncov_usa_root-sequence.json
-rw-r--r-- 1 fanninpm fanninpm  5729468 May  8 10:57 ncov_usa_test.json
-rw-r--r-- 1 fanninpm fanninpm  1776605 May  8 02:45 ncov_usa_tip-frequencies.json
```

I believe this comes out to 78% space savings for the `ohio` build and 88% for the `usa` build.

(N.B. the feature I used in this tool was added in Python 3.9, which is newer than the Python version in the `nextstrain/base` Docker image.)

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
