### PR TITLE
Strip directories from tarball members

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -47,6 +47,11 @@ def extract_tar_file_contents(filename, filetype):
             suffixes = Path(member.name).suffixes
 
             if extension in suffixes:
+                # Only use the last part of the member file name, excluding any
+                # leading directories that might include the root file system.
+                member_path = Path(member.name)
+                member.name = member_path.name
+
                 # By default, return the binary stream for the member file.
                 internal_member = member
                 break


### PR DESCRIPTION
## Description of proposed changes

When extracting tarballs prior to sanitizing data, uses only the final filename component of the path for each member in the tarball. This strips any leading directories that might be in the path like a single "/" in GISAID's tarballs for Augur that would cause files to be written to the root level of the file system.

## Testing

 - [x] Tested locally with a download from GISAID in "Input for Augur" format
