### PR TITLE
Update scripts to use augur.io Developer API

### DIFF
--- a/scripts/combine_metadata.py
+++ b/scripts/combine_metadata.py
@@ -1,5 +1,6 @@
 import argparse
-from augur.io import open_file, read_metadata
+from augur.io import read_metadata
+from augur.io.file import open_file
 from Bio import SeqIO
 import csv
 import sys

--- a/scripts/mask-alignment.py
+++ b/scripts/mask-alignment.py
@@ -2,7 +2,9 @@
 Mask initial bases from alignment FASTA
 """
 import argparse
-from augur.io import open_file, read_sequences, write_sequences
+from augur.io import read_sequences
+from augur.io.file import open_file
+from augur.io.sequences import write_sequences
 import Bio
 import Bio.SeqIO
 from Bio.Seq import Seq

--- a/scripts/mutation_summary.py
+++ b/scripts/mutation_summary.py
@@ -1,5 +1,5 @@
 import argparse, os, glob
-from augur.io import open_file
+from augur.io.file import open_file
 from Bio import SeqIO, SeqFeature, Seq
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 import numpy as np

--- a/scripts/sanitize_metadata.py
+++ b/scripts/sanitize_metadata.py
@@ -1,5 +1,6 @@
 import argparse
-from augur.io import open_file, read_metadata
+from augur.io import read_metadata
+from augur.io.file import open_file
 import csv
 import os
 from pathlib import Path

--- a/scripts/sanitize_sequences.py
+++ b/scripts/sanitize_sequences.py
@@ -1,5 +1,7 @@
 import argparse
-from augur.io import open_file, read_sequences, write_sequences
+from augur.io import read_sequences
+from augur.io.file import open_file
+from augur.io.sequences import write_sequences
 import hashlib
 from pathlib import Path
 import re


### PR DESCRIPTION
Starting with Augur 19.0.0, the only public augur.io functions are `read_metadata` and `read_sequences`. All other functions must be imported from the Developer API.

