### PR TITLE
Start from actually-aligned sequences

### DIFF
--- a/nextstrain_profiles/nextstrain-country/builds.yaml
+++ b/nextstrain_profiles/nextstrain-country/builds.yaml
@@ -25,12 +25,10 @@ include_hcov19_prefix: True
 files:
   description: "nextstrain_profiles/nextstrain-country/nextstrain_description.md"
 
-# Note: unaligned sequences are provided as "aligned" sequences to avoid an initial full-DB alignment
-# as we re-align everything after subsampling.
 inputs:
   - name: gisaid
     metadata: "s3://nextstrain-ncov-private/metadata.tsv.gz"
-    aligned: "s3://nextstrain-ncov-private/sequences.fasta.xz"
+    aligned: "s3://nextstrain-ncov-private/aligned.fasta.xz"
     skip_sanitize_metadata: true
 
 # Define locations for which builds should be created.

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -25,12 +25,10 @@ include_hcov19_prefix: True
 files:
   description: "nextstrain_profiles/nextstrain-gisaid/nextstrain_description.md"
 
-# Note: unaligned sequences are provided as "aligned" sequences to avoid an initial full-DB alignment
-# as we re-align everything after subsampling.
 inputs:
   - name: gisaid
     metadata: "s3://nextstrain-ncov-private/metadata.tsv.gz"
-    aligned: "s3://nextstrain-ncov-private/sequences.fasta.xz"
+    aligned: "s3://nextstrain-ncov-private/aligned.fasta.xz"
     skip_sanitize_metadata: true
 
 # Define locations for which builds should be created.

--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -25,12 +25,10 @@ include_hcov19_prefix: False
 files:
   description: "nextstrain_profiles/nextstrain-open/nextstrain_description.md"
 
-# Note: unaligned sequences are provided as "aligned" sequences to avoid an initial full-DB alignment
-# as we re-align everything after subsampling.
 inputs:
   - name: open
     metadata: "s3://nextstrain-data/files/ncov/open/metadata.tsv.gz"
-    aligned: "s3://nextstrain-data/files/ncov/open/sequences.fasta.xz"
+    aligned: "s3://nextstrain-data/files/ncov/open/aligned.fasta.xz"
     skip_sanitize_metadata: true
 
 # Define locations for which builds should be created.


### PR DESCRIPTION
Use aligned sequences as the aligned sequences input, rather than pass off unaligned sequences as the aligned sequences input.

This should be inconsequential to workflow behaviour or results, but it makes the config a bit more straightforward and less confusing.

In a quick dig thru history, it seems like ncov-ingest's aligned.fasta.xz was not _quite_ available when we first switched our profiles to use an "aligned" input instead of a "sequences" input.  The original use of "aligned" with unaligned sequences was driven by run time concerns and related to the move of the filtering step after the subsampling step and move of the "preprocess" steps from this workflow (ncov) to ncov-ingest.¹

Resolves <https://github.com/nextstrain/ncov/issues/1054>.

¹ <https://github.com/nextstrain/ncov/pull/814>
  <https://github.com/nextstrain/ncov/pull/823>

## Testing

I've been starting from `aligned.fasta.zst` when testing the [21L-rooted builds](https://github.com/nextstrain/ncov/pull/1029) and all seems fine.

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
