### PR TITLE
Use Augur's `io.read_metadata`

### DIFF
--- a/scripts/combine_metadata.py
+++ b/scripts/combine_metadata.py
@@ -1,6 +1,5 @@
 import argparse
-from augur.io import open_file
-from augur.utils import read_metadata
+from augur.io import open_file, read_metadata
 from Bio import SeqIO
 import csv
 import sys
@@ -45,7 +44,12 @@ if __name__ == '__main__':
     # READ IN METADATA FILES
     metadata = []
     for (origin, fname) in zip(args.origins, args.metadata):
-        data, columns = read_metadata(fname)
+        data = read_metadata(fname)
+        columns = ["strain"] + data.columns.tolist()
+        data = data.to_dict(orient="index")
+        for strain in data.keys():
+            data[strain]["strain"] = strain
+
         metadata.append({'origin': origin, "fname": fname, 'data': data, 'columns': columns, 'strains': {s for s in data.keys()}})
 
     # SUMMARISE INPUT METADATA
@@ -64,8 +68,8 @@ if __name__ == '__main__':
     for strain in combined_data:
         for column in combined_columns:
             if column not in combined_data[strain]:
-                combined_data[strain][column] = EMPTY    
-    
+                combined_data[strain][column] = EMPTY
+
     for idx in range(1, len(metadata)):
         for strain, row in metadata[idx]['data'].items():
             if strain not in combined_data:

--- a/scripts/combine_metadata.py
+++ b/scripts/combine_metadata.py
@@ -45,10 +45,9 @@ if __name__ == '__main__':
     metadata = []
     for (origin, fname) in zip(args.origins, args.metadata):
         data = read_metadata(fname)
-        columns = ["strain"] + data.columns.tolist()
+        data.insert(0, "strain", data.index.values)
+        columns = data.columns
         data = data.to_dict(orient="index")
-        for strain in data.keys():
-            data[strain]["strain"] = strain
 
         metadata.append({'origin': origin, "fname": fname, 'data': data, 'columns': columns, 'strains': {s for s in data.keys()}})
 

--- a/scripts/construct-recency-from-submission-date.py
+++ b/scripts/construct-recency-from-submission-date.py
@@ -1,6 +1,6 @@
 import argparse
 from datetime import datetime
-from augur.utils import read_metadata
+from augur.io import read_metadata
 import json
 
 def get_recency(date_str, ref_date):
@@ -31,12 +31,12 @@ if __name__ == '__main__':
     parser.add_argument('--output', type=str, required=True, help="output json")
     args = parser.parse_args()
 
-    meta, columns = read_metadata(args.metadata)
+    meta = read_metadata(args.metadata)
 
     node_data = {'nodes':{}}
     ref_date = datetime.now()
 
-    for strain, d in meta.items():
+    for strain, d in meta.iterrows():
         if 'date_submitted' in d and d['date_submitted'] and d['date_submitted'] != "undefined":
             node_data['nodes'][strain] = {'recency': get_recency(d['date_submitted'], ref_date)}
 

--- a/scripts/find_clusters.py
+++ b/scripts/find_clusters.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
-from augur.utils import read_tree, read_node_data, read_metadata
+from augur.io import read_metadata
+from augur.utils import read_tree, read_node_data
 from collections import Counter
 import csv
 import hashlib
@@ -26,7 +27,7 @@ if __name__ == "__main__":
     tree = read_tree(args.tree)
     tree.collapse_all(lambda c: c.branch_length < 1e-5)
 
-    metadata, columns = read_metadata(args.metadata)
+    metadata = read_metadata(args.metadata)
     muts = read_node_data(args.mutations)
     attribute_name = args.attribute_name
     group_by = args.group_by
@@ -43,7 +44,7 @@ if __name__ == "__main__":
                 child_muts_data = muts["nodes"].get(child.name, {})
                 any_muts = (len(child_muts_data.get("muts", [])) > 0)
                 if not any_muts:
-                    count_by_group[metadata[child.name][group_by]] += 1
+                    count_by_group[metadata.loc[child.name, group_by]] += 1
 
                     if polytomy_sequence_id is None and "sequence" in child_muts_data:
                         polytomy_sequence_id = hashlib.sha256(child_muts_data["sequence"].encode()).hexdigest()[:MAX_HASH_LENGTH]
@@ -72,7 +73,7 @@ if __name__ == "__main__":
                 writer.writerow({
                     "strain": polytomy.name,
                     args.attribute_name: polytomy_sequence_id,
-                    group_by: metadata[polytomy.name][group_by]
+                    group_by: metadata.loc[polytomy.name, group_by]
                 })
 
             for child in polytomy.clades:
@@ -80,7 +81,7 @@ if __name__ == "__main__":
                     writer.writerow({
                         "strain": child.name,
                         args.attribute_name: polytomy_sequence_id,
-                        group_by: metadata[child.name][group_by]
+                        group_by: metadata.loc[child.name, group_by]
                     })
 
             clusters += 1


### PR DESCRIPTION
## Description of proposed changes

Replaces all uses of `augur.utils.read_metadata` with the newer (and supported) `augur.io.read_metadata` function. This new function returns a pandas DataFrame instead of a dictionary, so many of the changes here update helper scripts to interact with DataFrames where possible.

## Related issue(s)

Related to https://github.com/nextstrain/augur/pull/934 and https://github.com/nextstrain/augur/issues/970

## Testing

 - Tested combined metadata with two input datasets
 - Confirmed that find clusters and recency annotation scripts produced identical output before and after changes