### PR TITLE
Switch from monthly → weekly grouping for 2m builds

### DIFF
--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 3 November 2022: Use weekly grouping for "2m" timespan in Nextstrain profile builds. [PR 1023](https://github.com/nextstrain/ncov/pull/1023)
+
 - 2 November 2022: Make RBD levels filterable [PR 1028](https://github.com/nextstrain/ncov/pull/1028)
 
 - 21 October 2022: Implement RBD-level coloring for BA.2 (21L) descendants. For background on this and lineage definitions please see [Variant report 2022-10-17](https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md). [PR 1018](https://github.com/nextstrain/ncov/pull/1018).

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,9 +5,9 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
-- November 2: Make RBD levels filterable [PR 1028](https://github.com/nextstrain/ncov/pull/1028)
-- October 21: Implement RBD-level coloring for BA.2 (21L) descendants. For background on this and lineage definitions please see [Variant report 2022-10-17](https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md). [PR 1018](https://github.com/nextstrain/ncov/pull/1018).
+- 2 November 2022: Make RBD levels filterable [PR 1028](https://github.com/nextstrain/ncov/pull/1028)
 
+- 21 October 2022: Implement RBD-level coloring for BA.2 (21L) descendants. For background on this and lineage definitions please see [Variant report 2022-10-17](https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md). [PR 1018](https://github.com/nextstrain/ncov/pull/1018).
 
 ## v12 (12 July 2022)
 

--- a/nextstrain_profiles/nextstrain-country/builds.yaml
+++ b/nextstrain_profiles/nextstrain-country/builds.yaml
@@ -81,13 +81,13 @@ subsampling:
       exclude: "--exclude-where 'country={country}'"
     # Recent focal samples for region
     focal_recent:
-      group_by: "division year month"
+      group_by: "division week"
       max_sequences: 2560
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'country!={country}'"
     # Early contextual samples from the rest of the world
     context_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 640
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'country={country}'"

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -159,13 +159,13 @@ subsampling:
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
     focal_recent:
-      group_by: "division year month"
+      group_by: "division week"
       max_sequences: 2560
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 640
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region={region}'"
@@ -237,13 +237,13 @@ subsampling:
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
     focal_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 2560
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 640
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region={region}'"
@@ -331,32 +331,32 @@ subsampling:
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Asia'"
     europe_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Europe'"
     north_america_recent:
-      group_by: "division year month"
+      group_by: "division week"
       max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
-      group_by: "division year month"
+      group_by: "division week"
       max_sequences: 200
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"

--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -159,13 +159,13 @@ subsampling:
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
     focal_recent:
-      group_by: "division year month"
+      group_by: "division week"
       max_sequences: 2560
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 640
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region={region}'"
@@ -237,13 +237,13 @@ subsampling:
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
     focal_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 2560
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 640
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region={region}'"
@@ -331,32 +331,32 @@ subsampling:
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Asia'"
     europe_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Europe'"
     north_america_recent:
-      group_by: "division year month"
+      group_by: "division week"
       max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
-      group_by: "country year month"
+      group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
-      group_by: "division year month"
+      group_by: "division week"
       max_sequences: 200
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"


### PR DESCRIPTION
## Description of proposed changes

`--min-date 2M` + `--group-by month` has funny interactions. For example, if the current date is 3/15, the min date would be 1/15. The monthly grouping would over-sample the partial months (1/15-1/31 and 3/1-3/15) compared to the full middle month. Weekly grouping minimizes this over-sampling to just 2 partial weeks out of 8 or 9 weeks.

## Preview staging builds

- [gisaid/global/2m](https://nextstrain.org/staging/ncov/gisaid/trial/use-weekly-grouping-for-2m/global/2m)
- [gisaid/africa/2m](https://nextstrain.org/staging/ncov/gisaid/trial/use-weekly-grouping-for-2m/africa/2m)
- [gisaid/asia/2m](https://nextstrain.org/staging/ncov/gisaid/trial/use-weekly-grouping-for-2m/asia/2m)
- [gisaid/europe/2m](https://nextstrain.org/staging/ncov/gisaid/trial/use-weekly-grouping-for-2m/europe/2m)
- [gisaid/north-america/2m](https://nextstrain.org/staging/ncov/gisaid/trial/use-weekly-grouping-for-2m/north-america/2m)
- [gisaid/oceania/2m](https://nextstrain.org/staging/ncov/gisaid/trial/use-weekly-grouping-for-2m/oceania/2m)
- [gisaid/south-america/2m](https://nextstrain.org/staging/ncov/gisaid/trial/use-weekly-grouping-for-2m/south-america/2m)
- [open/global/2m](https://nextstrain.org/staging/ncov/open/trial/use-weekly-grouping-for-2m/global/2m)
- [open/africa/2m](https://nextstrain.org/staging/ncov/open/trial/use-weekly-grouping-for-2m/africa/2m)
- [open/asia/2m](https://nextstrain.org/staging/ncov/open/trial/use-weekly-grouping-for-2m/asia/2m)
- [open/europe/2m](https://nextstrain.org/staging/ncov/open/trial/use-weekly-grouping-for-2m/europe/2m)
- [open/north-america/2m](https://nextstrain.org/staging/ncov/open/trial/use-weekly-grouping-for-2m/north-america/2m)
- [open/oceania/2m](https://nextstrain.org/staging/ncov/open/trial/use-weekly-grouping-for-2m/oceania/2m)
- [open/south-america/2m](https://nextstrain.org/staging/ncov/open/trial/use-weekly-grouping-for-2m/south-america/2m)

## Related issue(s)

Related to #957 (funny interactions originally mentioned there)

## Testing

- [x] Start trial runs
    - [GISAID](https://github.com/nextstrain/ncov/actions/runs/3371994763)
    - [open](https://github.com/nextstrain/ncov/actions/runs/3371998863)
- [x] Check results of trial runs

## Release checklist

~If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow~ N/A

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
