### PR TITLE
Fix strain name sanitize logic

### DIFF
--- a/defaults/lat_longs.tsv
+++ b/defaults/lat_longs.tsv
@@ -14604,6 +14604,7 @@ country	China	33.394333	104.689839
 country	Colombia	2.893108	-73.7845142
 country	Costa Rica	10.0379	-83.818759
 country	Côte d'Ivoire	7.9897371	-5.5679458
+country	Cote d'Ivoire	7.9897371	-5.5679458
 country	Croatia	45.1	15.2
 country	Cuba	23.0131338	-80.8328748
 country	Curacao	12.1845	-68.9640875031406

--- a/scripts/sanitize_metadata.py
+++ b/scripts/sanitize_metadata.py
@@ -470,6 +470,9 @@ if __name__ == '__main__':
             # Replace whitespaces from strain names with nothing to match Nextstrain's
             # convention since whitespaces are not allowed in FASTA record names.
             metadata[strain_field] = metadata[strain_field].str.replace(" ", "")
+
+            # Replace standard characters that are not accepted by all downstream
+            # tools as valid FASTA names.
             metadata[strain_field] = metadata[strain_field].str.replace("'", "-")
 
             # Rename columns as needed, after transforming strain names. This

--- a/scripts/sanitize_metadata.py
+++ b/scripts/sanitize_metadata.py
@@ -467,9 +467,9 @@ if __name__ == '__main__':
                     lambda strain: strip_prefixes(strain, args.strip_prefixes)
                 )
 
-            # Replace whitespaces from strain names with underscores to match GISAID's
+            # Replace whitespaces from strain names with nothing to match Nextstrain's
             # convention since whitespaces are not allowed in FASTA record names.
-            metadata[strain_field] = metadata[strain_field].str.replace(" ", "_")
+            metadata[strain_field] = metadata[strain_field].str.replace(" ", "")
 
             # Rename columns as needed, after transforming strain names. This
             # allows us to avoid keeping track of a new strain name field

--- a/scripts/sanitize_metadata.py
+++ b/scripts/sanitize_metadata.py
@@ -470,6 +470,7 @@ if __name__ == '__main__':
             # Replace whitespaces from strain names with nothing to match Nextstrain's
             # convention since whitespaces are not allowed in FASTA record names.
             metadata[strain_field] = metadata[strain_field].str.replace(" ", "")
+            metadata[strain_field] = metadata[strain_field].str.replace("'", "-")
 
             # Rename columns as needed, after transforming strain names. This
             # allows us to avoid keeping track of a new strain name field

--- a/scripts/sanitize_sequences.py
+++ b/scripts/sanitize_sequences.py
@@ -26,6 +26,10 @@ def rename_sequences(sequences, pattern):
         # trailing components of the strain name.
         sequence.id = re.sub(pattern, "", sequence.description)
 
+        # Replace standard characters that are not accepted by all downstream
+        # tools as valid FASTA names.
+        sequence.id = sequence.id.replace("'", "-")
+
         # The name field stores the same information for a simple FASTA input, so we need to override its value, too.
         sequence.name = sequence.id
 


### PR DESCRIPTION
## Description of proposed changes

Fixes three bugs. The first bug is in the sanitize logic for the workflow when run with data from GISAID's full FASTA and metadata downloads. Although GISAID replaces whitespace in strain names with underscores for some downloads, it does not replace this whitespace in the larger downloads. The sanitize metadata script previously converted whitespace in strain names to underscores (following the GISAID convention), but the sanitize sequences script _removed_ whitespace from strain names (following the Nextstrain convention). As a result, builds that relied on sequences from countries with spaces in their names (e.g., "South Africa") would not have any of the expected sequences from those countries since metadata had names like `South_Africa` and sequences had names like `SouthAfrica`. After merging this PR, all data from the full GISAID downloads will have names like `SouthAfrica`, fixing the original bug.

The second bug occurs in the workflow where genomes from countries with single quotes in their names (e.g., Cote d'Ivoire) have the single quotes dropped from their strain names during tree building causing a mismatch between tip names and metadata records at the augur refine step. The solution here is a brute-force one of replacing these single quotes with hyphens in both metadata and sequence records, so the names do not get mangled downstream. Ideally, we should replace this kind of logic with an augur curate command or equivalent csvtk/seqkit commands.

The third bug is a mismatch between spellings of Cote d'Ivoire in latitude/longitude data and in GISAID's metadata. This PR adds a latitude and longitude value for "Cote d'Ivoire" (how it is spelled in GISAID) along with the existing "Côte d'Ivoire" spelling (how it is spelled in Nextstrain-sanitized data from ncov-ingest). This fix allows the country's data to appear on the map in the correct place when users run the workflow with GISAID data.

## Testing

- [x] Tested manually with Africa CDC builds
