### PR TITLE
nextstrain: add immune_escape and ace2_binding colorings

### DIFF
--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 9 December 2022: Add `immune escape` and `ace2_binding` from metadata  as colorings for `nextstrain-open` and `nextstrain-gisaid` builds. [PR 1036](https://github.com/nextstrain/ncov/pull/1036)
+
 - 24 November 2022: Add "1m" timespan in Nextstrain profile builds. [PR 1027](https://github.com/nextstrain/ncov/pull/1027)
 
 - 24 November 2022: calculate_delta_frequency: Allow script to work with fewer pivots available than requested with `--delta-pivots`. [PR 1027](https://github.com/nextstrain/ncov/pull/1027)

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -208,6 +208,16 @@ rule auspice_config:
                     "type": "ordinal"
                 },
                 {
+                    "key": "immune_escape",
+                    "title": "Immune Escape vs BA.2",
+                    "type": "continuous"
+                },
+                {
+                    "key": "ace2_binding",
+                    "title": "ACE2 binding vs BA.2",
+                    "type": "continuous"
+                },
+                {
                     "key": "logistic_growth",
                     "title": "Logistic Growth",
                     "type": "continuous"


### PR DESCRIPTION
`immune_escape` and `ace2_binding` scores are taken from metadata
where they were added in https://github.com/nextstrain/ncov-ingest/pull/369

Only relevant for `nextstrain-open` and `nextstrain-gisaid` profiles

## Testing

- [x] Run test build on branch (open for faster results): e.g. https://nextstrain.org/staging/ncov/open/trial/pr-1036/global/all-time, `nextstrain build --aws-batch --attach f171c2b7-37f4-4fef-a811-758c81c37eb6 --no-download .`, https://nextstrain.org/staging/ncov/open/trial/pr-1036/reference

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.
