### PR TITLE
Elevate XBB.1.5 as Nextstrain clade 23A

### DIFF
--- a/defaults/clade_emergence_dates.tsv
+++ b/defaults/clade_emergence_dates.tsv
@@ -31,3 +31,4 @@ Nextstrain_clade	first_sequence
 22D (Omicron)	2022-04-01
 22E (Omicron)	2022-07-10
 22F (Omicron)	2022-08-01
+23A (Omicron)	2022-10-01

--- a/defaults/clade_hierarchy.tsv
+++ b/defaults/clade_hierarchy.tsv
@@ -29,3 +29,4 @@ clade	parent	WHO
 22D	21L	Omicron
 22E	22B	Omicron
 22F	21L	Omicron
+23A	22F	Omicron

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -169,3 +169,8 @@ clade	gene	site	alt
 22F (Omicron)	nuc	17859	C
 22F (Omicron)	nuc	23019	C
 22F (Omicron)	nuc	26275	G
+
+23A (Omicron)	clade	22F (Omicron)
+23A (Omicron)	nuc	22317	T
+23A (Omicron)	nuc	23018	C
+23A (Omicron)	nuc	27915	T

--- a/defaults/clades_nextstrain.tsv
+++ b/defaults/clades_nextstrain.tsv
@@ -169,3 +169,8 @@ clade	gene	site	alt
 22F	nuc	17859	C
 22F	nuc	23019	C
 22F	nuc	26275	G
+
+23A	clade	22F
+23A	nuc	22317	T
+23A	nuc	23018	C
+23A	nuc	27915	T

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -32882,6 +32882,7 @@ clade_membership	22C (Omicron)
 clade_membership	22D (Omicron)
 clade_membership	22E (Omicron)
 clade_membership	22F (Omicron)
+clade_membership	23A (Omicron)
 
 ################
 
@@ -32889,11 +32890,10 @@ clade_membership	22F (Omicron)
 emerging_lineage	BQ.1.1
 emerging_lineage	BA.2.3.20
 emerging_lineage	BN.1
-emerging_lineage	BM.1.1
-emerging_lineage	BA.2.75.2
-emerging_lineage	BA.5.2.23
 emerging_lineage	BS.1
 emerging_lineage	XBC
+emerging_lineage	CH.1.1
+emerging_lineage	XAY
 
 ################
 

--- a/defaults/emerging_lineages.tsv
+++ b/defaults/emerging_lineages.tsv
@@ -170,6 +170,11 @@ clade	gene	site	alt
 22F (Omicron)	nuc	23019	C
 22F (Omicron)	nuc	26275	G
 
+23A (Omicron)	clade	22F (Omicron)
+23A (Omicron)	nuc	22317	T
+23A (Omicron)	nuc	23018	C
+23A (Omicron)	nuc	27915	T
+
 BQ.1.1	clade	22E (Omicron)
 BQ.1.1	nuc	22599	C
 
@@ -184,21 +189,6 @@ BN.1	nuc	22599	C
 BN.1	nuc	22629	C
 BN.1	nuc	23031	C
 
-BM.1.1	clade	22D (Omicron)
-BM.1.1	nuc	18583	A
-BM.1.1	nuc	22599	C
-BM.1.1	nuc	23019	C
-
-BA.2.75.2	clade	22D (Omicron)
-BA.2.75.2	nuc	5192	T
-BA.2.75.2	nuc	23019	C
-BA.2.75.2	nuc	25157	A
-
-BA.5.2.23	clade	22B (Omicron)
-BA.5.2.23	nuc	4576	T
-BA.5.2.23	nuc	22326	T
-BA.5.2.23	nuc	22896	C
-
 BS.1	clade	21L (Omicron)
 BS.1	nuc	9866	T
 BS.1	nuc	10393	C
@@ -211,3 +201,19 @@ XBC	nuc	27898	C
 XBC	nuc	21635	T
 XBC	nuc	27718	C
 XBC	nuc	7091	A
+
+XAY	clade	20A
+XAY	nuc	12163	A
+XAY	nuc	21618	G
+XAY	nuc	21623	G
+XAY	nuc	22899	A
+XAY	nuc	23679	T
+XAY	nuc	27575	G
+
+CH.1.1	clade	22D (Omicron)
+CH.1.1	nuc	3857	A
+CH.1.1	nuc	23019	C
+CH.1.1	nuc	22599	C
+CH.1.1	nuc	20741	G
+CH.1.1	nuc	22893	C
+CH.1.1	nuc	22917	G

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 30 January 2022: Include new clade 23A correspoding to Pango lineage XBB.1.5. See [PR 1043](https://github.com/nextstrain/ncov/pull/1043) for the rationale behind this clade update.
+
 - 9 December 2022: Add `immune escape` and `ace2_binding` from metadata  as colorings for `nextstrain-open` and `nextstrain-gisaid` builds. [PR 1036](https://github.com/nextstrain/ncov/pull/1036)
 
 - 24 November 2022: Add "1m" timespan in Nextstrain profile builds. [PR 1027](https://github.com/nextstrain/ncov/pull/1027)


### PR DESCRIPTION
## Elevation criteria

In North America, XBB.1.5 has reached a share of around 15% in samples collected at the beginning of January. Using a simple logistical model, it has a growth advantage of around 7-8%.

XBB.1.5 hence satisfies criteria 4 of the most recent Nextstrain clade naming criteria (https://next.nextstrain.org/blog/2022-04-29-SARS-CoV-2-clade-naming-2022):
> A clade shows consistent >0.05 per day growth in frequency where it’s circulating and has reached >5% regional frequency

Furthermore, XBB.1.5 has additional Spike mutations S:G252V and S:S486P (known to increase ACE2 binding) and hence satisfies the additional criterion:
> Additionally, for points 2, 3, and 4, we require the clade to show multiple mutations in S1 or particular mutations of known biological relevance.

XBB.1.5 as a proportion of all sequences in North America:
<img width="1030" alt="image" src="https://user-images.githubusercontent.com/25161793/215565745-c70110c4-1c73-443d-a88b-3af14bcdb5ad.png">

XBB.1.5 growth advantage vs all other sequences in North America:
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/25161793/215565755-b0751ccc-97c3-4cb3-aa77-9f32e18ede47.png">

Source: https://cov-spectrum.org/explore/North%20America/AllSamples/from=2022-07-25&to=2023-01-15/variants?nextcladePangoLineage=XBB.1.5*&dateSubmittedFrom=2020-01-06&dateSubmittedTo=2023-01-30&

## Testing

Test build looks good, it's grey because input metadata does not have any 23A yet, this is expected:

<img width="1809" alt="image" src="https://user-images.githubusercontent.com/25161793/215556724-27a51adf-534c-4428-b667-32a88817dae5.png">

https://next.nextstrain.org/staging/ncov/gisaid/trial/23A/global/all-time

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

