### PR TITLE
Refine explanation of refine step

### DIFF
--- a/docs/src/reference/troubleshoot.rst
+++ b/docs/src/reference/troubleshoot.rst
@@ -30,7 +30,7 @@ There are a few steps where sequences can be removed:
    - Check the ``results/{build_name}/filtered_log.tsv`` file to see the filtered reason for each sequence.
 
 -  Samples may be randomly removed during subsampling; see :doc:`../guides/workflow-config-file` for more info.
--  During the ``refine`` step, where samples that deviate more than 4 interquartile ranges from the root-to-tip vs time are removed
+-  During the ``refine`` step, Augur can drop samples that deviate from the expected clock rate. Inspect the log file named like ``logs/refine_{build_name}.txt`` to look for samples filtered by this step. :ref:`See the refine configuration guide <workflow-config-refine>`, for details on the clock rate filter.
 
 Sequencing and alignment errors
 -------------------------------

--- a/docs/src/reference/workflow-config-file.rst
+++ b/docs/src/reference/workflow-config-file.rst
@@ -831,6 +831,7 @@ tree-builder-args
 -  default: ``'-ninit 10 -n 4'``
 
 
+.. _workflow-config-refine:
 
 refine
 ------


### PR DESCRIPTION
## Description of proposed changes

Removes mention of explicit interquartile distances expected by refine in favor of a link to the refine config guide where the current default is shown. Adds a mention of the log file to check for names of samples that get dropped by the clock filter.

## Related issue(s)

Related to https://github.com/nextstrain/ncov/pull/1016

## Testing

 - [x] Test docs in PR check ([preview](https://nextstrain--1026.org.readthedocs.build/projects/ncov/en/1026/reference/troubleshoot.html#my-genomes-aren-t-included-in-the-analysis))