### PR TITLE
Skip RTD redirects syncing on fork repositories

### DIFF
--- a/.github/workflows/sync-redirects.yaml
+++ b/.github/workflows/sync-redirects.yaml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   sync:
+    # Prevent this job from running on forks.
+    if: github.repository_owner == 'nextstrain'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description of proposed changes

RTD redirects are to be synced on every push to master in this repository. This requires triggering the workflow on push to that branch, and ideally a workflow-level condition to not run on forks. There is no such workflow-level condition, so the next best thing is a job-level condition. On forks, the workflow will still run on each push to master but the job will be skipped instead of [failing](https://github.com/victorlin/ncov/actions/runs/3578375990/jobs/6018469090) due to a missing RTD token.

## Testing

- [x] Job is skipped on a personal fork from this PR's source branch ([evidence](https://github.com/victorlin/ncov/actions/runs/3578557436))
- [ ] Post-merge: job still runs on this workflow

## Release checklist

N/A, internal dev change