### PR TITLE
Add Code/Screenshot Reuse Info

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid/nextstrain_description.md
+++ b/nextstrain_profiles/nextstrain-gisaid/nextstrain_description.md
@@ -22,3 +22,9 @@ At the specific request of GISAID, we:
  - maintain the prefix `hCoV-19/` in the names of viral isolates
  - disable download of full metadata TSV and provide instead an acknowledgments TSV in the "Download Data" link at the bottom of the page
  - refrain from sharing alignments or other intermediate files computed in our pipeline
+
+#### Reusing code or images
+
+All source code for Auspice, the visualization tool, is freely available under the terms of the [GNU Affero General Public License](https://github.com/nextstrain/auspice/blob/HEAD/LICENSE.txt).
+
+Screenshots may be used under a [CC-BY-4.0 license](https://creativecommons.org/licenses/by/4.0/) and attribution to nextstrain.org must be provided. A high-quality download option is available by clicking the **DOWNLOAD DATA** button at the bottom of the page and selecting **SCREENSHOT (SVG)**.

--- a/nextstrain_profiles/nextstrain-open/nextstrain_description.md
+++ b/nextstrain_profiles/nextstrain-open/nextstrain_description.md
@@ -40,3 +40,9 @@ The links below refer to the `${BUILD_PART_0}` region; substitute `${BUILD_PART_
 - [${BUILD_PART_0}/6m Auspice tree](https://data.nextstrain.org/files/ncov/open/${BUILD_PART_0}/${BUILD_PART_0}.json)
 - [${BUILD_PART_0}/6m Auspice root sequence](https://data.nextstrain.org/files/ncov/open/${BUILD_PART_0}/${BUILD_PART_0}_root-sequence.json)
 - [${BUILD_PART_0}/6m Auspice tip frequencies](https://data.nextstrain.org/files/ncov/open/${BUILD_PART_0}/${BUILD_PART_0}_tip-frequencies.json)
+
+#### Reusing code or images
+
+All source code for Auspice, the visualization tool, is freely available under the terms of the [GNU Affero General Public License](https://github.com/nextstrain/auspice/blob/HEAD/LICENSE.txt).
+
+Screenshots may be used under a [CC-BY-4.0 license](https://creativecommons.org/licenses/by/4.0/) and attribution to nextstrain.org must be provided. A high-quality download option is available by clicking the **DOWNLOAD DATA** button at the bottom of the page and selecting **SCREENSHOT (SVG)**.


### PR DESCRIPTION
I regularly get questions about how to reuse screenshots from Nextstrain (all so far about SC2). People don't seem to be finding the info at the bottom of Nextstrain.org.

I thought adding something to this README might help - the formatting (whether `#` or `##` and whether above or below 'Get in touch' could be changed.
Text is copied directly from what you can see at the bottom of Nextstrain.org.

We may also want to consider adding this to the footer of `ncov` builds for added visibility.