### PR TITLE
docs: Improve `tree` entry readability in config file reference

### DIFF
--- a/docs/src/reference/workflow-config-file.rst
+++ b/docs/src/reference/workflow-config-file.rst
@@ -817,6 +817,10 @@ tree
 
 -  type: object
 -  description: Parameters for phylogenetic inference by ``augur tree``. The tree “method” is hardcoded to ``iqtree``.
+-  Valid attributes:
+
+.. contents::
+   :local:
 
 tree-builder-args
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description of proposed changes

Add "Valid attributes" list to `tree` rule

- more consistent with other rules
- helps readability by indenting tree-builder-args under the list

## Related issue(s)

_N/A_

## Testing

See preview

## Release checklist

_N/A_