### PR TITLE
docs: Install more Python deps with Pip instead of Conda

### DIFF
--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -3,13 +3,13 @@ channels:
   - defaults
 dependencies:
   - make
-  - recommonmark
-  - requests
-  - sphinx
   - pip
   - pip:
     - nextstrain-sphinx-theme>=2020.2
-    - sphinx-markdown-tables
+    - recommonmark
+    - requests
+    - sphinx
     - sphinx-argparse
-    - sphinx-tabs
     - sphinx-copybutton
+    - sphinx-markdown-tables
+    - sphinx-tabs

--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -9,6 +9,7 @@ dependencies:
     - recommonmark
     - requests
     - sphinx
+    - docutils<0.18
     - sphinx-argparse
     - sphinx-copybutton
     - sphinx-markdown-tables


### PR DESCRIPTION
Everything but make is pip-installable and the Conda environment is
currently having issues on both RTD (where builds are stopped due to
memory usage) and on GitHub Actions (where builds fail in pip during dep
resolution during the Conda env install).¹  Installing more things with
Pip may help it out.

¹ https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1657059168195909

## Related issue(s)

Alternative to #974.
