### PR TITLE
Parameterize Nextclade dataset in config

### DIFF
--- a/defaults/auspice_config.json
+++ b/defaults/auspice_config.json
@@ -11,6 +11,16 @@
       "type": "categorical"
     },
     {
+        "key": "immune_escape",
+        "title": "Immune Escape vs BA.2",
+        "type": "continuous"
+    },
+    {
+        "key": "ace2_binding",
+        "title": "ACE2 binding vs BA.2",
+        "type": "continuous"
+    },
+    {
       "key": "pango_lineage",
       "title": "PANGO Lineage",
       "type": "categorical"

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -47,6 +47,7 @@ sanitize_metadata:
     - "GC-Content=gc_content"
 
 reference_node_name: "USA/WA1/2020"
+nextclade_dataset: sars-cov-2
 
 # Define files used for external configuration. Common examples consist of a
 # list of strains to include and exclude from analyses, a reference sequence to

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 16 March 2023: Add a build configuration option, `nextclade_dataset`, to allow users to change the Nextclade dataset used for alignment and quality control. For example, setting `nextclade_dataset: sars-cov-2-21L` will use the BA.2 (Nextstrain 21L) dataset that provides immune escape and ACE2 binding scores. [See the workflow configuration guide for more details](https://docs.nextstrain.org/projects/ncov/en/latest/reference/workflow-config-file.html#nextclade-dataset). [PR 1046](https://github.com/nextstrain/ncov/pull/1046)
+
 - 30 January 2023: Include new clade 23A correspoding to Pango lineage XBB.1.5. See [PR 1043](https://github.com/nextstrain/ncov/pull/1043) for the rationale behind this clade update.
 
 - 9 December 2022: Add `immune escape` and `ace2_binding` from metadata  as colorings for `nextstrain-open` and `nextstrain-gisaid` builds. [PR 1036](https://github.com/nextstrain/ncov/pull/1036)

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,7 +5,7 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
-- 30 January 2022: Include new clade 23A correspoding to Pango lineage XBB.1.5. See [PR 1043](https://github.com/nextstrain/ncov/pull/1043) for the rationale behind this clade update.
+- 30 January 2023: Include new clade 23A correspoding to Pango lineage XBB.1.5. See [PR 1043](https://github.com/nextstrain/ncov/pull/1043) for the rationale behind this clade update.
 
 - 9 December 2022: Add `immune escape` and `ace2_binding` from metadata  as colorings for `nextstrain-open` and `nextstrain-gisaid` builds. [PR 1036](https://github.com/nextstrain/ncov/pull/1036)
 

--- a/docs/src/reference/workflow-config-file.rst
+++ b/docs/src/reference/workflow-config-file.rst
@@ -374,6 +374,17 @@ Secondary configuration
 
 These parameters are other high-level parameters which may affect multiple Snakemake rules, or modify which rules are run.
 
+nextclade_dataset
+-----------------
+
+- type: string
+- description: Name of a Nextclade dataset that appears in the output of ``nextclade dataset list``. The workflow will download the corresponding dataset by running ``nextclade dataset get --name {nextclade_dataset}`` where the value in the curly brackets is the value defined in the configuration file. The final alignment for each build will use the reference sequence and gene map from this dataset.
+- default: ``sars-cov-2``
+- examples:
+
+  - ``sars-cov-2-21L``
+  - ``sars-cov-2-no-recomb``
+
 default_build_name
 ------------------
 

--- a/scripts/join-metadata-and-clades.py
+++ b/scripts/join-metadata-and-clades.py
@@ -37,7 +37,9 @@ column_map = {
     "deletions": "deletions",
     "insertions": "insertions",
     "substitutions": "substitutions",
-    "aaSubstitutions": "aaSubstitutions"
+    "aaSubstitutions": "aaSubstitutions",
+    "immune_escape": "immune_escape",
+    "ace2_binding": "ace2_binding",
 }
 
 preferred_types = {
@@ -137,7 +139,8 @@ def main():
     result.loc[np.isnan(div_array)|np.isnan(t), "clock_deviation"] = np.nan
 
     for col in list(column_map.values()) + ["clock_deviation"]:
-        result[col] = result[col].fillna(VALUE_MISSING_DATA)
+        if col in result:
+            result[col] = result[col].fillna(VALUE_MISSING_DATA)
 
     # Move the new column so that it's next to other clade columns
     if INSERT_BEFORE_THIS_COLUMN in result.columns:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -458,7 +458,7 @@ rule prepare_nextclade:
     output:
         nextclade_dataset = "data/sars-cov-2-nextclade-defaults.zip",
     params:
-        name = "sars-cov-2",
+        name = config["nextclade_dataset"],
     conda: config["conda_environment"]
     shell:
         """


### PR DESCRIPTION
## Description of proposed changes

Prototypes an idea of allowing users to choose their own Nextclade dataset for the final alignment with Nextclade. Adds minimal logic and config to allow users to pull in immune escape and ACE2 binding scores to their builds by switching their default dataset.

As with the Nextclade web UI, users must understand that their trees and annotations on those trees will not make sense biologically if they use sequences that don't descend from BA.2 (Nextstrain clade 21L). This PR doesn't implement any checks or force any filters to ensure that input data are reasonable, unlike [the RBD levels annotations](https://github.com/nextstrain/ncov/blob/bb8874cab00aff86ed2df9a711bac94301f584cd/workflow/snakemake_rules/main_workflow.smk#L1314) in this workflow or [the ncov-ingest logic to pull in the same phenotypic scores](https://github.com/nextstrain/ncov-ingest/blob/6dd205494a2980e230a4cf64fb6fffb6caaf96eb/bin/join-metadata-and-clades#L107-L108).

## Testing

Tested with this minimal build config based on the CI build:

```yaml
inputs:
  - name: gisaid
    metadata: "s3://nextstrain-ncov-private/100k/metadata.tsv.xz"
    aligned: "s3://nextstrain-ncov-private/100k/sequences.fasta.xz"

nextclade_dataset: sars-cov-2-21L

builds:
  europe:
    subsampling_scheme: nextstrain_ci_sampling
    region: Europe

filter:
  skip_diagnostics: true

subsampling:
  # Custom subsampling logic for CI tests.
  nextstrain_ci_sampling:
    # Focal samples for region
    region:
      group_by: "division year month"
      max_sequences: 50
      exclude: "--exclude-where 'region!={region}'"
      min_date: --min-date 2022-01-01
    # Contextual samples for region from the rest of the world
    global:
      group_by: "year month"
      max_sequences: 50
      exclude: "--exclude-where 'region={region}'"
      min_date: --min-date 2022-01-01
```

Run the build like so:

```bash
snakemake --forceall -p -j 4 --use-conda --conda-frontend mamba --configfile immune_escape.yaml
```

An example tree with immune escape scores from this build looked like this:

![image](https://user-images.githubusercontent.com/85372/217936299-06a84a39-4c33-4a9f-807f-231e67deadf0.png)

And ACE2 binding:

![image](https://user-images.githubusercontent.com/85372/217936347-2d87fef1-d1dc-499e-b06d-7c8a9b960257.png)

This tree is a good example where the input sequences should be limited to 21L descendants and haven't been fully.

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.
