### PR TITLE
Remove explicit step to activate Conda environment

### DIFF
--- a/docs/src/tutorial/custom-data.rst
+++ b/docs/src/tutorial/custom-data.rst
@@ -23,12 +23,6 @@ If you are not already there, change directory to the ``ncov`` directory:
 
       cd ncov
 
-and activate the ``nextstrain`` conda environment:
-
-   .. code:: text
-
-      conda activate nextstrain
-
 .. _custom-data-curate-data-from-gisaid:
 
 Curate data from GISAID

--- a/docs/src/tutorial/example-data.rst
+++ b/docs/src/tutorial/example-data.rst
@@ -16,19 +16,13 @@ Prerequisites
 Setup
 -----
 
-1. Activate the ``nextstrain`` conda environment:
-
-   .. code:: text
-
-      conda activate nextstrain
-
-2. Change directory to the ``ncov`` directory:
+1. Change directory to the ``ncov`` directory:
 
    .. code:: text
 
       cd ncov
 
-3. Download the example tutorial repository into a new subdirectory of ``ncov/`` called ``ncov-tutorial/``:
+2. Download the example tutorial repository into a new subdirectory of ``ncov/`` called ``ncov-tutorial/``:
 
    .. code:: text
 

--- a/docs/src/tutorial/genomic-surveillance.rst
+++ b/docs/src/tutorial/genomic-surveillance.rst
@@ -26,12 +26,6 @@ If you are not already there, change directory to the ``ncov`` directory:
 
       cd ncov
 
-and activate the ``nextstrain`` conda environment:
-
-   .. code:: text
-
-      conda activate nextstrain
-
 .. _genomic-surveillance-curate-data-from-gisaid:
 
 Curate data from GISAID


### PR DESCRIPTION
## Description of proposed changes

With https://github.com/nextstrain/docs.nextstrain.org/pull/123, the `nextstrain` conda environment is no longer common across all runtimes. "Native" runtime users are expected to remember to activate the Conda environment.

## Related issue(s)

Related to https://github.com/nextstrain/docs.nextstrain.org/pull/123#discussion_r972482630

## Tasks

- [ ] Merge https://github.com/nextstrain/docs.nextstrain.org/pull/123 before merging this

## Testing

- [ ] Preview pages look good
