### PR TITLE
Elevate XBB as 22F

### DIFF
--- a/defaults/clade_emergence_dates.tsv
+++ b/defaults/clade_emergence_dates.tsv
@@ -30,3 +30,4 @@ Nextstrain_clade	first_sequence
 22C (Omicron)	2021-12-01
 22D (Omicron)	2022-04-01
 22E (Omicron)	2022-07-10
+22F (XBB)	2022-07-10

--- a/defaults/clade_emergence_dates.tsv
+++ b/defaults/clade_emergence_dates.tsv
@@ -30,4 +30,4 @@ Nextstrain_clade	first_sequence
 22C (Omicron)	2021-12-01
 22D (Omicron)	2022-04-01
 22E (Omicron)	2022-07-10
-22F (XBB)	2022-07-10
+22F (Omicron)	2022-08-01

--- a/defaults/clade_hierarchy.tsv
+++ b/defaults/clade_hierarchy.tsv
@@ -28,4 +28,4 @@ clade	parent	WHO
 22C	21L	Omicron
 22D	21L	Omicron
 22E	22B	Omicron
-22F	21L
+22F	21L	Omicron

--- a/defaults/clade_hierarchy.tsv
+++ b/defaults/clade_hierarchy.tsv
@@ -28,3 +28,4 @@ clade	parent	WHO
 22C	21L	Omicron
 22D	21L	Omicron
 22E	22B	Omicron
+22F	21L

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -163,3 +163,9 @@ clade	gene	site	alt
 22E (Omicron)	nuc	16935	A
 22E (Omicron)	nuc	28312	T
 22E (Omicron)	nuc	22942	A
+
+22F (Omicron)	clade	21L (Omicron)
+22F (Omicron)	nuc	15461	A
+22F (Omicron)	nuc	17859	C
+22F (Omicron)	nuc	23019	C
+22F (Omicron)	nuc	26275	G

--- a/defaults/clades_nextstrain.tsv
+++ b/defaults/clades_nextstrain.tsv
@@ -163,3 +163,9 @@ clade	gene	site	alt
 22E	nuc	16935	A
 22E	nuc	28312	T
 22E	nuc	22942	A
+
+22F	clade	21L
+22F	nuc	15461	A
+22F	nuc	17859	C
+22F	nuc	23019	C
+22F	nuc	26275	G

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -31869,7 +31869,7 @@ clade_membership	22B (Omicron)
 clade_membership	22C (Omicron)
 clade_membership	22D (Omicron)
 clade_membership	22E (Omicron)
-clade_membership	22F (XBB)
+clade_membership	22F (Omicron)
 
 ################
 

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -31869,13 +31869,12 @@ clade_membership	22B (Omicron)
 clade_membership	22C (Omicron)
 clade_membership	22D (Omicron)
 clade_membership	22E (Omicron)
+clade_membership	22F (XBB)
 
 ################
 
 
-emerging_lineage	BQ.1
 emerging_lineage	BQ.1.1
-emerging_lineage	XBB
 emerging_lineage	BA.2.3.20
 emerging_lineage	BN.1
 emerging_lineage	BM.1.1

--- a/defaults/emerging_lineages.tsv
+++ b/defaults/emerging_lineages.tsv
@@ -164,11 +164,11 @@ clade	gene	site	alt
 22E (Omicron)	nuc	28312	T
 22E (Omicron)	nuc	22942	A
 
-22F (XBB)	clade	21L (Omicron)
-22F (XBB)	nuc	15461	A
-22F (XBB)	nuc	17859	C
-22F (XBB)	nuc	23019	C
-22F (XBB)	nuc	26275	G
+22F (Omicron)	clade	21L (Omicron)
+22F (Omicron)	nuc	15461	A
+22F (Omicron)	nuc	17859	C
+22F (Omicron)	nuc	23019	C
+22F (Omicron)	nuc	26275	G
 
 BQ.1.1	clade	22E (Omicron)
 BQ.1.1	nuc	22599	C

--- a/defaults/emerging_lineages.tsv
+++ b/defaults/emerging_lineages.tsv
@@ -158,20 +158,20 @@ clade	gene	site	alt
 22D (Omicron)	nuc	3796	T
 22D (Omicron)	nuc	26275	G
 
-BQ.1	clade	22B (Omicron)
-BQ.1	nuc	14257	C
-BQ.1	nuc	16935	A
-BQ.1	nuc	28312	T
-BQ.1	nuc	22942	A
+22E (Omicron)	clade	22B (Omicron)
+22E (Omicron)	nuc	14257	C
+22E (Omicron)	nuc	16935	A
+22E (Omicron)	nuc	28312	T
+22E (Omicron)	nuc	22942	A
+
+22F (XBB)	clade	21L (Omicron)
+22F (XBB)	nuc	15461	A
+22F (XBB)	nuc	17859	C
+22F (XBB)	nuc	23019	C
+22F (XBB)	nuc	26275	G
 
 BQ.1.1	clade	BQ.1
 BQ.1.1	nuc	22599	C
-
-XBB	clade	21L (Omicron)
-XBB	nuc	15461	A
-XBB	nuc	17859	C
-XBB	nuc	23019	C
-XBB	nuc	26275	G
 
 BA.2.3.20	clade	21L (Omicron)
 BA.2.3.20	nuc	6770	G

--- a/defaults/emerging_lineages.tsv
+++ b/defaults/emerging_lineages.tsv
@@ -170,7 +170,7 @@ clade	gene	site	alt
 22F (XBB)	nuc	23019	C
 22F (XBB)	nuc	26275	G
 
-BQ.1.1	clade	BQ.1
+BQ.1.1	clade	22E (Omicron)
 BQ.1.1	nuc	22599	C
 
 BA.2.3.20	clade	21L (Omicron)


### PR DESCRIPTION
## Description of proposed changes

(Code changes @corneliusroemer, elevation reasons contributed by @trvrb)

This PR elevates Pango lineage XBB to Nextstrain clade 22F. Per [cov-lineages.org](https://cov-lineages.org/lineage.html?lineage=XBB), XBB is a "recombinant lineage of BJ.1 and BA.2.75 with breakpoint in S1". It possesses spike mutations:

V83A, H146Q, Q183E, V210I, G213E, R346T, L368I, V445P, F486S, F490S

<img width="1151" alt="mutations" src="https://user-images.githubusercontent.com/1176109/197447887-b85a1619-a3a2-405d-bea4-9bb57c12ca6e.png">

XBB is now at 19% frequency in Asia in the standard 2m Asia-focused ncov build:

<img width="1150" alt="frequency" src="https://user-images.githubusercontent.com/1176109/197448110-c43dcef0-157e-4fbf-81b7-ebf4b71cd78e.png">

Applying the method from [Figgins and Bedford](https://bedford.io/papers/figgins-rt-from-frequency-dynamics/), we estimate frequencies in Bangladesh, India and Singapore are now at 98%, 49% and 93% respectively:

![omicron-ba275_variant-estimated-frequency](https://user-images.githubusercontent.com/1176109/197448795-b435a5e7-cd19-4013-9021-dc1cdd1f63a7.png)

And simple logistic growth rates have followed 0.21, 0.05 and 0.17 per day respectively.

![omicron-ba275_logistic-growth-transformed-axis](https://user-images.githubusercontent.com/1176109/197448480-1e281b9f-e11b-4563-81f2-3973a4310e0b.png)

If we look more broadly, we observe equivalent growth rates between BQ.1 and XBB in regions where they are co-circulating, this being Australia and the US.

![omicron-ba275_variant-estimated-log-cases](https://user-images.githubusercontent.com/1176109/197448935-1198bb50-fec9-484f-800a-e98d5b150bc5.png)

![omicron-ba275_variant-rt](https://user-images.githubusercontent.com/1176109/197448954-83edce76-daef-4a43-b1f5-8c82c807063e.png)

It's too early to say whether BQ.1 or XBB will have a larger global impact, however, it's now clear that XBB meets our criteria 4 for designating a Nextstrain clade, namely:

>A clade shows consistent >0.05 per day growth in frequency where it’s circulating and has reached >5% regional frequency 

_Edited by @trvrb Oct 23, 2022_

## Testing

Trial build results are available at https://nextstrain.org/staging/ncov/gisaid/trial/xbb-is-22F/asia/2m, etc...

