### PR TITLE
Add `Nextclade_pango` to colours & filters in Auspice

### DIFF
--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -191,6 +191,11 @@ rule auspice_config:
                     "title": "Pango Lineage",
                     "type": "categorical"
                 },
+                {
+                    "key": "Nextclade_pango",
+                    "title": "Nextclade Pango Lineage",
+                    "type": "categorical"
+                },
                 gisaid_clade_coloring,
                 {
                     "key": "S1_mutations",
@@ -281,6 +286,7 @@ rule auspice_config:
                 "clade_membership",
                 "emerging_lineage",
                 "pango_lineage",
+                "Nextclade_pango",
                 "region",
                 "country",
                 "division",


### PR DESCRIPTION
## Description of proposed changes

Nextclade pango-assigned lineage is sometimes faster at incorporating new lineages of interest (and also is guaranteed to assign these phylogenetically), so having these designations on the tree is useful for seeing them.

I have tried to do this so it applies to all Nextstrain builds (GISAID, open, etc) but would be good if someone can double-check that this should work.

## Related issue(s)

Should resolve #919 (?)

## Testing

~~UNTESTED~~
Edit: now tested via the test builds but not full builds - see below


