### PR TITLE
docs: Add links in Data Prep guide to Nextstrain and CDC data files

### DIFF
--- a/docs/src/guides/data-prep/index.rst
+++ b/docs/src/guides/data-prep/index.rst
@@ -16,3 +16,8 @@ We describe the following ways to prepare data for a SARS-CoV-2 analysis:
    local-data
    gisaid-search
    gisaid-full
+
+Alternatively, use pre-curated data files:
+
+1. :ref:`Nextstrain remote inputs <remote-inputs-open-files>`
+2. `CDC: US State and Territory subsample datasets and example builds <https://github.com/CDCgov/usa-sars-cov-2-nextstrain-sets>`__

--- a/docs/src/reference/remote_inputs.rst
+++ b/docs/src/reference/remote_inputs.rst
@@ -49,6 +49,8 @@ Our GISAID and GenBank (open) profiles each define 7 builds (a Global build and 
 
 --------------
 
+.. _remote-inputs-open-files:
+
 Summary of available GenBank (open) files
 -----------------------------------------
 


### PR DESCRIPTION
[_(preview)_](https://nextstrain--955.org.readthedocs.build/projects/ncov/en/955/guides/data-prep/index.html)

## Description of proposed changes

This PR adds links to publicly available pre-curated data files. I thought the data prep guide would be an appropriate place to link out to these resources.

## Related issue(s)

- Fixes #954

## Testing

_N/A_

## Release checklist

_N/A_