### PR TITLE
Deploy *_root-sequence.json sidecar files

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -133,7 +133,7 @@ config["conda_environment"] = CONDA_ENV_PATH
 wildcard_constraints:
     # Allow build names to contain alphanumeric characters, underscores, and hyphens
     # but not special strings used for Nextstrain builds.
-    build_name = r'(?:[-a-zA-Z0-9_](?!(tip-frequencies)))+',
+    build_name = r'(?:[-a-zA-Z0-9_](?!tip-frequencies|root-sequence))+',
     date = r"\d{4}-\d{2}-\d{2}",
     origin = r"[-a-zA-Z0-9_]+"
 

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -38,7 +38,7 @@ properties:
       # Allow build names to contain alphanumeric characters, underscores, and hyphens
       # but not special strings used for Nextstrain builds.  Also used in the
       # workflow's wildcard_constraints.
-      pattern: "^(?:[-a-zA-Z0-9_](?!(tip-frequencies)))+$"
+      pattern: "^(?:[-a-zA-Z0-9_](?!tip-frequencies|root-sequence))+$"
 
   S3_DST_COMPRESSION:
     type: string

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -312,7 +312,7 @@ rule dated_json:
     message: "Copying dated Auspice JSON"
     input:
         auspice_json = rules.finalize.output.auspice_json,
-        tip_frequencies_json = rules.include_hcov19_prefix.output.tip_frequencies
+        tip_frequencies_json = rules.finalize.output.tip_frequency_json
     output:
         dated_auspice_json = "auspice/{prefix}_{build_name}_{date}.json",
         dated_tip_frequencies_json = "auspice/{prefix}_{build_name}_{date}_tip-frequencies.json"

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -35,8 +35,10 @@ rule all_regions:
     input:
         auspice_json = expand("auspice/{prefix}_{build_name}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
         tip_frequencies_json = expand("auspice/{prefix}_{build_name}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
+        root_sequence_json = expand("auspice/{prefix}_{build_name}_root-sequence.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES),
         dated_auspice_json = expand("auspice/{prefix}_{build_name}_{date}.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date())),
-        dated_tip_frequencies_json = expand("auspice/{prefix}_{build_name}_{date}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date()))
+        dated_tip_frequencies_json = expand("auspice/{prefix}_{build_name}_{date}_tip-frequencies.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date())),
+        dated_root_sequence_json = expand("auspice/{prefix}_{build_name}_{date}_root-sequence.json", prefix=config["auspice_json_prefix"], build_name=BUILD_NAMES, date=config.get("build_date", get_todays_date()))
 
 # This cleans out files to allow re-run of 'normal' run with `export`
 # to check lat-longs & orderings
@@ -312,10 +314,12 @@ rule dated_json:
     message: "Copying dated Auspice JSON"
     input:
         auspice_json = rules.finalize.output.auspice_json,
-        tip_frequencies_json = rules.finalize.output.tip_frequency_json
+        tip_frequencies_json = rules.finalize.output.tip_frequency_json,
+        root_sequence_json = rules.finalize.output.root_sequence_json
     output:
         dated_auspice_json = "auspice/{prefix}_{build_name}_{date}.json",
-        dated_tip_frequencies_json = "auspice/{prefix}_{build_name}_{date}_tip-frequencies.json"
+        dated_tip_frequencies_json = "auspice/{prefix}_{build_name}_{date}_tip-frequencies.json",
+        dated_root_sequence_json = "auspice/{prefix}_{build_name}_{date}_root-sequence.json"
     benchmark:
         "benchmarks/dated_json_{prefix}_{build_name}_{date}.txt"
     wildcard_constraints:
@@ -324,13 +328,14 @@ rule dated_json:
         # the user-defined prefix as a constraint, so Snakemake does not parse
         # parts of the actual build names as part of the prefix.
         prefix = re.escape(config["auspice_json_prefix"]),
-        build_name = r'(?:[-a-zA-Z0-9_](?!(tip-frequencies|\d{4}-\d{2}-\d{2})))+',
+        build_name = r'(?:[-a-zA-Z0-9_](?!tip-frequencies|root-sequence|\d{4}-\d{2}-\d{2}))+',
         date = r"\d{4}-\d{2}-\d{2}"
     conda: config["conda_environment"]
     shell:
         """
         cp {input.auspice_json} {output.dated_auspice_json}
         cp {input.tip_frequencies_json} {output.dated_tip_frequencies_json}
+        cp {input.root_sequence_json} {output.dated_root_sequence_json}
         """
 
 #

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1480,7 +1480,7 @@ rule include_hcov19_prefix:
 rule finalize:
     message: "Remove extraneous colorings for main build and move frequencies"
     input:
-        auspice_json = lambda w: rules.include_hcov19_prefix.output.auspice_json,
+        auspice_json = rules.include_hcov19_prefix.output.auspice_json,
         frequencies = rules.include_hcov19_prefix.output.tip_frequencies,
         root_sequence_json = rules.export.output.root_sequence_json
     output:


### PR DESCRIPTION
These were generated by the "finalize" rule but not deployed because
they weren't inputs of the "all_regions" rule, on which the "deploy"
rule piggybacked.

Note however that the "upload" rule did include them, but that doesn't
affect deploy on nextstrain.org (only data.nextstrain.org/files/ncov/…).

## Testing

- [x] CI build works locally
- [x] DAG (`--filegraph` version) looks correct 

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
