### PR TITLE
feat: deploy builds eagerly, not wait until all done

### DIFF
--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,13 +5,13 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 4 November 2022: Deploy individual builds to Nextstrain as soon as they are ready, as opposed to only once all builds are ready to speed up the feedback loop [PR #1025](https://github.com/nextstrain/ncov/pull/1025)
 - 3 November 2022: Use weekly grouping for "2m" timespan in Nextstrain profile builds. [PR 1023](https://github.com/nextstrain/ncov/pull/1023)
 
 - 2 November 2022: Make RBD levels filterable [PR 1028](https://github.com/nextstrain/ncov/pull/1028)
 
-- 21 October 2022: Implement RBD-level coloring for BA.2 (21L) descendants. For background on this and lineage definitions please see [Variant report 2022-10-17](https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md). [PR 1018](https://github.com/nextstrain/ncov/pull/1018).
-
-## v12 (12 July 2022)
+- 21 October 2022: Implement RGB-level coloring for BA.2 (21L) descendants. For background on this and lineage definitions please see [Variant report 2022-10-17](https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md). [PR 1018](https://github.com/nextstrain/ncov/pull/1018).
+## v12 (12 July 2022)
 
 - 1 July 2022: Update workflow to support Nextclade v2 (PRs [963](https://github.com/nextstrain/ncov/pull/963), [969](https://github.com/nextstrain/ncov/pull/969)). See [the Nextclade changelog](https://github.com/nextstrain/nextclade/blob/bdfd9cff73f8181bb5891a9a9c49eb0218e7e868/CHANGELOG.md#nextclade-200) for more information.
 


### PR DESCRIPTION
## Description of proposed changes

Currently we only deploy builds once all builds are done.

Especially when testing, this causes unnecessarily large delays: some builds can be done as soon as 1.5hr after a build is started, but others may take 12hr.

This PR adds an intermediate rule that deploys a single build as soon as all files are ready. This was discussed briefly on Slack and @trvrb gave green light for this change: https://bedfordlab.slack.com/archives/CSKMU6YUC/p1666885515151009

Changes are minimal, I tested this using dry run, will make a test run, this should work well and help test things faster in the future.

To make it easier to check builds that have finished, I've added Slack messages including the URL for each successful deployment. We already output a lot of files anyways and having clickable URLs is quite useful.

## Testing

Test builds:
```
nextstrain build --aws-batch --no-download --attach 484fdc4c-4465-4f99-a791-6d991bfcee17 .
nextstrain build --aws-batch --no-download --attach 30b12b38-16e1-4f92-b7e3-761b282c8c14 .
```

https://nextstrain.org/staging/ncov/gisaid/trial/eager/global/all-time
https://nextstrain.org/staging/ncov/open/trial/eager/global/all-time

The first build was already deployed after less than 90min (reference, open)