### PR TITLE
Add omicron levels coloring

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -68,6 +68,7 @@ files:
   emerging_lineages: "defaults/emerging_lineages.tsv"
   mutational_fitness_distance_map: "defaults/mutational_fitness_distance_map.json"
   sites_to_mask: "defaults/sites_ignored_for_tree_topology.txt"
+  rbd_level_definitions: "defaults/rbd_levels.yaml"
 
 # Define genes to translate during alignment by nextalign.
 genes: ["ORF1a", "ORF1b", "S", "ORF3a", "E", "M", "ORF6", "ORF7a", "ORF7b", "ORF8", "N", "ORF9b"]

--- a/defaults/rbd_levels.yaml
+++ b/defaults/rbd_levels.yaml
@@ -1,0 +1,19 @@
+---
+## Definitions of the RBD mutations (in Spike) which define a genomes "RBD Level"
+## See https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md
+
+rbd_mutations:
+  # each entry in this list defines a RBD position. Each entry is a list of length 3 where
+  # [0] is the basal codon, [1] is the 1-based spike aa position, [2] is a list of codons which result in a level elevation
+  - ["R", 346, ["T", "S"]]
+  - ["K", 356, ["T"]]
+  - ["K", 444, ["T", "R", "N", "M"]]
+  - ["V", 445, ["A", "P"]]
+  - ["G", 446, ["S", "D"]]
+  - ["N", 450, ["D"]]
+  - ["L", 452, ["R", "Q", "M"]]
+  - ["N", 460, ["K"]]
+  - ["F", 486, ["S", "V", "L", "P"]]
+  - ["F", 490, ["S", "V", "L", "P"]]
+  - ["R", 493, ["Q"]] # note wuhan was Q, so a reversion here elevates the level
+  - ["S", 494, ["P"]]

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- October 21: Implement RGB-level coloring for BA.2 (21L) descendants. For background on this and lineage definitions please see [Variant report 2022-10-17](https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md). [PR 1018](https://github.com/nextstrain/ncov/pull/1018).
+
 ## v12 (12 July 2022)
 
 - 1 July 2022: Update workflow to support Nextclade v2 (PRs [963](https://github.com/nextstrain/ncov/pull/963), [969](https://github.com/nextstrain/ncov/pull/969)). See [the Nextclade changelog](https://github.com/nextstrain/nextclade/blob/bdfd9cff73f8181bb5891a9a9c49eb0218e7e868/CHANGELOG.md#nextclade-200) for more information.

--- a/scripts/assign_rbd_levels.py
+++ b/scripts/assign_rbd_levels.py
@@ -12,13 +12,13 @@ def find_matching_nodes(clades_fname, basal_clade_label, tree_fname):
                 basal_node_name = name
                 break
     if not basal_node_name:
-        print(f"ERROR: no node found with a clade_annotation of {basal_clade_label}")
-        sys.exit(2)
+        print(f"WARNING: no node found with a clade_annotation of {basal_clade_label}. This script will proceed, but no levels will be exported.")
+        return set()
     print(f"Node representing {basal_clade_label}: {basal_node_name}")
     T = Phylo.read(tree_fname, 'newick')
     basal_node = T.find_any({"name": basal_node_name})
     if not basal_node:
-        print(f"ERROR: {basal_node_name} not found in provided tree")
+        print(f"ERROR: {basal_node_name} not found in provided tree") # this should be fatal as it indicates a mismatch of provided inputs
         sys.exit(2)
     names = set([basal_node_name]) # include parent (the basal_clade_label defining branch)
     for n in basal_node.find_clades():

--- a/scripts/assign_rbd_levels.py
+++ b/scripts/assign_rbd_levels.py
@@ -1,8 +1,30 @@
-from Bio import SeqIO
+from Bio import SeqIO, Phylo
 import json
 import yaml
 import sys
 import argparse
+
+def find_matching_nodes(clades_fname, basal_clade_label, tree_fname):
+    basal_node_name = None
+    with open(clades_fname) as fh:
+        for name, node_data in json.load(fh)['nodes'].items():
+            if node_data.get('clade_annotation', '') == basal_clade_label:
+                basal_node_name = name
+                break
+    if not basal_node_name:
+        print(f"ERROR: no node found with a clade_annotation of {basal_clade_label}")
+        sys.exit(2)
+    print(f"Node representing {basal_clade_label}: {basal_node_name}")
+    T = Phylo.read(tree_fname, 'newick')
+    basal_node = T.find_any({"name": basal_node_name})
+    if not basal_node:
+        print(f"ERROR: {basal_node_name} not found in provided tree")
+        sys.exit(2)
+    names = set([basal_node_name]) # include parent (the basal_clade_label defining branch)
+    for n in basal_node.find_clades():
+        names.add(n.name)
+
+    return names
 
 def classify_into_levels(spike_seq, rbd_mutations):
     level_num = 0
@@ -31,7 +53,19 @@ if __name__ == '__main__':
     parser.add_argument('--config', type=str, metavar="YAML", required=True, help="config defining the RBD mutations")
     parser.add_argument('--spike-alignment', type=str, metavar="FASTA", required=True, help="input spike alignment (usually from nextclade)")
     parser.add_argument('--output-node-data', type=str, metavar="JSON", required=True, help="output node-data JSON")
+    parser.add_argument('--clades-node-data', type=str, metavar="JSON", required=False, help="Clade definitions JSON. Only descendants of the basal-clade-label will be labelled.")
+    parser.add_argument('--basal-clade-label', type=str, metavar="STRING", required=False, help="Used in conjunction with --clades-node-data and --tree")
+    parser.add_argument('--tree', type=str, metavar="NEWICK", required=False, help="Used in conjunction with --clades-node-data and --basal-clade-label")
     args = parser.parse_args()
+
+    if args.clades_node_data and args.basal_clade_label and args.tree:
+        selected_nodes = find_matching_nodes(args.clades_node_data, args.basal_clade_label, args.tree)
+        use_node = lambda name: name in selected_nodes
+    elif args.clades_node_data or args.tree or args.basal_clade_label:
+        print("ERROR: if you provide --clades-node-data you must provide --tree, and vice-versa")
+        sys.exit(2)
+    else:
+        use_node = lambda name: True
 
     with open(args.config, "r") as stream:
         config = yaml.safe_load(stream)
@@ -44,7 +78,8 @@ if __name__ == '__main__':
     spike_aln = {}
     with open(args.spike_alignment) as handle:
         for record in SeqIO.parse(handle, "fasta"):
-            spike_aln[record.id] = record.seq
+            if use_node(record.id):
+                spike_aln[record.id] = record.seq
 
     node_data = {
         "nodes": {}, # encode the levels for augur export

--- a/scripts/assign_rbd_levels.py
+++ b/scripts/assign_rbd_levels.py
@@ -1,0 +1,60 @@
+from Bio import SeqIO
+import json
+import yaml
+import sys
+import argparse
+
+def classify_into_levels(spike_seq, rbd_mutations):
+    level_num = 0
+    codons = []
+    calls = []
+    for idx in range(0, len(rbd_mutations)):
+        (basal_codon, position, alts) = rbd_mutations[idx]
+        aa = spike_seq[position-1] # humans use 1-based positions, python uses 0-based
+        codons.append(aa)
+        if aa==basal_codon:
+            calls.append('basal')
+        elif aa in alts:
+            calls.append('alts')
+            level_num +=1
+        elif aa=='X' or aa=='-':
+            calls.append('X-')
+        else:
+            calls.append('other')
+    return (level_num, codons, calls)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Assign (omicron) levels to strains",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('--config', type=str, metavar="YAML", required=True, help="config defining the RBD mutations")
+    parser.add_argument('--spike-alignment', type=str, metavar="FASTA", required=True, help="input spike alignment (usually from nextclade)")
+    parser.add_argument('--output-node-data', type=str, metavar="JSON", required=True, help="output node-data JSON")
+    args = parser.parse_args()
+
+    with open(args.config, "r") as stream:
+        config = yaml.safe_load(stream)
+    try:
+        rbd_mutations=config['rbd_mutations']
+    except KeyError:
+        print("ERROR: the provided yaml config did not define a `rbd_mutations` list")
+        sys.exit(2)
+
+    spike_aln = {}
+    with open(args.spike_alignment) as handle:
+        for record in SeqIO.parse(handle, "fasta"):
+            spike_aln[record.id] = record.seq
+
+    node_data = {
+        "nodes": {}, # encode the levels for augur export
+        "rbd_level_details": {} # for more info, as needed
+    }
+
+    for name, seq in spike_aln.items():
+        (level_num, codons, calls) = classify_into_levels(seq, rbd_mutations)
+        node_data['nodes'][name] = {'rbd_level': level_num}
+        node_data['rbd_level_details'][name] = ", ".join([f"S:{x[0][1]}{x[1]} ({x[2]})" for x in zip(rbd_mutations, codons, calls)])
+
+    with open(args.output_node_data, 'w') as fh:
+        json.dump(node_data, fh, indent=2)

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -203,6 +203,11 @@ rule auspice_config:
                     "type": "continuous"
                 },
                 {
+                    "key": "rbd_level",
+                    "title": "RBD Level",
+                    "type": "ordinal"
+                },
+                {
                     "key": "logistic_growth",
                     "title": "Logistic Growth",
                     "type": "continuous"
@@ -288,6 +293,7 @@ rule auspice_config:
                 "pango_lineage",
                 "Nextclade_pango",
                 "region",
+                "level",
                 "country",
                 "division",
                 location_filter,

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1304,6 +1304,25 @@ rule find_clusters:
            --output {output.clusters}
        """
 
+rule assign_rbd_levels:
+    input:
+        spike_alignment="results/{build_name}/translations/aligned.gene.S_withInternalNodes.fasta"
+    params:
+        config=config["files"]["rbd_level_definitions"],
+    output:
+        node_data="results/{build_name}/rbd_levels.json",
+    benchmark:
+        "benchmarks/assign_levels_{build_name}.txt",
+    conda:
+        config["conda_environment"],
+    shell:
+        """
+        python3 scripts/assign_rbd_levels.py \
+            --spike-alignment {input.spike_alignment} \
+            --config {params.config} \
+            --output-node-data {output.node_data} 2>&1 | tee {log}
+        """
+
 def export_title(wildcards):
     # TODO: maybe we could replace this with a config entry for full/human-readable build name?
     location_name = wildcards.build_name
@@ -1340,6 +1359,7 @@ def _get_node_data_by_wildcards(wildcards):
         rules.mutational_fitness.output.node_data,
         rules.distances.output.node_data,
         rules.calculate_epiweeks.output.node_data,
+        rules.assign_rbd_levels.output.node_data,
     ]
 
     if "run_pangolin" in config and config["run_pangolin"]:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1306,9 +1306,12 @@ rule find_clusters:
 
 rule assign_rbd_levels:
     input:
-        spike_alignment="results/{build_name}/translations/aligned.gene.S_withInternalNodes.fasta"
+        spike_alignment="results/{build_name}/translations/aligned.gene.S_withInternalNodes.fasta",
+        clades="results/{build_name}/clades.json",
+        tree = "results/{build_name}/tree.nwk",
     params:
         config=config["files"]["rbd_level_definitions"],
+        basal_clade_label="21L (Omicron)"
     output:
         node_data="results/{build_name}/rbd_levels.json",
     benchmark:
@@ -1320,6 +1323,9 @@ rule assign_rbd_levels:
         python3 scripts/assign_rbd_levels.py \
             --spike-alignment {input.spike_alignment} \
             --config {params.config} \
+            --clades-node-data {input.clades} \
+            --basal-clade-label {params.basal_clade_label:q} \
+            --tree {input.tree} \
             --output-node-data {output.node_data} 2>&1 | tee {log}
         """
 


### PR DESCRIPTION
For background please see "Variant report 2022-10-17" section of https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md for details of lineage classification. This commit is very much a first pass to see if (a) it works robustly on large datasets and (b) there is interest in including it (there is from me!)

Note that the mutations are relative to BA.2 so we should really use this for omicron-only builds, which are being developed elsewhere. This is especially relevant for S:493 where we consider a reversion to increase the level, meaning strains basal to BA.2 will be elevated inappropriately.


Trial builds via https://github.com/nextstrain/ncov/actions/runs/3278003787. 
nextstrain URLs: https://nextstrain.org/staging/ncov/gisaid/trial/feat-levels/REGION_NAME
e.g.  https://nextstrain.org/staging/ncov/gisaid/trial/feat-levels/global/2m
You can attach to this AWS job via:
`nextstrain build --aws-batch --attach 08b4c304-03ea-49f6-af22-f60102f14896 /home/runner/work/ncov/ncov`
View this job in the AWS console via
    https://console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/08b4c304-03ea-49f6-af22-f60102f14896



cc @corneliusroemer 