### PR TITLE
rebuild-country workflow: rename repository dispatch type

### DIFF
--- a/.github/workflows/rebuild-country.yml
+++ b/.github/workflows/rebuild-country.yml
@@ -6,7 +6,7 @@ on:
   repository_dispatch:
     types:
       - rebuild
-      - gisaid/rebuild
+      - rebuild-country
   # Manually triggered using GitHub's UI
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This workflow shared the same repository dispatch types as our
automated workflow `rebuild-gisaid` so it was triggered by our automated
ncov-ingest run¹

Renaming the repository dispatch type to `rebuild-country` so that it
can still be triggered by a repository dispatch if desired, but is no
longer triggered by our automated runs.

¹ https://github.com/nextstrain/ncov/actions/runs/2593788265


<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
