### PR TITLE
fix: select_first was called with 1 empty values

### DIFF
--- a/workflow/wdl/tasks/ncov_ingest.wdl
+++ b/workflow/wdl/tasks/ncov_ingest.wdl
@@ -180,7 +180,7 @@ task genbank_ingest {
         export NEXTCLADE_CACHE="~{basename(select_first([cache_nextclade_old,'']),'.xz')}"
       elif [[ $NEXTCLADE_CACHE == *.zst ]]; then
         cp ~{cache_nextclade_old} .
-        zstd -T0 -d ~{basename(select_first([cache_nextclade_old]))}
+        zstd -T0 -d ~{basename(select_first([cache_nextclade_old,'']))}
         export NEXTCLADE_CACHE="~{basename(select_first([cache_nextclade_old,'']),'.zst')}"
       fi
 


### PR DESCRIPTION
## Description of proposed changes

See commit for details. Apparently prior tests had always been passing a nextclade cache, so this bug did not surface earlier. Thanks @victorlin !

## Related to

* https://github.com/nextstrain/ncov/pull/999

