### PR TITLE
wdl: use cp instead of mv

### DIFF
--- a/workflow/wdl/tasks/ncov_ingest.wdl
+++ b/workflow/wdl/tasks/ncov_ingest.wdl
@@ -46,16 +46,16 @@ task gisaid_ingest {
 
       # Detect and decompress xz or zst files
       if [[ $NEXTCLADE_CACHE == *.xz ]]; then
-        mv ~{cache_nextclade_old} .
+        cp ~{cache_nextclade_old} .
         xz -T0 --decompress ~{basename(select_first([cache_nextclade_old,'']))}
         export NEXTCLADE_CACHE="~{basename(select_first([cache_nextclade_old,'']),'.xz')}"
       elif [[ $NEXTCLADE_CACHE == *.zst ]]; then
-        mv ~{cache_nextclade_old} .
+        cp ~{cache_nextclade_old} .
         zstd -T0 -d ~{basename(select_first([cache_nextclade_old,'']))}
         export NEXTCLADE_CACHE="~{basename(select_first([cache_nextclade_old,'']),'.zst')}"
       fi
 
-      mv $NEXTCLADE_CACHE ${NCOV_INGEST_DIR}/data/gisaid/nextclade_old.tsv
+      cp $NEXTCLADE_CACHE ${NCOV_INGEST_DIR}/data/gisaid/nextclade_old.tsv
       echo "nextclade_old.tsv has " `wc -l ${NCOV_INGEST_DIR}/data/gisaid/nextclade_old.tsv` " records."
     fi
 
@@ -175,16 +175,16 @@ task genbank_ingest {
 
       # Detect and decompress xz or zst files
       if [[ $NEXTCLADE_CACHE == *.xz ]]; then
-        mv ~{cache_nextclade_old} .
+        cp ~{cache_nextclade_old} .
         xz -T0 --decompress ~{basename(select_first([cache_nextclade_old,'']))}
         export NEXTCLADE_CACHE="~{basename(select_first([cache_nextclade_old,'']),'.xz')}"
       elif [[ $NEXTCLADE_CACHE == *.zst ]]; then
-        mv ~{cache_nextclade_old} .
+        cp ~{cache_nextclade_old} .
         zstd -T0 -d ~{basename(select_first([cache_nextclade_old]))}
         export NEXTCLADE_CACHE="~{basename(select_first([cache_nextclade_old,'']),'.zst')}"
       fi
 
-      mv $NEXTCLADE_CACHE ${NCOV_INGEST_DIR}/data/genbank/nextclade_old.tsv
+      cp $NEXTCLADE_CACHE ${NCOV_INGEST_DIR}/data/genbank/nextclade_old.tsv
       echo "nextclade_old.tsv has " `wc -l ${NCOV_INGEST_DIR}/data/genbank/nextclade_old.tsv` " records."
     fi
 


### PR DESCRIPTION
## Description of proposed changes

* Copy the nextclade_cache instead of moving, to preserve older caches

While updating our cache on Terra, realized we may want to preserve older caches. 

An example case is when we pull an all dataset (All GenBank) and then subsequently start a new run subsetting to a region (e.g. North American GenBank). Moving the cache (during regional subsetting) destroys the All GenBank cache. This PR will fix that.

## Related issue(s)

Fixes: https://github.com/nextstrain/ncov/pull/1006
Related to https://github.com/nextstrain/ncov/issues/1005

## Testing

Will be tested by:

* https://github.com/nextstrain/ncov/issues/1005

Although suggestions appreciated.
