### PR TITLE
Fix color assignment for clades

### DIFF
--- a/scripts/assign-colors.py
+++ b/scripts/assign-colors.py
@@ -35,6 +35,9 @@ if __name__ == '__main__':
     if args.metadata:
         metadata = pd.read_csv(args.metadata, delimiter='\t')
         for name, trait in assignment.items():
+            if name == "clade_membership" and "Nextstrain_clade" in metadata:
+                subset_present = [x for x in assignment[name] if x in metadata["Nextstrain_clade"].unique()]
+                assignment[name] = subset_present
             if name in metadata:
                 subset_present = [x for x in assignment[name] if x in metadata[name].unique()]
                 assignment[name] = subset_present


### PR DESCRIPTION
## Description of proposed changes

The script `assign-colors.py` is supposed to only include colors for traits that are present for the relevant coloring in filtered / subsampled metadata. Ie not every "location" should be included in the produced colors.tsv file, only locations that are present in the filtered / subsampled metadata.

There was a bug that was causing this not to work for clades. This was because clades are labeled as `clade_membership` in the Auspice JSON and as `Nextstrain_clade` in the metadata. This necessitated special casing this look up in the `assign-colors.py` script. Without this fix, the script always includes all clades in its output making Omicron forever orange / red.

## Testing

I've tested locally, but will do a trial run now as well. When complete results will be available at [nextstrain.org/staging/ncov/gisaid/trial/fix-clade-color-ordering/global/2m](https://nextstrain.org/staging/ncov/gisaid/trial/fix-clade-color-ordering/global/2m), etc...
