### PR TITLE
Update filter docs

### DIFF
--- a/docs/src/reference/troubleshoot.rst
+++ b/docs/src/reference/troubleshoot.rst
@@ -23,13 +23,14 @@ There are a few steps where sequences can be removed:
 -  During the ``filter`` step:
 
    -  Samples that are included in `the exclude file <https://github.com/nextstrain/ncov/blob/master/defaults/exclude.txt>`__ are removed
-   -  Samples that fail the current filtering criteria, as defined in the ``parameters.yaml`` file, are removed. You can modify the snakefile as desired, but currently these are:
+   -  Samples that fail the filtering criteria, as defined in your :ref:`filter config <workflow-config-filter>`, are removed.
 
-      -  Minimum sequence length of 25kb
-      -  No ambiguity in (sample collection) date
+      - If you do not have any custom filtering criteria, the default filters in the `parameters.yaml <https://github.com/nextstrain/ncov/blob/master/defaults/parameters.yaml>`__ are applied.
 
-   -  Samples may be randomly removed during subsampling; see :doc:`../guides/workflow-config-file` for more info.
-   -  During the ``refine`` step, where samples that deviate more than 4 interquartile ranges from the root-to-tip vs time are removed
+   - Check the ``results/{build_name}/filtered_log.tsv`` file to see the filtered reason for each sequence.
+
+-  Samples may be randomly removed during subsampling; see :doc:`../guides/workflow-config-file` for more info.
+-  During the ``refine`` step, where samples that deviate more than 4 interquartile ranges from the root-to-tip vs time are removed
 
 Sequencing and alignment errors
 -------------------------------

--- a/docs/src/reference/workflow-config-file.rst
+++ b/docs/src/reference/workflow-config-file.rst
@@ -719,6 +719,7 @@ run_pangolin
 -  description: Enable annotation of Pangolin lineages for a given build's subsampled sequences.
 -  default: ``false``
 
+.. _workflow-config-mask:
 
 mask
 ----
@@ -771,6 +772,10 @@ min_length
 -  type: integer
 -  description: Minimum number of valid nucleotides (A, C, T, or G) for a genome to be included in the analysis by ``augur filter --min-length``.
 -  default: ``27000``
+
+.. note::
+   The ``min_length`` filter is applied to the **masked** sequences, not the original input sequences.
+   Depending on your :ref:`mask config parameters <workflow-config-mask>`, the masked sequences may contain more Ns than the original sequences and fail the ``min_length`` filter.
 
 exclude_where
 ~~~~~~~~~~~~~

--- a/docs/src/reference/workflow-config-file.rst
+++ b/docs/src/reference/workflow-config-file.rst
@@ -753,6 +753,7 @@ mask_sites
 
 
 
+.. _workflow-config-filter:
 
 filter
 ------

--- a/docs/src/reference/workflow-config-file.rst
+++ b/docs/src/reference/workflow-config-file.rst
@@ -124,7 +124,7 @@ builds
        subsampling_scheme: country
 
      # this will use a custom subsampling scheme that you provide
-     # which will have access to the provided `my_param` 
+     # which will have access to the provided `my_param`
      washington:
        subsampling_scheme: my_scheme
        my_param: some value
@@ -708,7 +708,7 @@ crowding_penalty
 
    priorities:
      crowding_penalty: 0.0
-     # You may wish to set `crowding_penalty = 0.0` (default value = `0.1`) if you are interested in seeing as many samples as possible that are closely related to your `focal` set. 
+     # You may wish to set `crowding_penalty = 0.0` (default value = `0.1`) if you are interested in seeing as many samples as possible that are closely related to your `focal` set.
 
 .. _title-1:
 


### PR DESCRIPTION
Miscellaneous updates to docs for filters.
Hopefully can help with some of the common questions we get about "why are X sequences excluded?"
* Troubleshooting docs
    * link to workflow config filter references docs
    * link to default parameters.yaml file
    * point users to `filtered_log.tsv` output of filter rule (I couldn't find any reference to this file in the docs!)
* Workflow config reference docs
    * Note that `min_length` is applied to **masked** sequences