### PR TITLE
Elevate lineage BQ.1 to clade 22E

### DIFF
--- a/defaults/clade_emergence_dates.tsv
+++ b/defaults/clade_emergence_dates.tsv
@@ -29,3 +29,4 @@ Nextstrain_clade	first_sequence
 22B (Omicron)	2021-12-01
 22C (Omicron)	2021-12-01
 22D (Omicron)	2022-04-01
+22E (Omicron)	2022-07-10

--- a/defaults/clade_hierarchy.tsv
+++ b/defaults/clade_hierarchy.tsv
@@ -23,3 +23,8 @@ clade	parent	WHO
 21K	21M	Omicron
 21L	21M	Omicron
 21M	20B	Omicron
+22A	21L	Omicron
+22B	21L	Omicron
+22C	21L	Omicron
+22D	21L	Omicron
+22E	22B	Omicron

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -157,3 +157,9 @@ clade	gene	site	alt
 22D (Omicron)	clade	21L (Omicron)
 22D (Omicron)	nuc	3796	T
 22D (Omicron)	nuc	26275	G
+
+22E (Omicron)	clade	22B (Omicron)
+22E (Omicron)	nuc	14257	C
+22E (Omicron)	nuc	16935	A
+22E (Omicron)	nuc	28312	T
+22E (Omicron)	nuc	22942	A

--- a/defaults/clades_nextstrain.tsv
+++ b/defaults/clades_nextstrain.tsv
@@ -157,3 +157,9 @@ clade	gene	site	alt
 22D	clade	21L
 22D	nuc	3796	T
 22D	nuc	26275	G
+
+22E	clade	22B
+22E	nuc	14257	C
+22E	nuc	16935	A
+22E	nuc	28312	T
+22E	nuc	22942	A

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -31658,6 +31658,7 @@ clade_membership	22A (Omicron)
 clade_membership	22B (Omicron)
 clade_membership	22C (Omicron)
 clade_membership	22D (Omicron)
+clade_membership	22E (Omicron)
 
 ################
 


### PR DESCRIPTION
## Description of proposed changes

This commit elevates lineage BQ.1 as clade 22E. BQ.1 is Pango lineage BA.5.3.1.1.1.1.1 that bears mutations at ORF1a: Q556K, L3829F, ORF1b: Y264H, M1156I, ORF9b: S10F, N: E136D, and spike K444T and N460K.

Mutational path leading to BQ.1 can be seen at [nextstrain.org/nextclade/sars-cov-2](https://nextstrain.org/nextclade/sars-cov-2?branchLabel=aa) and is copied below:

![Screen Shot 2022-10-12 at 11 48 16 AM](https://user-images.githubusercontent.com/1176109/195424049-8b1cff26-2e26-462e-aa60-23db5d89f550.png)

BQ.1 has been rapidly going in frequency across multiple geographies. If we apply method from [Figgins and Bedford, 2022, medRxiv](https://bedford.io/papers/figgins-rt-from-frequency-dynamics/) we can estimate growth rates across lineages. Currently the US has the most recent sequencing data (31k sequences from the previous 30 days) which allows estimates of lineage-level Rt. Figures below are borrowed from [github.com/blab/rt-from-frequency-dynamics/tree/master/results/pango-countries](https://github.com/blab/rt-from-frequency-dynamics/tree/master/results/pango-countries):

![pango-countries_variant-rt](https://user-images.githubusercontent.com/1176109/195426003-9a3b44f5-3855-4c56-abbe-75ffb1b3f75f.png)

![pango-countries_variant-rt-listplot](https://user-images.githubusercontent.com/1176109/195426067-a67fe3b6-3f1a-4bf8-b175-ead1807aabb4.png)

![pango-countries_variant-rt-top](https://user-images.githubusercontent.com/1176109/195426080-08cfd625-7338-4dcd-9530-47f6b42a1595.png)

BQ.1 here combines both BQ.1 and BQ.1.1 for more power in analysis and shows that they are currently handily above other lineages in the US. We estimate current BQ.1 frequency in the US to be about 6.5% with a lineage-specific Rt of 1.35 and logit frequency growth of 0.11 per day.

Furthermore, we see this pattern of rapid growth of BQ.1 repeated in other geographies. The following uses geographies that have sufficient sequencing data and specifically breaks out BA.2.75.2, BQ.1, BQ.1.1 and XBB. Figures below are borrowed here [github.com/blab/rt-from-frequency-dynamics/tree/master/results/omicron-ba275](https://github.com/blab/rt-from-frequency-dynamics/tree/master/results/omicron-ba275):

![omicron-ba275_variant-rt](https://user-images.githubusercontent.com/1176109/195426974-26205e0e-dc56-4993-98af-7a05d9d4df1c.png)

BQ.1 hits our [clade designation criteria 4](https://next.nextstrain.org/blog/2022-04-29-SARS-CoV-2-clade-naming-2022): 

>A clade shows consistent >0.05 per day growth in frequency where it’s circulating and has reached >5% regional frequency

## Testing

This PR is running now and output will be available at [nextstrain.org/staging/ncov/gisaid/trial/clade-22E/global/2m](https://nextstrain.org/staging/ncov/gisaid/trial/clade-22E/global/2m), etc... shortly.

## Release checklist

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.
