### PR TITLE
add: annotation updates up to 2022-07-05

### DIFF
--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -157,8 +157,17 @@ location	Tubas
 location	Jenin
 
 ### Lebanon
+# Tripoli
+location	North Lebanon
+
 # Nabatieh
 location	Bint Jbeil
+
+# Minieh-Danniyeh
+location	North Lebanon
+
+# Akkar
+location	Akkar
 
 ### Syria
 # Idleb
@@ -707,6 +716,7 @@ location	Gudimalakapur
 location	Gudimalkapur
 location	Hanamkonda
 location	Himayathnagar
+location	Hyderab
 location	Hyderabad IN
 location	Jagital
 location	Jagital Rural
@@ -885,6 +895,7 @@ location	Daman and Diu
 # Odisha
 location	Baleshwar
 location	Bhubaneshwar
+location	Cuttak
 location	Ganjam
 location	Jharsuguda
 location	Khordah
@@ -897,7 +908,7 @@ location	Sambalpur
 # Chhattisgarh
 location	Bemetara
 location	Bhilai
-location	Bilaspur CT
+location	Bilaspur
 location	Dhamtari
 location	Durg
 location	Gariyaband
@@ -1342,6 +1353,7 @@ location	Rajgadh
 location	Rajsamand
 location	Sawai Madhopur
 location	Shri Ganganagar
+location	Shriganga Nagar
 location	Shriganganagar
 location	Siakr
 location	Sikar
@@ -1365,6 +1377,7 @@ location	Bareilly
 location	Basti
 location	Bhadohi
 location	Bijnor
+location	Budaun
 location	Chandarnagar
 location	Chandauli
 location	Chanduali
@@ -1394,7 +1407,7 @@ location	Kanpur Nagar
 location	Kanpurnagar
 location	Kaushambi
 location	Khorabar
-location	Kupwara UP
+location	Kupwara
 location	Kushinagar
 location	Lakhimpur (Uttar Pradesh)
 location	Lakhimpurkheri
@@ -1475,6 +1488,7 @@ location	New Delhi
 location	North East
 location	North West
 location	South
+location	South Delhi
 location	South East
 location	South West
 location	Tughlakabad
@@ -1562,13 +1576,14 @@ location	Sri Muktsar Sahib
 location	Tarntaran
 
 # Himachal Pradesh
-location	Bilaspur HP
+location	Bilaspur
 location	Chamba
 location	Hamirpur
 location	Indore (Himachal Pradesh)
 location	Kangra
 location	Kasauli
 location	Kullu
+location	Lahul and Spiti
 location	Mandi
 location	Nahan
 location	Ner Chowk
@@ -1578,6 +1593,7 @@ location	Palampur
 location	Rishikesh (Himachal Pradesh)
 location	Shimla
 location	Sirmaur
+location	Solan
 location	Tanda
 location	Una
 
@@ -1592,7 +1608,7 @@ location	Doda
 location	Jammu
 location	Kathua
 location	Kulgam
-location	Kupwara JK
+location	Kupwara
 location	Nagrota
 location	Nanak Nagar
 location	Poonch
@@ -2012,6 +2028,7 @@ location	Kalachandpur
 location	Kalapara
 location	Kalkini
 location	Kallyanpur
+location	Kamalapur
 location	Kamrangirchar
 location	Kapasia
 location	Karaniganj
@@ -2802,6 +2819,7 @@ location	Gowa
 location	Jeneponto
 location	Luwu
 location	Luwu Timur
+location	Makasar
 location	Makassar
 location	Manado (South Sulawesi)
 location	Maros
@@ -3076,6 +3094,9 @@ location	Loumbila
 location	Ziniare
 
 ### Ghana
+# Bono Region
+location	Sunyani
+
 # Western Region
 location	Abuakwa South (Western Region)
 location	Asankragua
@@ -3086,8 +3107,48 @@ location	Takoradi
 location	Tarkwa
 location	Tarkwa Gold Fields
 
+# Upper West Region
+location	Nandom
+location	Ndom
+location	Wa
+
+# Ashanti Region
+location	Kumasi
+location	Kumasi Metropolitan
+location	Kwadaso
+
 # Central Region GH
 location	Cape Coast
+
+# Bono East Region
+location	Kintampo (Bono East Region)
+
+# Ghana
+location	Kintampo (Ghana)
+
+# Northern Region GH
+location	Tamale (Northern Region GH)
+
+# Volta Region
+location	Ho
+
+# Upper East Region
+location	Bolgatanga (Upper East Region)
+location	Lerigu (Upper East Region)
+location	Navrongo
+
+# Eastern Region GH
+location	Abuakwa North
+location	Abuakwa South (Eastern Region GH)
+location	Akyemansa
+location	Atiwa West
+location	Koforidua
+location	Kwahu East
+location	Kwahu West (Eastern Region GH)
+location	New Juaben South (Eastern Region GH)
+
+# North East Region
+location	Lerigu (North East Region)
 
 # Greater Accra
 location	Accra
@@ -3110,49 +3171,8 @@ location	Ledzokuku Krowor Municipal
 location	Ledzokuku-Krowor
 location	Tema Metropolitan
 
-# Eastern Region GH
-location	Abuakwa North
-location	Abuakwa South (Eastern Region GH)
-location	Akyemansa
-location	Atiwa West
-location	Koforidua
-location	Kwahu East
-location	Kwahu West (Eastern Region GH)
-location	New Juaben South (Eastern Region GH)
-
-# Ashanti Region
-location	Kumasi
-location	Kumasi Metropolitan
-location	Kwadaso
-
-# Volta Region
-location	Ho
-
-# Bono Region
-location	Sunyani
-
-# Bono East Region
-location	Kintampo (Bono East Region)
-
-# Ghana
-location	Kintampo (Ghana)
-
-# Northern Region GH
-location	Tamale (Northern Region GH)
+# Northern
 location	Tamale (Northern)
-
-# Upper West Region
-location	Nandom
-location	Ndom
-location	Wa
-
-# North East Region
-location	Lerigu (North East Region)
-
-# Upper East Region
-location	Bolgatanga (Upper East Region)
-location	Lerigu (Upper East Region)
-location	Navrongo
 
 ### Togo
 # Golfe
@@ -3256,6 +3276,9 @@ location	Ebolowa
 location	Kribi
 location	Sangmelima
 
+# East
+location	Bertoua
+
 # Littoral CM
 location	Deido
 location	Douala
@@ -3276,6 +3299,9 @@ location	Yaounde
 
 # Adamaoua
 location	Ngaoundere Urbain
+
+# North
+location	Garoua
 
 ### Republic of the Congo
 # Brazzaville
@@ -3923,7 +3949,7 @@ location	Sironko
 location	Soroti
 location	Tororo
 
-# Northern Region UG
+# Northern
 location	Amuru
 location	Gulu
 location	Moroto
@@ -3948,6 +3974,10 @@ location	Ntchisi
 location	Lilongwe
 
 # Northern Region MW
+location	Mzimba
+location	Nkhata Bay
+
+# Northern
 location	Karonga
 location	Mzimba
 location	Mzuzu
@@ -5266,6 +5296,7 @@ location	Castellterçol
 location	Castillo de Ferran
 location	Catlab
 location	Centelles
+location	Centenys
 location	Cerdanya
 location	Cerdanyola
 location	Cerdanyola del Valles
@@ -5428,6 +5459,7 @@ location	Montornes del Valles
 location	Montseny
 location	Mora D'Ebre
 location	Mosqueroles
+location	Nan
 location	Navarcles
 location	Navas
 location	Ocata
@@ -5841,6 +5873,7 @@ location	Erce Pres Liffre
 location	Etables sur Mer
 location	Etel
 location	Etrelles
+location	Evran
 location	Fegreac
 location	Finistere
 location	Fleurigne
@@ -6085,6 +6118,7 @@ location	St Quay Perros
 location	St Quay Portrieux
 location	St Samson sur Rance
 location	St Sauveur des Landes
+location	St Suliac
 location	St Symphorien
 location	St Thual
 location	Ste Cecile
@@ -7756,6 +7790,7 @@ location	Mont-de-l'Enclus
 location	Mouscron
 location	Obigies
 location	Pecq
+location	Pipaix
 location	Ploegsteert
 location	Péruwelz
 location	Ramegnies-Chin
@@ -7895,6 +7930,7 @@ location	Villers-Saint-Amand
 location	Wadelincourt
 
 # Mons
+location	Angre
 location	Baudour
 location	Bauffe
 location	Boussu
@@ -8025,6 +8061,7 @@ location	Sint-Gillis-Waas
 location	Sint-Niklaas
 location	Stekene
 location	Temse
+location	Verrebroek
 location	Vrasene
 
 # La Louvière
@@ -8059,6 +8096,7 @@ location	Froidchapelle
 location	Gozée
 location	Ham-sur-Heure
 location	Ham-sur-Heure-Nalinnes
+location	Lobbes
 location	Macon BE
 location	Momignies
 location	Mont-Sainte-Geneviève
@@ -8244,6 +8282,7 @@ location	Gooik
 location	Grimbergen
 location	Groot-Bijgaarden
 location	Halle
+location	Heikruis
 location	Herfelingen
 location	Herne
 location	Hoeilaart
@@ -8580,6 +8619,7 @@ location	Heer
 location	Maffe
 location	Natoye
 location	Rochefort BE
+location	Somme-Leuze
 location	Sorinnes
 location	Spontin
 location	Yvoir
@@ -8627,6 +8667,7 @@ location	Varendonk
 location	Veerle
 location	Vorselaar
 location	Vosselaar
+location	Wechelderzande
 location	Weelde
 location	Westerlo
 location	Wortel
@@ -8703,6 +8744,7 @@ location	Paal
 location	Schulen
 location	Sint-Truiden
 location	Stevoort
+location	Stokrooie
 location	Tessenderlo
 location	Velm
 location	Waterschei-Zwartberg
@@ -8753,6 +8795,7 @@ location	Borgloon
 location	Eisden
 location	Gellik
 location	Genoelselderen
+location	Guigoven
 location	Heers
 location	Hoelbeek
 location	Hoeselt
@@ -8772,6 +8815,7 @@ location	Rekem
 location	Riemst
 location	Sint-Huibrechts-Hern
 location	Uikhoven
+location	Ulbeek
 location	Vechmaal
 location	Vliermaal
 location	Vliermaalroot
@@ -8905,12 +8949,14 @@ location	Chaineux
 location	Ensival
 location	Eupen
 location	Eynatten
+location	Fosse
 location	Henri-Chapelle
 location	Hergenrath
 location	Herve
 location	Jalhay
 location	Kelmis
 location	Kettenis
+location	Lierneux
 location	Limbourg BE
 location	Lontzen
 location	Malmedy
@@ -11364,6 +11410,7 @@ location	Pencin
 location	Plavy
 location	Prepere
 location	Prisovice
+location	Prysk
 location	Přepeře
 location	Ralsko
 location	Rynoltice
@@ -11539,7 +11586,7 @@ location	Radosov
 location	Radostin nad Oslavou
 location	Rantirov
 location	Rapotice
-location	Rohozna VY
+location	Rohozna
 location	Rokytnice nad Rokytnou
 location	Rouchovany
 location	Rovecne
@@ -11638,7 +11685,7 @@ location	Pardubice (Pardubice Region)
 location	Policka
 location	Prachovice
 location	Prelouc
-location	Rohozna PA
+location	Rohozna
 location	Sebranice
 location	Sec
 location	Slatinany
@@ -11725,6 +11772,7 @@ location	Chornice (South Moravian Region)
 location	Chudcice
 location	Citonice
 location	Damborice
+location	Deblin
 location	Divaky
 location	Dobsice
 location	Dolni Bojanovice
@@ -12022,6 +12070,7 @@ location	Lipova-Lazne
 location	Litovel
 location	Mikulovice U Jeseniku
 location	Naklo CZ
+location	Nezamyslice U Prostejova
 location	Oldrichov
 location	Olomouc
 location	Olomouckykraj
@@ -14756,6 +14805,11 @@ location	Zyrardow
 location	Zyrardowski
 location	Łaz
 
+# Masovia
+location	Nowy Dwor Mazowiecki
+location	Parzniew
+location	Warsaw
+
 # Podkarpackie
 location	Bachórzec
 location	Blazowa Dolna
@@ -17006,27 +17060,44 @@ location	Tartagal
 
 # Jujuy
 location	Abra Pampa
+location	Aguaray
 location	Aguas Calientes
+location	Cachi
+location	Cafayate
 location	Calilegua
 location	El Carmen AR
+location	El Tala
 location	El Talar
+location	Embarcacion
 location	Fraile Pintado
 location	Humahuaca
 location	La Esperanza
+location	La Poma
 location	La Quiaca
+location	Las Lajitas
 location	Ledesma
 location	Libertador General San Martin
 location	Libertador Gra. San Martin
 location	Libertador Gral. San Martin
 location	Maimara
+location	Molinos
 location	Monterrico
+location	Mosconi
 location	Palpala
 location	Perico
+location	Pichanal
+location	Rosario de la Frontera
+location	Sac
+location	Salta
+location	Salvador Mazza
+location	San Jose de Metan
 location	San Pedro (Jujuy)
 location	San Pedro de Jujuy
 location	San Salavdor de Jujuy
 location	San Salvador de Jujuy
+location	Santa Victoria Este
 location	Susques
+location	Tartagal
 location	Tilcara
 
 ### Uruguay
@@ -17303,6 +17374,7 @@ location	Cerro Navia
 location	Colina (Region Metropolitana de Santiago)
 location	Conchali
 location	Curacavi
+location	Curavi
 location	El Bosque CL
 location	El Monte
 location	Estacion Central
@@ -17446,6 +17518,7 @@ location	Calama
 location	Mejillones
 location	Ollague
 location	Region de Antogafasta
+location	San Miguel
 location	San Pedro de Atacama
 location	Taltal
 location	Tarapaca
@@ -17643,10 +17716,10 @@ location	Ariquemes
 location	Buritis (Rondonia)
 location	Cacaulandia
 location	Cacoal
-location	Campo Grande RO
+location	Campo Grande
 location	Campo Novo de Rondonia
 location	Candeias do Jamari
-location	Cariacica RO
+location	Cariacica
 location	Castanheiras
 location	Caucalandia
 location	Cerejeira
@@ -17884,6 +17957,7 @@ location	Cachoeira do Sul
 location	Cachoeirnha
 location	Camaquã
 location	Cambara do Sul
+location	Campestre Da Serra
 location	Campo Bom
 location	Candelaria BR
 location	Candiota
@@ -17949,6 +18023,7 @@ location	Ibiruba
 location	Igrejinha
 location	Ijui
 location	Imbe
+location	Independencia
 location	Itaqui
 location	Ivoti
 location	Lagoa Vermelha
@@ -17956,9 +18031,11 @@ location	Lajeado (Rio Grande do Sul)
 location	Lavras do Sul
 location	Lindolfo Collor
 location	Linha Nova
+location	Maquine
 location	Marata BR
 location	Mariana Pimentel
 location	Montenegro BR
+location	Morrinhos do Sul
 location	Morro Reuter
 location	Mostardas
 location	Muitos Capoes
@@ -17966,6 +18043,7 @@ location	Nonoai (Rio Grande do Sul)
 location	Nova Araca
 location	Nova Bassano
 location	Nova Brescia
+location	Nova Esperanca do Sul
 location	Nova Hartz
 location	Nova Petropolis
 location	Nova Roma do Sul
@@ -17981,8 +18059,10 @@ location	Pareci Novo
 location	Parobe
 location	Passo Fundo
 location	Passo do Sobrado
+location	Paverama
 location	Pedras Altas
 location	Pelotas
+location	Pinhal Da Serra
 location	Pirapo
 location	Piratini
 location	Poco Das Antas
@@ -17990,6 +18070,7 @@ location	Portao
 location	Porto Alegre (Rio Grande do Sul)
 location	Porto Xavier
 location	Portão
+location	Presidente Lucena
 location	Quaraí
 location	Quari
 location	Rio Grande BR
@@ -18016,6 +18097,7 @@ location	Santo Antonio Das Missoes
 location	Sao Borja
 location	Sao Francisco de Paula
 location	Sao Jeronimo
+location	Sao Joao Da Urtiga
 location	Sao Jose Dos Ausentes
 location	Sao Lourenco do Sul
 location	Sao Luiz Gonzaga
@@ -18035,7 +18117,7 @@ location	Selbach
 location	Serafina Correa
 location	Sertao
 location	Sertao Santana
-location	Soledade RS
+location	Soledade
 location	São Domingos do Sul
 location	São Leopoldo
 location	Tapejara (Rio Grande do Sul)
@@ -18049,6 +18131,7 @@ location	Teutonia
 location	Tiradentes (Rio Grande do Sul)
 location	Torres BR
 location	Tramandai
+location	Travesseiro
 location	Tres Coroas
 location	Tres Passos
 location	Tres de Maio
@@ -18222,6 +18305,7 @@ location	California BR
 location	Cambara
 location	Cambe
 location	Cambira
+location	Campina Da Lagoa
 location	Campina Grande do Sul
 location	Campo Largo BR
 location	Campo Magro
@@ -18366,6 +18450,7 @@ location	Pinhao
 location	Pirai do Sul
 location	Piraquara
 location	Pitanga
+location	Planalto
 location	Ponta Grossa
 location	Pontal do Parana
 location	Porecatu
@@ -18660,7 +18745,7 @@ location	Saudades
 location	Schroeder
 location	Seara
 location	Sideropolis
-location	Soledade SC
+location	Soledade
 location	Sombrio
 location	Sul Brasil
 location	Taio
@@ -18841,7 +18926,7 @@ location	Quirinopolis
 location	Rialma
 location	Rianapolis
 location	Rio Verde (Goiás)
-location	Rio de Janeiro GO
+location	Rio de Janeiro
 location	Rubiataba
 location	Sanclerlandia
 location	Santa Barbara de Goias
@@ -18874,7 +18959,7 @@ location	Trindade (Goiás)
 location	Trombas
 location	Turvania
 location	Turvelandia
-location	Uberlandia GO
+location	Uberlandia
 location	Uruacu
 location	Uruana
 location	Urutai
@@ -19549,6 +19634,7 @@ location	Alto Jequitiba
 location	Alvinopolis
 location	Alvorada de Minas
 location	Andradas
+location	Andrelandia
 location	Antonio Carlos (Minas Gerais)
 location	Aracuai
 location	Araguari
@@ -19574,6 +19660,7 @@ location	Boa Esperanca (Minas Gerais)
 location	Bocaiuva
 location	Bom Despacho
 location	Bom Jardim de Minas
+location	Bom Sucesso
 location	Bonfim (Minas Gerais)
 location	Botelhos
 location	Botumirim
@@ -19588,7 +19675,7 @@ location	Cachoeira Da Prata
 location	Cachoeira de Pajeu
 location	Caetanopolis
 location	Cajuri
-location	Caldas MG
+location	Caldas
 location	Camanducaia
 location	Cambuquira
 location	Campanario
@@ -19618,6 +19705,7 @@ location	Cassia BR
 location	Cataguases
 location	Catas Altas
 location	Catuji
+location	Catuti
 location	Cedro do Abaete
 location	Chacara
 location	Chiador
@@ -19825,11 +19913,13 @@ location	Rio Manso
 location	Rio Paranaiba
 location	Rio Piracicaba
 location	Rio Pomba
+location	Ritapolis
 location	Sabara
 location	Sabinopolis
 location	Santa Barbara (Minas Gerais)
 location	Santa Barbara do Monte Verde
 location	Santa Barbara do Tugurio
+location	Santa Cruz de Minas
 location	Santa Juliana
 location	Santa Luzia (Minas Gerais)
 location	Santa Maria de Itabira
@@ -19848,6 +19938,7 @@ location	Sao Domingos Das Dores
 location	Sao Francisco (Minas Gerais)
 location	Sao Francisco de Sales
 location	Sao Goncalo do Abaete
+location	Sao Goncalo do Para
 location	Sao Goncalo do Sapucai
 location	Sao Joao Evangelista
 location	Sao Joao del Rei
@@ -19885,13 +19976,14 @@ location	Turmalina
 location	Uba
 location	Ubaporanga
 location	Uberaba
-location	Uberlandia MG
+location	Uberlandia
 location	Uberlândia
 location	Umburatiba
 location	Unai
 location	Urucania
 location	Varginha
 location	Varjão de Minas
+location	Varzelandia
 location	Vespasiano
 location	Vicosa (Minas Gerais)
 location	Virginopolis
@@ -19969,12 +20061,13 @@ location	Rio Bonito
 location	Rio Claro (Rio de Janeiro)
 location	Rio Das Flores
 location	Rio Das Ostras
+location	Rio de Janeiro
 location	Rio de Janeiro RJ
 location	Santa Maria Madalena
 location	Santo Antonio de Padua
 location	Sao Fidelis
 location	Sao Francisco de Itabapoana
-location	Sao Goncalo RJ
+location	Sao Goncalo
 location	Sao Joao Da Barra
 location	Sao Jose de Uba
 location	Sao Jose do Vale do Rio Preto
@@ -20074,6 +20167,7 @@ location	Canapolis (Bahia)
 location	Canarana (Bahia)
 location	Candeias
 location	Candido Sales
+location	Cansancao
 location	Canudos
 location	Capela do Alto Alegre
 location	Capim Grosso
@@ -20150,6 +20244,7 @@ location	Livramento de Nossa Senhora
 location	Luis Eduardo Magalhaes
 location	Macajuba
 location	Macarani
+location	Macaubas
 location	Madre de Deus
 location	Maiquinique
 location	Malhada
@@ -20182,13 +20277,15 @@ location	Pintadas
 location	Poa (Bahia)
 location	Pojuca
 location	Pontal (Bahia)
+location	Ponto Novo
 location	Porto Seguro
-location	Prado BR
+location	Prado
 location	Queimadas (Bahia)
+location	Quijingue
 location	Remanso
 location	Retirolandia
 location	Riachao do Jacuipe
-location	Riacho de Santana BA
+location	Riacho de Santana
 location	Ribeira do Pombal
 location	Rio do Antonio
 location	Rodelas
@@ -20247,6 +20344,7 @@ location	Alegre
 location	Alfredo Chaves
 location	Alto Rio Novo
 location	Anchieta
+location	Anfonso Claudio
 location	Apiaca
 location	Aracruz
 location	Atilio Vivacqua
@@ -20255,12 +20353,15 @@ location	Barra do Sao Francisco
 location	Boa Esperanca (Espirito Santo)
 location	Bom Jesus do Norte
 location	Brejetuba
+location	Cachoeiro de Itapemerim
 location	Cachoeiro de Itapemirim
+location	Campos Dos Goytacazes
 location	Cariacica (Espirito Santo)
 location	Castelo
 location	Colatina
 location	Conceicao Da Barra
 location	Conceicao do Castelo
+location	Curitiba
 location	Domingos Martins
 location	Dores do Rio Preto
 location	Ecoporanga
@@ -20274,7 +20375,9 @@ location	Ibitirama
 location	Iconha
 location	Irupi
 location	Itaguacu
+location	Itamaraju
 location	Itapemirim
+location	Itatiaiucu
 location	Iuna
 location	Jaguare
 location	Jeronimo Monteiro
@@ -20295,13 +20398,18 @@ location	Ponto Belo
 location	Presidente Kennedy (Espirito Santo)
 location	Rio Bananal
 location	Rio Novo do Sul
+location	Rio de Janeiro
 location	Rochedo (Espirito Santo)
+location	Santa
 location	Santa Leopoldina
 location	Santa Maria de Jetiba
 location	Santa Teresa
 location	Sao Gabriel Da Palha
+location	Sao Jose Dos Calcados
+location	Sao Jose Dos Campos
 location	Sao Jose do Calcado
 location	Sao Mateus
+location	Sao Roque do Canaa
 location	Serra
 location	Sooretama
 location	Vargem Alta
@@ -20451,7 +20559,7 @@ location	Salitre BR
 location	Santa Quiteria
 location	Santana do Cariri
 location	Sao Benedito
-location	Sao Goncalo CE
+location	Sao Goncalo
 location	Sao Goncalo do Amarante (Ceará)
 location	Sao Joao do Jaguaribe
 location	Sao Luis do Curu
@@ -20633,6 +20741,7 @@ location	Lajeado (Pernambuco)
 location	Lajedo
 location	Limoeira
 location	Limoeiro
+location	Macaparana
 location	Manari
 location	Manaus (Pernambuco)
 location	Mirandiba
@@ -20811,7 +20920,7 @@ location	Poco Branco
 location	Presidente Juscelino (Rio Grande do Norte)
 location	Rafael Fernandes
 location	Rgoianinha
-location	Riacho de Santana RN
+location	Riacho de Santana
 location	Riachuelo (Rio Grande do Norte)
 location	Santa Cruz (Rio Grande do Norte)
 location	Santa Maria (Rio Grande do Norte)
@@ -21145,6 +21254,7 @@ location	Puerto Lopez
 location	San Pablo (Manabi)
 location	San Vicente EC
 location	Sucre EC
+location	Tosagua
 
 # Guayas
 location	Daule
@@ -21418,6 +21528,7 @@ location	Armenia (Quindio)
 location	Buenavista
 location	Calarca
 location	Circacia
+location	Circasia
 location	Cordoba, Quindio
 location	Filandia
 location	Genova CO
@@ -21556,7 +21667,7 @@ location	Betulia
 location	Bogota (Antioquia)
 location	Bolivar (Antioquia)
 location	Caceres CO
-location	Caldas CO ANT
+location	Caldas (Antioquia)
 location	Canasgordas
 location	Caracoli
 location	Carepa
@@ -21611,7 +21722,7 @@ location	Mutata
 location	Nechi
 location	Necocli
 location	Necoclí
-location	Prado CO
+location	Prado
 location	Puerto Triunfo
 location	Quibdo (Antioquia)
 location	Remedios
@@ -22079,7 +22190,7 @@ location	Aguacaliente
 location	Alvarado
 location	Carmen CR
 location	Cartago CR
-location	Central CR
+location	Central
 location	Concepcion CR
 location	Dulce Nombre
 location	El Guarco
@@ -22123,6 +22234,16 @@ location	Sacacoyo
 location	San Jose Villanueva
 location	San Pablo Tacachico
 location	Santa Tecla
+
+# San Salvador
+location	Ayutuxtepeque
+location	Guazapa
+location	Ilopango
+location	Mejicanos
+location	San Salvador
+location	Santo Tomas SV
+location	Soyapango
+location	Tonacatepeque
 
 ### Honduras
 # El Paraíso
@@ -22479,7 +22600,7 @@ location	General Escobedo
 location	General Zuazua
 location	Gral. Escobedo
 location	Guadalupe (Nuevo Leon)
-location	Iztapalapa NLE
+location	Iztapalapa
 location	Jardines de la Silla
 location	La Reforma
 location	Lampazos
@@ -22503,10 +22624,10 @@ location	Nicolas Romero
 location	Alvaro Obregon
 location	Chimalhuacan
 location	Coyoacan
-location	Cuauhtemoc CMX
+location	Cuauhtemoc
 location	Gustavo A. Madero
 location	Iztacalco
-location	Iztapalapa CMX
+location	Iztapalapa
 location	Miguel Hidalgo
 location	Tlalpan
 
@@ -22764,6 +22885,7 @@ location	Humbolt County
 location	Imperial County CA
 location	Inyo County
 location	Kern County
+location	King County
 location	Kings County CA
 location	Lake County CA
 location	Lassen County
@@ -22917,12 +23039,14 @@ location	Ada
 location	Alameda County AZ
 location	Anchorage
 location	Apache County
+location	Arapahoe
 location	Bakersfield
 location	Bergen County AZ
 location	Bernalillo
 location	Bexar County AZ
 location	Boulder
 location	Brevard
+location	Brown
 location	Burleigh County AZ
 location	Butler County AZ
 location	Cabarrus AZ
@@ -22932,6 +23056,8 @@ location	Cobb
 location	Cochise Co.
 location	Cochise County
 location	Coconino County
+location	Dakota
+location	Dekalb
 location	Denton
 location	Denver
 location	Doa Ana County AZ
@@ -22940,6 +23066,7 @@ location	El Centro
 location	El Paso County AZ
 location	Fairfax
 location	Franklin County AZ
+location	Fresno AZ
 location	Gila County
 location	Graham County AZ
 location	Grays Harbor
@@ -22955,6 +23082,8 @@ location	Imperial Ca
 location	Imperial County AZ
 location	Jefferson AZ
 location	Johnson AZ
+location	Josephine
+location	Kane
 location	King AZ
 location	King County AZ
 location	Kings AZ
@@ -22985,13 +23114,17 @@ location	Orange AZ
 location	Osceola County
 location	Outagamie
 location	Palo Verde
+location	Pierce
 location	Pima County
 location	Pinal County
 location	Portsmouth
 location	Pulaski
+location	Queens
+location	Ramsey
 location	Sa Luis
 location	Salt Lake
 location	San Diego AZ
+location	San Luis Obispo
 location	Santa Cruz County AZ
 location	Santa Fe AZ
 location	Spokane County AZ
@@ -23002,6 +23135,7 @@ location	Utah AZ
 location	Valdez-Cordova
 location	Valencia AZ
 location	Wake
+location	Washoe
 location	Wayne AZ
 location	Whatcom
 location	Will
@@ -23738,26 +23872,39 @@ location	Woodward County
 # Minnesota
 location	Anoka County
 location	Benton County MN
+location	Brown County
+location	Carlton County
 location	Carver County
 location	Cass County MN
 location	Chisago
 location	Chisago County
-location	Clay County MN
+location	Clay County
 location	Dakota County
+location	Dodge County
+location	Douglas County
 location	Fillmore County
 location	Freeborn County
 location	Goodhue County
 location	Hennepin County
 location	Houston County MN
+location	Isanti County
+location	Kandiyohi County
+location	Le Sueur County
+location	Martin County
+location	Mcleod County
 location	Norman County
 location	Olmsted County
 location	Pine County
 location	Polk County MN
 location	Ramsey County
+location	Rice County
 location	Rose
 location	Scott County MN
+location	Sherburne County
 location	Stearns County
+location	Todd County
 location	Wabasha County
+location	Waseca County
 location	Washington County MN
 location	Winona County
 
@@ -24136,11 +24283,13 @@ location	Lafayette
 location	Lafayette County WI
 location	Langlade
 location	Langlade County
+location	Lee County
 location	Lincoln County WI
 location	Lincoln WI
 location	Manitowoc County
 location	Marathon
 location	Marathon County
+location	Maricopa County
 location	Marinette County
 location	Marquette
 location	Marquette County WI
@@ -24206,7 +24355,7 @@ location	Wood WI
 
 # Illinois
 location	Adams County IL
-location	Alamance County IL
+location	Alamance County
 location	Alexander
 location	Alexander County IL
 location	Alexander County, Il
@@ -24342,7 +24491,7 @@ location	Piatt County, Il
 location	Pike County IL
 location	Pike County, Il
 location	Pope County
-location	Porter County IL
+location	Porter County
 location	Pulaski County IL
 location	Pulaski County, Il
 location	Putman
@@ -24941,7 +25090,7 @@ location	Macon IN
 location	Marion County IN
 location	Monroe County IN
 location	Newton County IN
-location	Porter County IN
+location	Porter County
 location	Ripley County
 location	St Joseph County
 location	St. Joseph County
@@ -24987,6 +25136,7 @@ location	Wayne County MI
 
 # Georgia
 location	Appling County
+location	Atlanta
 location	Bibb County GA
 location	Bulloch
 location	Chatham County GA
@@ -25087,7 +25237,7 @@ location	Johnson OH
 location	Knox County OH
 location	Knox OH
 location	Lake County OH
-location	Lawrence OH
+location	Lawrence
 location	Lenawee
 location	Lenawee County
 location	Licking
@@ -25191,6 +25341,7 @@ location	Saint Lucie County
 location	Saint Petersburg
 location	Santa Rosa County
 location	Santa Rosa FL
+location	Sarasota County
 location	Seminole
 location	Seminole County FL
 location	St Lucie
@@ -25288,7 +25439,7 @@ location	Raleigh County
 location	Upshur
 
 # North Carolina
-location	Alamance County NC
+location	Alamance County
 location	Alexander County NC
 location	Anson County
 location	Ashe County
@@ -25312,6 +25463,7 @@ location	Cedar Grove NC
 location	Chatham County NC
 location	Chatlotte
 location	Cherokee County NC
+location	Cleveland
 location	Cleveland County NC
 location	Columbus County
 location	Columbus NC
@@ -25402,6 +25554,7 @@ location	Albemarle County
 location	Alexandria VA
 location	Arlington County
 location	Bristol County VA
+location	Charlottesville County
 location	Chesterfield County VA
 location	Danville County
 location	Dry Fork
@@ -25599,7 +25752,7 @@ location	Cattaragus County
 location	Cattaraugus County
 location	Cattarugus County
 location	Cayuga County
-location	Central NY
+location	Central
 location	Chautauqua
 location	Chautauqua County NY
 location	Chemung
@@ -25872,13 +26025,17 @@ division	Tubas
 division	Jenin
 
 ### Lebanon
+division	North
+division	Tripoli
 division	Tyr
 division	South
 division	Nabatieh
-division	Beirut
-division	Mount Lebanon
 division	Bekaa
+division	Mount Lebanon
 division	Lebanon
+division	Beirut
+division	Minieh-Danniyeh
+division	Akkar
 
 ### Jordan
 division	Aqaba
@@ -25937,7 +26094,6 @@ division	Capital Governorate
 ### Qatar
 division	Doha
 division	Qatar
-division	Ad-Dawhah
 
 ### Iran
 division	Maku
@@ -26742,22 +26898,23 @@ division	Centre BF
 division	Plateau Central
 
 ### Ghana
-division	Western Region
-division	Central Region GH
-division	Greater Accra
-division	Lower Manya Krobo
 division	Western North Region
-division	Eastern Region GH
-division	Volta
-division	Ashanti Region
-division	Volta Region
 division	Bono Region
+division	Western Region
+division	Upper West Region
+division	Ashanti Region
+division	Central Region GH
 division	Bono East Region
 division	Ghana
 division	Northern Region GH
-division	Upper West Region
-division	North East Region
+division	Volta Region
 division	Upper East Region
+division	Eastern Region GH
+division	North East Region
+division	Lower Manya Krobo
+division	Greater Accra
+division	Volta
+division	Northern
 
 ### Togo
 division	Golfe
@@ -26904,11 +27061,13 @@ division	Haut-Ogooue
 division	Far North
 division	South Region
 division	Yaoundé
+division	East
 division	Littoral CM
 division	Cameroon
 division	Centre Region
 division	South-West
 division	Adamaoua
+division	North
 
 ### Republic of the Congo
 division	Brazzaville
@@ -27122,7 +27281,7 @@ division	Kampala
 division	Central Uganda
 division	Eastern Region UG
 division	Uganda
-division	Northern Region UG
+division	Northern
 
 ### Malawi
 division	Southern Region MW
@@ -27130,6 +27289,7 @@ division	Central
 division	Central Region MW
 division	Malawi
 division	Northern Region MW
+division	Northern
 
 ### Mozambique
 division	Maputo
@@ -27428,6 +27588,7 @@ division	Maaseik
 division	Bastogne
 division	Arlon
 division	Verviers
+division	Skopje
 division	Samara
 
 ### Netherlands
@@ -27743,6 +27904,7 @@ division	Malopolskie
 division	Swietokrzyskie
 division	Warminsko-Mazurskie
 division	Mazowieckie
+division	Masovia
 division	Podkarpackie
 division	Lubelskie
 division	Podlaskie
@@ -28293,6 +28455,7 @@ division	Presidente Hayes
 division	Paraguay
 division	Concepción
 division	Alto Paraguay
+division	San Salvador
 
 ### Bolivia
 division	Tarija
@@ -28518,6 +28681,7 @@ division	Barbados
 
 ### El Salvador
 division	La Libertad SV
+division	San Salvador
 division	El Salvador
 
 ### Saint Lucia

--- a/defaults/lat_longs.tsv
+++ b/defaults/lat_longs.tsv
@@ -11762,6 +11762,7 @@ division	Agusan del Norte	8.92	125.46
 division	Ahvaz	31.3240443	48.6637087
 division	Aichi	35.067543	137.334061
 division	Akita	39.6898802	140.342608
+division	Akkar	34.55494655	36.195424722063564
 division	Aksaray	38.44611	33.878216
 division	Aktobe Region	48.2396582	57.7213289
 division	Akwa-Ibom	4.9408638	7.8412267
@@ -12387,6 +12388,7 @@ division	Duesseldorf	51.236437	6.809537
 division	Dupnitza	42.2613	23.1125
 division	Durango	24.019546	-104.658028
 division	Durazno	-33.0833329	-56.0833331
+division	East	3.9894393	14.178373
 division	East Azerbaijan	37.9211202	46.6821517
 division	East Azerbaijan Province	37.9211202	46.6821517
 division	East Java	-7.6977397	112.4914199
@@ -13274,6 +13276,7 @@ division	Miklavž na Dravskem Polju	46.5073791	15.6973717
 division	Miloslavov	48.0990612	17.3014502
 division	Mimaropa	13.0152201	121.40641830505142
 division	Minas Gerais	-18.35789	-44.411895
+division	Minieh-Danniyeh	34.3873612	36.07475900451338
 division	Minnesota	46.126042	-94.619581
 division	Minsk	53.902334	27.5618791
 division	Minsk Region	54.1603039	27.7558157
@@ -13447,6 +13450,7 @@ division	Nordland	67.27564050000001	13.862360639913621
 division	Normandie	48.8799	0.1713
 division	Norrbotten	66.936364	20.341728
 division	Norte de Santander	8.107454	-72.862123
+division	North	8.7712794	13.7803627
 division	North Aegean	38.72996345	25.95373062710608
 division	North Aegean Islands	38.72996345	25.95373062710608
 division	North America	28.2367447	-97.738017
@@ -13477,6 +13481,7 @@ division	North Western Province	7.9745867	79.97200526412345
 division	North-Western Zambia	-13.0143658	25.4624692
 division	Northeast Kenya	1.1613639999999998	40.19574646888216
 division	Northeastern Region MK	42.1670929	22.002467993493266
+division	Northern	2.797198	32.2643949
 division	Northern Cape	-29.573402	21.2051361
 division	Northern Ireland	54.60219	-6.687146
 division	Northern Mariana Islands	14.149020499999999	145.21345248318923


### PR DESCRIPTION
### Description of proposed changes:

Update annotations up to July 5th. 

Based on this [thread](https://github.com/nextstrain/ncov-ingest/pull/321), removed "additional_location_info" lines at various steps via:

```
cd ncov-ingest/source-data
grep -v "^#.*additional_location_info:" gisaid_annotations.tsv > filtered_gisaid_annotations.tsv
```

A more permanent fix would be to alter [ncov/scripts/curate_metadata/parse_additional_info.py](https://github.com/nextstrain/ncov/blob/master/scripts/curate_metadata/parse_additional_info.py)

Suggestions or discussions are welcome.

### Related Issue(s):

Related to https://github.com/nextstrain/ncov-ingest/pull/325

