### PR TITLE
add: context tar gz input to our Terra Workflow

### DIFF
--- a/workflow/wdl/tasks/nextstrain.wdl
+++ b/workflow/wdl/tasks/nextstrain.wdl
@@ -4,6 +4,7 @@ task nextstrain_build {
   input {
     File? sequence_fasta
     File? metadata_tsv
+    File? context_targz  #<= optional contextual sequence
     String build_name = "example"
 
     File? configfile_yaml # e.g. builds.yaml
@@ -25,10 +26,10 @@ task nextstrain_build {
     # Pull ncov, zika or similar pathogen repo
     wget -O master.zip ~{pathogen_giturl}
     INDIR=`unzip -Z1 master.zip | head -n1 | sed 's:/::g'`
-    unzip master.zip  
+    unzip master.zip
 
+    # If a config file (builds.yaml) file is not provided, generate one
     export CONFIGFILE_FLAG=""
-    
     if [ -n "~{sequence_fasta}" ]
     then
       if [ -z "~{metadata_tsv}" ]; then
@@ -60,6 +61,13 @@ task nextstrain_build {
 
     echo "CONFIGFILE_FLAG: " ${CONFIGFILE_FLAG}
 
+    # If a tar gz of contextual sequences are provided such as GISAID Regional datasets, move it to the ncov folder
+    if [ -n "~{context_targz}" ]
+    then
+      cp ~{context_targz} $INDIR/.
+    fi
+
+    # If a custom zipped folder of configs are provided, move it to ncov
     if [ -n "~{custom_zip}" ]
     then
       # Link custom profile (zipped version)

--- a/workflow/wdl/workflow.wdl
+++ b/workflow/wdl/workflow.wdl
@@ -8,6 +8,7 @@ workflow Nextstrain_WRKFLW {
     # Option 1: Pass in a sequence and metadata files, create a configfile_yaml
     File? sequence_fasta
     File? metadata_tsv
+    File? context_targz #<= optional contextual seqs in a tar.gz file
     String? build_name
 
     # Option 2: Use a custom config file (e.g. builds.yaml) with https or s3 sequence or metadata files
@@ -36,6 +37,7 @@ workflow Nextstrain_WRKFLW {
       # Option 1
       sequence_fasta = sequence_fasta,
       metadata_tsv = metadata_tsv,
+      context_targz = context_targz,
       build_name = build_name,
 
       # Option 2


### PR DESCRIPTION
## Description of proposed changes

By request, add a `context_targz` optional input file variable to pass in a bundled `tar.gz` of nextregion contextual sequences as described in the following tutorial.

* https://docs.nextstrain.org/projects/ncov/en/latest/guides/data-prep/gisaid-search.html?highlight=tar%20gz#download-contextual-data-for-your-region-of-interest

## Testing

If you have access, feel free to look at the running test on our [workspace](https://job-manager.dsde-prod.broadinstitute.org/jobs/d493b48f-9677-4fb9-a590-f15c1c3c19c4)


