### PR TITLE
docs: Replace sphinx_copybutton with nextstrain.sphinx.theme

### DIFF
--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -5,7 +5,7 @@ dependencies:
   - make
   - pip
   - pip:
-    - nextstrain-sphinx-theme>=2020.2
+    - nextstrain-sphinx-theme>=2022.5
     - recommonmark
     - requests
     - sphinx

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -63,7 +63,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_markdown_tables',
     'sphinx.ext.intersphinx',
-    'sphinx_copybutton',
+    'nextstrain.sphinx.theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## Description of proposed changes

The new extension already has sphinx_copybutton pre-installed and configured.

## Related issue(s)

https://github.com/nextstrain/sphinx-theme/issues/30

## Testing

- [ ] copy button works on RTD preview build