### PR TITLE
Elevate Pango lineage BA.2.75 to Nextstrain clade 22D

### DIFF
--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -153,3 +153,7 @@ clade	gene	site	alt
 22C (Omicron)	clade	21L (Omicron)
 22C (Omicron)	nuc	22917	A
 22C (Omicron)	nuc	23673	T
+
+22D (Omicron)	clade	21L (Omicron)
+22D (Omicron)	nuc	3796	T
+22D (Omicron)	nuc	26275	G

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -29167,6 +29167,7 @@ clade_membership	21M (Omicron)
 clade_membership	22A (Omicron)
 clade_membership	22B (Omicron)
 clade_membership	22C (Omicron)
+clade_membership	22D (Omicron)
 
 ################
 


### PR DESCRIPTION
This elevates the [Pango lineage BA.2.75](https://github.com/cov-lineages/pango-designation/issues/773) to Nextstrain clade 22D with the label `22D (Omicron)` as impactful Omicron sub-lineages BA.2, BA.4, BA.5, etc... are still labelled as [Omicron by the WHO](https://www.who.int/activities/tracking-SARS-CoV-2-variants).

Critically, BA.2.75 has been increasing in frequency rapidly in India with a consistent logistic growth rate of 0.13 per day, compared to a logistic growth rate of BA.5 of 0.01 per day.

![omicron-ba275_logistic-growth-transformed-axis-BA5-BA275](https://user-images.githubusercontent.com/1176109/180098173-237d4c8c-f683-42e4-83b5-82fcc7ef366e.png)

BA.2.75 was at 15% frequency directly estimated from GISAID data at the beginning of July. This increase of 0.13 per day is comparable to observed increase of [BA.5 in the US and the UK in May](https://github.com/blab/rt-from-frequency-dynamics/blob/6ba5e2e9f8d2459a38682093ff30490472537c46/results/omicron-countries-split/figures/omicron-countries-split_logistic-growth-transformed-axis-22B.png).

Observing this similar trajectory of BA.2.75 in India as observed for BA.5 in multiple geographies strongly suggests that this will be a globally competitive clade, especially as we're seeing BA.2.75 directly outcompete BA.5 in India.

Additionally, there are [nine spike substitutions observed in BA.2.75, including reversion of 493 to wild type](https://cov-spectrum.org/explore/World/AllSamples/Past6M/variants?pangoLineage=BA.2.75*&pangoLineage1=BA.5*&pangoLineage2=BA.2&analysisMode=CompareEquals&), which is greater than the three substitutions observed in BA.4/5.

<img width="742" alt="ncov_variants_shared_mutations_ba5_ba275" src="https://user-images.githubusercontent.com/1176109/180098255-387f5ee1-4f69-46ae-8a42-82968d00e35d.png">

These mutations include G446S which is [shown to escape from existing immunity to BA.2 viruses in DMS assays](https://twitter.com/jbloom_lab/status/1527872408652111872).

Previous Omicron-derived clades 22A (Pango lineage BA.4), 22B (lineage BA.5) and 22C (lineage BA.2.12.1) have driven sizable epidemics across the globe due to a combination of antigenic drift and increased intrinsic transmissibility.

Our primary rationale for labeling Nextstrain clades remains one of circulation and being able to discuss circulating viruses that are driving epidemics.

Our [existing 4 point rationale](https://nextstrain.org/blog/2022-04-29-SARS-CoV-2-clade-naming-2022) includes:

>4. A clade shows consistent >0.05 per day growth in frequency where it’s circulating and has reached >5% regional frequency

as a mechanism to identify a clade early on that is expected to circulate widely. However, this threshold has not been reached for BA.2.75 due to how we calculate "regional" frequency, in this case, frequency in Asia. Our regional frequency estimates subsample viruses within a region equally across countries within a region. However, India is a huge country and observing 15% frequency in India is perhaps 3X the global prevalence of observing 15% frequency in South America.

To be able to call clades at an appropriate time, we propose to add an additional criteria to our existing four, namely:

>5. A clade shows consistent >0.10 per day growth in frequency in a country with at least 50M people and has reached >25% frequency within this country

This gives a higher bar for country-level threshold in terms of variant spread and also restricts to larger countries to reduce stochastic impacts. Here, the observation of >25% frequency requires some extrapolation from samples collected in June to frequency in mid-July, but I think is justified.