### PR TITLE
Make RBD level coloring filterable

### DIFF
--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -6,6 +6,7 @@ We also use this change log to document new features that maintain backward comp
 ## New features since last version update
 
 - October 21: Implement RGB-level coloring for BA.2 (21L) descendants. For background on this and lineage definitions please see [Variant report 2022-10-17](https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md). [PR 1018](https://github.com/nextstrain/ncov/pull/1018).
+- November 2: Make RBD levels filterable [PR 1028](https://github.com/nextstrain/ncov/pull/1028)
 
 ## v12 (12 July 2022)
 

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,8 +5,9 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
-- October 21: Implement RGB-level coloring for BA.2 (21L) descendants. For background on this and lineage definitions please see [Variant report 2022-10-17](https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md). [PR 1018](https://github.com/nextstrain/ncov/pull/1018).
 - November 2: Make RBD levels filterable [PR 1028](https://github.com/nextstrain/ncov/pull/1028)
+- October 21: Implement RBD-level coloring for BA.2 (21L) descendants. For background on this and lineage definitions please see [Variant report 2022-10-17](https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md). [PR 1018](https://github.com/nextstrain/ncov/pull/1018).
+
 
 ## v12 (12 July 2022)
 

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -301,7 +301,8 @@ rule auspice_config:
                 "author",
                 originating_lab_filter,
                 submitting_lab_filter,
-                "recency"
+                "recency",
+                "rbd_level",
             ],
             "panels": [
                 "tree",


### PR DESCRIPTION
## Description of proposed changes

@jameshadfield added RBD levels as a coloring in PR https://github.com/nextstrain/ncov/pull/1018

This PR simply adds this coloring to the filters so one can filter by RBD levels.