### PR TITLE
Include Nextstrain profile for one-off country builds

### DIFF
--- a/.github/workflows/rebuild-country.yml
+++ b/.github/workflows/rebuild-country.yml
@@ -1,0 +1,89 @@
+name: Rebuild country-specific phylogenetic dataset
+
+on:
+  # This workflow can be triggered from repository_dispatch events,
+  # for instance, after the appropriate preprocessing actions have completed
+  repository_dispatch:
+    types:
+      - rebuild
+      - gisaid/rebuild
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+    inputs:
+      trial_name:
+        description: "Short name for this trial build, for prefixing the uploaded data and results files. WARNING: without this we will overwrite files in s3://nextstrain-ncov-private and the trees on nextstrain.org/ncov/gisaid..."
+        required: false
+      image:
+        description: 'Specific container image to use for build (will override the default of "nextstrain build")'
+        required: false
+
+env:
+  TRIAL_NAME: ${{ github.event.inputs.trial_name }}
+  NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.image }}
+
+jobs:
+  gisaid:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+      with:
+        python-version: 3.9
+
+    - name: Launch build
+      run: |
+        set -x
+
+        declare -a config
+        config+=(build_date=\'$(date +'%Y-%m-%d')\')
+        if [[ "$TRIAL_NAME" ]]; then
+          config+=(
+            S3_DST_BUCKET=nextstrain-ncov-private/trial/"$TRIAL_NAME"
+            deploy_url=s3://nextstrain-staging/
+            auspice_json_prefix=ncov_gisaid_trial_"$TRIAL_NAME"
+          )
+        else
+          config+=(slack_token=$SLACK_TOKEN)
+        fi
+
+        nextstrain build \
+          --aws-batch \
+          --detach \
+          --cpus 72 \
+          --memory 140GiB \
+          . \
+            deploy \
+            upload \
+            --config "${config[@]}" \
+            --profile nextstrain_profiles/nextstrain-country \
+            --set-threads tree=8 \
+        |& tee build-launch.log
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+
+    - name: Build info
+      run: |
+        if [[ "$TRIAL_NAME" ]]; then
+          echo "--> Trial name is: $TRIAL_NAME"
+          echo
+          echo "--> When completed, the following will be available:"
+          echo "build files: s3://nextstrain-ncov-private/trial/$TRIAL_NAME/"
+          echo "nextstrain URLs: https://nextstrain.org/staging/ncov/gisaid/trial/$TRIAL_NAME/REGION_NAME"
+        else
+          echo "--> GISAID phylogenetic analysis rebuilding on AWS"
+          echo
+          echo "--> When completed, the following will be updated:"
+          echo "build files: s3://nextstrain-ncov-private/REGION_NAME/"
+          echo "nextstrain URLs: https://nextstrain.org/ncov/gisaid/REGION_NAME"
+        fi
+        echo
+        echo "--> You can attach to this AWS job via:"
+        tail -n1 build-launch.log
+        echo
+        JOBID=$( tail -n1 build-launch.log | sed -E 's/.+attach ([-a-f0-9]+).+/\1/' )
+        echo "--> View this job in the AWS console via"
+        echo "    https://console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/${JOBID}"
+        echo

--- a/nextstrain_profiles/nextstrain-country/builds.yaml
+++ b/nextstrain_profiles/nextstrain-country/builds.yaml
@@ -1,0 +1,172 @@
+auspice_json_prefix: ncov_country
+
+# Define custom rules for pre- or post-standard workflow processing of data.
+custom_rules:
+  - workflow/snakemake_rules/export_for_nextstrain.smk
+
+# These parameters are only used by the `export_for_nextstrain` rule and shouldn't need to be modified.
+# To modify the s3 _source_ bucket, specify this directly in the `inputs` section of the config.
+# P.S. These are intentionally set as top-level keys as this allows command-line overrides.
+S3_DST_BUCKET: "nextstrain-ncov-private"
+S3_DST_COMPRESSION: "xz"
+S3_DST_ORIGINS: ["gisaid"]
+upload:
+  - build-files
+
+# Deploy and Slack options are related to Nextstrain live builds and don't need to be modified for local builds
+deploy_url: s3://nextstrain-data
+slack_token: ~
+slack_channel: "#ncov-gisaid-updates"
+
+genes: ["ORF1a", "ORF1b", "S", "ORF3a", "E", "M", "ORF6", "ORF7a", "ORF7b", "ORF8", "N", "ORF9b"]
+use_nextalign: true
+include_hcov19_prefix: True
+
+files:
+  description: "nextstrain_profiles/nextstrain-country/nextstrain_description.md"
+
+# Note: unaligned sequences are provided as "aligned" sequences to avoid an initial full-DB alignment
+# as we re-align everything after subsampling.
+inputs:
+  - name: gisaid
+    metadata: "s3://nextstrain-ncov-private/metadata.tsv.gz"
+    aligned: "s3://nextstrain-ncov-private/sequences.fasta.xz"
+    skip_sanitize_metadata: true
+
+# Define locations for which builds should be created.
+# For each build we specify a subsampling scheme via an explicit key.
+# These subsampling schemes are defined at the bottom of this file.
+# (They override the defaults)
+# North America and Oceania are subsampled at the "division" level
+# Africa, Asia, Europe and South America are subsampled at the "country" level
+#
+# Auspice config is specified in rule auspice_config in export_for_nextstrain.smk
+builds:
+  nextstrain_country_2m:
+    subsampling_scheme: nextstrain_country_2m
+    title: Genomic epidemiology of SARS-CoV-2 with country-focused subsampling over the past 2 months
+    country: India
+  nextstrain_country_6m:
+    subsampling_scheme: nextstrain_country_6m
+    title: Genomic epidemiology of SARS-CoV-2 with country-focused subsampling over the past 6 months
+    country: India
+  nextstrain_country_all-time:
+    subsampling_scheme: nextstrain_country_all-time
+    title: Genomic epidemiology of SARS-CoV-2 with country-focused subsampling since pandemic start
+    country: India
+
+# remove sequences without division label in US
+filter:
+  exclude_where: "division='USA'"
+
+subsampling:
+
+  # Custom subsampling logic for regions over 2m
+  # Grouping by division for North America and Oceania
+  # 4000 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  nextstrain_country_2m:
+    # Early focal samples for region
+    focal_early:
+      group_by: "division year month"
+      max_sequences: 640
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!={country}'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 160
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country={country}'"
+    # Recent focal samples for region
+    focal_recent:
+      group_by: "division year month"
+      max_sequences: 2560
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!={country}'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 640
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'country={country}'"
+
+  # Custom subsampling logic for regions over 2m
+  # Grouping by division for North America and Oceania
+  # 4000 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  nextstrain_country_6m:
+    # Early focal samples for region
+    focal_early:
+      group_by: "division year month"
+      max_sequences: 640
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!={country}'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 160
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country={country}'"
+    # Recent focal samples for region
+    focal_recent:
+      group_by: "division year month"
+      max_sequences: 2560
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!={country}'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 640
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'country={country}'"
+
+  # Custom subsampling logic for regions over 2m
+  # Grouping by division for North America and Oceania
+  # 4000 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  nextstrain_country_all-time:
+    # Focal samples for country
+    focal:
+      group_by: "division year month"
+      max_sequences: 640
+      exclude: "--exclude-where 'country!={country}'"
+    # Contextual samples from the rest of the world
+    context:
+      group_by: "country year month"
+      max_sequences: 160
+      exclude: "--exclude-where 'country={country}'"
+
+# if different traits should be reconstructed for some builds, specify here
+# otherwise the default trait config in defaults/parameters.yaml will used
+traits:
+  nextstrain_country_2m:
+    sampling_bias_correction: 2.5
+    columns: ["country"]
+  nextstrain_country_6m:
+    sampling_bias_correction: 2.5
+    columns: ["country"]
+  nextstrain_country_all-time:
+    sampling_bias_correction: 2.5
+    columns: ["country"]
+
+# Define frequencies parameters
+# Target frequencies to "2m", "6m" and "all-time" builds
+# narrow_bandwidth = 0.019 or 7 days for "2m"
+# narrow_bandwidth = 0.038 or 14 days for "6m" and "all-time"
+frequencies:
+  nextstrain_country_2m:
+    min_date: "2M"
+    narrow_bandwidth: 0.019
+    recent_days_to_censor: 7
+  nextstrain_country_6m:
+    min_date: "6M"
+    narrow_bandwidth: 0.038
+    recent_days_to_censor: 7
+  nextstrain_country_all-time:
+    min_date: "2020-01-01"
+    narrow_bandwidth: 0.038
+    recent_days_to_censor: 7

--- a/nextstrain_profiles/nextstrain-country/config.yaml
+++ b/nextstrain_profiles/nextstrain-country/config.yaml
@@ -1,0 +1,12 @@
+configfile:
+  - defaults/parameters.yaml
+  - nextstrain_profiles/nextstrain-country/builds.yaml
+
+cores: 8
+keep-going: False
+printshellcmds: True
+show-failed-logs: True
+restart-times: 2
+reason: True
+stats: stats.json
+set-threads: tree=4

--- a/nextstrain_profiles/nextstrain-country/nextstrain_description.md
+++ b/nextstrain_profiles/nextstrain-country/nextstrain_description.md
@@ -1,0 +1,12 @@
+Compiled Nextstrain SARS-CoV-2 resources are available at [nextstrain.org/sars-cov-2](https://nextstrain.org/sars-cov-2/). Follow [@nextstrain](https://twitter.com/nextstrain) for updates.
+
+This phylogeny shows evolutionary relationships of SARS-CoV-2 viruses from the ongoing COVID-19 pandemic. Although the genetic relationships among sampled viruses are generally quite clear, there is considerable uncertainty surrounding estimates of specific transmission dates and in reconstruction of geographic spread. Please be aware that specific inferred geographic transmission patterns and temporal estimates are only a hypothesis.
+
+Site numbering and genome structure uses [Wuhan-Hu-1/2019](https://www.ncbi.nlm.nih.gov/nuccore/MN908947) as reference. The phylogeny is rooted relative to early samples from Wuhan. Temporal resolution assumes a nucleotide substitution rate of 8 &times; 10^-4 subs per site per year. Mutational fitness is calculated using results from [Obermeyer et al (under review)](https://www.medrxiv.org/content/10.1101/2021.09.07.21263228v1). Full details on bioinformatic processing can be found [here](https://github.com/nextstrain/ncov).
+
+We gratefully acknowledge the authors, originating and submitting laboratories of the genetic sequences and metadata made available through [GISAID](https://gisaid.org) on which this research is based. An attribution table is available by clicking on "Download Data" at the bottom of the page and then clicking on "Acknowledgments" in the resulting dialog box.
+
+At the specific request of GISAID, we:
+ - maintain the prefix `hCoV-19/` in the names of viral isolates
+ - disable download of full metadata TSV and provide instead an acknowledgments TSV in the "Download Data" link at the bottom of the page
+ - refrain from sharing alignments or other intermediate files computed in our pipeline


### PR DESCRIPTION
This copies the existing Nextstrain GISAID profile with builds for multiple regions and replaces it with a simpler profile that does a 2m / 6m / all-time build for a single specified country

This is designed to be manually run from GitHub Actions when there is interest in particular country-level build.