### PR TITLE
Bump Nextclade/Nextalign to version 2.3.0

### DIFF
--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -7,8 +7,8 @@ dependencies:
   - augur=15.0.1
   - epiweeks=2.1.2
   - iqtree=2.2.0_beta
-  - nextalign=2.2.0
-  - nextclade=2.2.0
+  - nextalign=2.3.0
+  - nextclade=2.3.0
   - pangolin=3.1.20
   - pangolearn=2022.01.20
   - python>=3.7*


### PR DESCRIPTION
## Description of proposed changes

Version 2.3.0 fixes an issue with failed input sequences [1].

[1] https://github.com/nextstrain/nextclade/releases/tag/2.3.0

## Related issue(s)

Related to https://github.com/nextstrain/nextclade/issues/921

## Testing

- [x] Test locally with `snakemake --use-conda --configfile nextstrain_profiles/nextstrain-ci/builds.yaml`