### PR TITLE
Let the user know when a requested build does not exist

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -184,6 +184,9 @@ def _get_specific_subsampling_setting(setting, optional=False):
         if isinstance(value, str):
             # Load build attributes including geographic details about the
             # build's region, country, division, etc. as needed for subsampling.
+            if wildcards.build_name not in config["builds"]:
+                raise Exception(f"The requested build name {wildcards.build_name!r} does not exist in the given configuration file. This error occurred while looking up the subsampling setting {setting!r}. This missing build might indicate a typo in the build name.")
+
             build = config["builds"][wildcards.build_name]
             value = value.format(**build)
             if value !="":


### PR DESCRIPTION
## Description of proposed changes

Fixes an issue where the user can request a Snakemake target from the command line that does not match any of the builds they have defined in their configuration and Snakemake raises an unhelpful `KeyError`. This change looks for the build name in the config first and then raises an exception with a more helpful error message, to let the user know what they can do to fix the problem.

## Testing

Tested with same command that was originally used to produce the error at office hours.