### PR TITLE
Add display name clades_display_name.tsv for human friendly names

### DIFF
--- a/defaults/clades_display_name.tsv
+++ b/defaults/clades_display_name.tsv
@@ -1,0 +1,176 @@
+clade	gene	site	alt
+
+19A	nuc	8782	C
+19A	nuc	14408	C
+
+19B	nuc	8782	T
+19B	nuc	28144	C
+
+20A	clade	19A
+20A	nuc	14408	T
+20A	nuc	23403	G
+
+20B	clade	20A
+20B	nuc	28881	A
+20B	nuc	28882	A
+
+20C	clade	20A
+20C	nuc	1059	T
+20C	nuc	25563	T
+
+20D	clade	20B
+20D	nuc	4002	T
+20D	nuc	10097	A
+20D	nuc	13536	T
+20D	nuc	23731	T
+
+20E	clade	20A
+20E	nuc	22227	T
+20E	nuc	28932	T
+20E	nuc	29645	T
+
+20F	clade	20B
+20F	nuc	1163	T
+20F	nuc	7540	C
+20F	nuc	16647	T
+20F	nuc	18555	T
+20F	nuc	22992	A
+20F	nuc	23401	A
+
+20G	clade	20C
+20G	nuc	10319	T
+20G	nuc	18424	G
+20G	nuc	25907	T
+20G	nuc	27964	T
+20G	nuc	28472	T
+20G	nuc	28869	T
+
+20H (Beta)	clade	20C
+20H (Beta)	nuc	23012	A
+20H (Beta)	nuc	23063	T
+20H (Beta)	nuc	23403	G
+20H (Beta)	nuc	26456	T
+
+20I (Alpha)	clade	20B
+20I (Alpha)	nuc	14676	T
+20I (Alpha)	nuc	15279	T
+20I (Alpha)	nuc	23063	T
+
+20J (Gamma)	clade	20B
+20J (Gamma)	nuc	733	C
+20J (Gamma)	nuc	2749	T
+20J (Gamma)	nuc	3828	T
+20J (Gamma)	nuc	5648	C
+20J (Gamma)	nuc	12778	T
+20J (Gamma)	nuc	13860	T
+
+21A (Delta)	clade	20A
+21A (Delta)	nuc	21618	G
+21A (Delta)	nuc	26767	C
+21A (Delta)	nuc	28461	G
+
+21B (Kappa)	clade	20A
+21B (Kappa)	nuc	17523	T
+21B (Kappa)	nuc	22917	G
+21B (Kappa)	nuc	23012	C
+21B (Kappa)	nuc	27638	C
+21B (Kappa)	nuc	28881	T
+21B (Kappa)	nuc	29402	T
+
+21C (Epsilon)	clade	20C
+21C (Epsilon)	nuc	17014	T
+21C (Epsilon)	nuc	21600	T
+21C (Epsilon)	nuc	22018	T
+21C (Epsilon)	nuc	22917	G
+
+21D (Eta)	clade	20A
+21D (Eta)	nuc	14407	T
+21D (Eta)	nuc	20724	G
+21D (Eta)	nuc	23593	C
+21D (Eta)	nuc	24224	C
+21D (Eta)	nuc	24748	T
+
+21E (Theta)	clade	20B
+21E (Theta)	nuc	12049	T
+21E (Theta)	nuc	23341	C
+21E (Theta)	nuc	23604	A
+21E (Theta)	nuc	24187	A
+21E (Theta)	nuc	24836	A
+
+21F (Iota)	clade	20C
+21F (Iota)	nuc	16500	C
+21F (Iota)	nuc	20262	G
+21F (Iota)	nuc	21575	T
+21F (Iota)	nuc	22320	G
+
+21G (Lambda)	clade	20D
+21G (Lambda)	nuc	21786	T
+21G (Lambda)	nuc	21789	T
+21G (Lambda)	nuc	22917	A
+21G (Lambda)	nuc	23031	C
+
+21H (Mu)	clade	20A
+21H (Mu)	nuc	3428	G
+21H (Mu)	nuc	4878	T
+21H (Mu)	nuc	11451	G
+21H (Mu)	nuc	13057	T
+21H (Mu)	nuc	17491	T
+21H (Mu)	nuc	27925	A
+
+21I (Delta)	clade	21A (Delta)
+21I (Delta)	nuc	5184	T
+21I (Delta)	nuc	9891	T
+21I (Delta)	nuc	22227	T
+
+21J (Delta)	clade	21A (Delta)
+21J (Delta)	nuc	11332	G
+21J (Delta)	nuc	19220	T
+
+21K (BA.1)	clade	21M (Omicron)
+21K (BA.1)	nuc	15240	T
+21K (BA.1)	nuc	23202	A
+21K (BA.1)	nuc	23525	T
+21K (BA.1)	nuc	27259	C
+
+21L (BA.2)	clade	21M (Omicron)
+21L (BA.2)	nuc	21618	T
+21L (BA.2)	nuc	22775	A
+
+21M (Omicron)	clade	20B
+21M (Omicron)	nuc	18163	G
+21M (Omicron)	nuc	23599	G
+
+22A (BA.4)	clade	21L (BA.2)
+22A (BA.4)	nuc	12160	A
+22A (BA.4)	nuc	9866	C
+22A (BA.4)	nuc	28724	T
+
+22B (BA.5)	clade	21L (BA.2)
+22B (BA.5)	nuc	12160	A
+22B (BA.5)	nuc	9866	C
+22B (BA.5)	nuc	27259	A
+
+22C (BA.2.12.1)	clade	21L (BA.2)
+22C (BA.2.12.1)	nuc	22917	A
+22C (BA.2.12.1)	nuc	23673	T
+
+22D (BA.2.75)	clade	21L (BA.2)
+22D (BA.2.75)	nuc	3796	T
+22D (BA.2.75)	nuc	26275	G
+
+22E (BQ.1)	clade	22B (BA.5)
+22E (BQ.1)	nuc	14257	C
+22E (BQ.1)	nuc	16935	A
+22E (BQ.1)	nuc	28312	T
+22E (BQ.1)	nuc	22942	A
+
+22F (XBB)	clade	21L (BA.2)
+22F (XBB)	nuc	15461	A
+22F (XBB)	nuc	17859	C
+22F (XBB)	nuc	23019	C
+22F (XBB)	nuc	26275	G
+
+23A (XBB.1.5)	clade	22F (XBB)
+23A (XBB.1.5)	nuc	22317	T
+23A (XBB.1.5)	nuc	23018	C
+23A (XBB.1.5)	nuc	27915	T

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -33525,9 +33525,9 @@ recency	New
 ################
 
 
-clade_membership	20H (Beta, V2)
-clade_membership	20I (Alpha, V1)
-clade_membership	20J (Gamma, V3)
+clade_membership	20H (Beta)
+clade_membership	20I (Alpha)
+clade_membership	20J (Gamma)
 clade_membership	21A (Delta)
 clade_membership	21I (Delta)
 clade_membership	21J (Delta)
@@ -33538,16 +33538,16 @@ clade_membership	21E (Theta)
 clade_membership	21F (Iota)
 clade_membership	21G (Lambda)
 clade_membership	21H (Mu)
-clade_membership	21K (Omicron)
-clade_membership	21L (Omicron)
 clade_membership	21M (Omicron)
-clade_membership	22A (Omicron)
-clade_membership	22B (Omicron)
-clade_membership	22C (Omicron)
-clade_membership	22D (Omicron)
-clade_membership	22E (Omicron)
-clade_membership	22F (Omicron)
-clade_membership	23A (Omicron)
+clade_membership	21K (BA.1)
+clade_membership	21L (BA.2)
+clade_membership	22A (BA.4)
+clade_membership	22B (BA.5)
+clade_membership	22C (BA.2.12.1)
+clade_membership	22D (BA.2.75)
+clade_membership	22E (BQ.1)
+clade_membership	22F (XBB)
+clade_membership	23A (XBB.1.5)
 
 ################
 

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -64,7 +64,7 @@ files:
   auspice_config: "defaults/auspice_config.json"
   lat_longs: "defaults/lat_longs.tsv"
   description: "defaults/description.md"
-  clades: "defaults/clades.tsv"
+  clades: "defaults/clades_display_name.tsv"
   emerging_lineages: "defaults/emerging_lineages.tsv"
   mutational_fitness_distance_map: "defaults/mutational_fitness_distance_map.json"
   sites_to_mask: "defaults/sites_ignored_for_tree_topology.txt"


### PR DESCRIPTION
## Description of proposed changes

Adds an additional clades.tsv that is for human consumption
It combines Nextstrain clade, WHO variant and Pango lineage names
Nextstrain clade is always displayed
WHO variants are added in parens when meaningful (pre-Omicron)
Pango lineage names are used for Omicron era

For now, we keep the old `clades.tsv` around and add a new one - but if desired we could just replace the `clades.tsv` with the one added here. I don't have enough experience with this repo to know which pattern is better.

It will look something like this:
![image](https://user-images.githubusercontent.com/25161793/225950641-70ddd1c9-a799-4289-8d0e-fb7a37b75fc9.png)

So `22A (Omicron)` becomes `22A (BA.4)`

Further patterns are:
- `19A`
- `20I (Alpha)`
- `21M (Omicron)`
- `22C (BA.2.12.1)`
- `22E (BQ.1)`
- `23A (XBB.1.5)`

## Needs fixing

Because the new display names are not in the metadata (yet), color-ordering grays them out.

![image](https://user-images.githubusercontent.com/25161793/225984719-18aa2cfe-0f47-483f-99d7-875b900122bc.png)

Possible fixes:
- Change `assign-colors.py` script to allow metadata to be ignored for certain colorings
- Edit assign-colors to take in node-data-JSONs and use these preferentially over metadata
- Rewrite the `clade_membership` column values for metadata that is fed into `assign-colors.py` to work with existing `assign-colors.py`
- Delete the `clade_membership` column from metadata, maybe that's enough to get `assign-colors.py` to ignore that column without requiring editing of the script.

None of these fixes are perfect. Rewriting the metadata column `clade_membership` before passing to `assign-colors.py` may be the easiest.

In general, it could be a good idea to turn `assign-colors.py` into an augur subcommand `augur 

## Testing

- [x] Tested locally with Europe build visible above and it worked.
- [ ] Run big test builds: https://github.com/nextstrain/ncov/actions/runs/4449254982, result will be here: https://next.nextstrain.org/staging/ncov/open/trial/display-names/africa/all-time (and at similar URLs)

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.
