### PR TITLE
Elevate XBB.1.16 as new clade 23B

### DIFF
--- a/defaults/clade_emergence_dates.tsv
+++ b/defaults/clade_emergence_dates.tsv
@@ -32,3 +32,4 @@ Nextstrain_clade	first_sequence
 22E (Omicron)	2022-07-10
 22F (Omicron)	2022-08-01
 23A (Omicron)	2022-10-01
+23B (Omicron)	2022-11-01

--- a/defaults/clade_hierarchy.tsv
+++ b/defaults/clade_hierarchy.tsv
@@ -30,3 +30,4 @@ clade	parent	WHO
 22E	22B	Omicron
 22F	21L	Omicron
 23A	22F	Omicron
+23B	22F	Omicron

--- a/defaults/clades.tsv
+++ b/defaults/clades.tsv
@@ -174,3 +174,9 @@ clade	gene	site	alt
 23A (Omicron)	nuc	22317	T
 23A (Omicron)	nuc	23018	C
 23A (Omicron)	nuc	27915	T
+
+23B (Omicron)	clade	22F (Omicron)
+23B (Omicron)	nuc	12730	A
+23B (Omicron)	nuc	14856	G
+23B (Omicron)	nuc	18703	T
+23B (Omicron)	nuc	28447	G

--- a/defaults/clades_nextstrain.tsv
+++ b/defaults/clades_nextstrain.tsv
@@ -174,3 +174,9 @@ clade	gene	site	alt
 23A	nuc	22317	T
 23A	nuc	23018	C
 23A	nuc	27915	T
+
+23B	clade	22F
+23B	nuc	12730	A
+23B	nuc	14856	G
+23B	nuc	18703	T
+23B	nuc	28447	G

--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -33548,16 +33548,14 @@ clade_membership	22D (Omicron)
 clade_membership	22E (Omicron)
 clade_membership	22F (Omicron)
 clade_membership	23A (Omicron)
+clade_membership	23B (Omicron)
 
 ################
 
 emerging_lineage	BA.2.3.20
 emerging_lineage	BN.1
-emerging_lineage	BQ.1.1
-emerging_lineage	BS.1
 emerging_lineage	CH.1.1
 emerging_lineage	XAY
-emerging_lineage	XBB.1.16
 emerging_lineage	XBC
 
 ################

--- a/defaults/emerging_lineages.tsv
+++ b/defaults/emerging_lineages.tsv
@@ -175,9 +175,6 @@ clade	gene	site	alt
 23A (Omicron)	nuc	23018	C
 23A (Omicron)	nuc	27915	T
 
-BQ.1.1	clade	22E (Omicron)
-BQ.1.1	nuc	22599	C
-
 BA.2.3.20	clade	21L (Omicron)
 BA.2.3.20	nuc	6770	G
 BA.2.3.20	nuc	22332	A
@@ -188,12 +185,6 @@ BN.1	clade	22D (Omicron)
 BN.1	nuc	22599	C
 BN.1	nuc	22629	C
 BN.1	nuc	23031	C
-
-BS.1	clade	21L (Omicron)
-BS.1	nuc	9866	T
-BS.1	nuc	10393	C
-BS.1	nuc	16418	T
-BS.1	nuc	26733	C
 
 XBC	clade	20A
 XBC	nuc	23670	T
@@ -217,9 +208,3 @@ CH.1.1	nuc	22599	C
 CH.1.1	nuc	20741	G
 CH.1.1	nuc	22893	C
 CH.1.1	nuc	22917	G
-
-XBB.1.16	clade	23A (Omicron)
-XBB.1.16	nuc	12730	A
-XBB.1.16	nuc	14856	G
-XBB.1.16	nuc	18703	T
-XBB.1.16	nuc	28447	G

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 11 April 2023: Elevate XBB.1.16 as new clade 23B. See [PR TKTK](https://github.com/nextstrain/ncov/pull/TKTK) for the rationale behind this clade update.
+
 - 6 April 2023: Update conda environment dependencies: augur 19.2.0 -> 21.1.0, nextalign/nextclade 2.9.1 -> 2.13.1, iqtree 2.2.0_beta -> 2.2.0.3. [PR 1056](https://github.com/nextstrain/ncov/pull/1056)
 
 - 16 March 2023: Add a build configuration option, `nextclade_dataset`, to allow users to change the Nextclade dataset used for alignment and quality control. For example, setting `nextclade_dataset: sars-cov-2-21L` will use the BA.2 (Nextstrain 21L) dataset that provides immune escape and ACE2 binding scores. [See the workflow configuration guide for more details](https://docs.nextstrain.org/projects/ncov/en/latest/reference/workflow-config-file.html#nextclade-dataset). [PR 1046](https://github.com/nextstrain/ncov/pull/1046)

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,7 +5,7 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
-- 11 April 2023: Elevate XBB.1.16 as new clade 23B. See [PR TKTK](https://github.com/nextstrain/ncov/pull/TKTK) for the rationale behind this clade update.
+- 11 April 2023: Elevate XBB.1.16 as new clade 23B. See [PR 1059](https://github.com/nextstrain/ncov/pull/1059) for the rationale behind this clade update.
 
 - 6 April 2023: Update conda environment dependencies: augur 19.2.0 -> 21.1.0, nextalign/nextclade 2.9.1 -> 2.13.1, iqtree 2.2.0_beta -> 2.2.0.3. [PR 1056](https://github.com/nextstrain/ncov/pull/1056)
 


### PR DESCRIPTION
# Elevation criteria

In India, XBB.1.16 has reached a share of around 75% in samples collected mid March.

In all Asian sequences in GISAID at time of writing, XBB.1.16 represents around 10% of all sequences collected mid March.

A simple logistical growth model shows an absolute daily growth advantage of around 9% in all of Asia.

The relative growth against all of XBB* is around 5% in India.

Similar advantages are also apparent in the US.

XBB.1.16 hence clearly satisfies criterion 4 of the most recent Nextstrain clade naming criteria ("A clade shows consistent >0.05 per day growth in frequency where it’s circulating and has reached >5% regional frequency", see https://next.nextstrain.org/blog/2022-04-29-SARS-CoV-2-clade-naming-2022).

Also the additional requirement of "multiple mutations in S1 or particular mutations of known biological relevance." are satisfied, as compared to parental 22F (XBB), XBB.1.16 has 3 S1 mutations (180V, 478R, 486P) of which 2 are in the receptor binding domain and of known biological relevance (478R, 486P). While is already present in clade 23A (XBB.1.5), XBB.1.16 has evolved this substitution independently. What makes XBB.1.16 distinct is the additional substitution 478R.

Share of XBB.1.16 vs other clades over time in select countries (logit scale):
![image](https://user-images.githubusercontent.com/25161793/231096557-c3b2b3f4-47a6-4add-a0f3-6d5a6b1017a2.png)

Absolute numbers of cases (to be taken with grain of salt due to changing testing) in select countries showing XBB.1.16 driving a wave in India (linear scale):
![image](https://user-images.githubusercontent.com/25161793/231096917-dc910fda-be0f-49ad-8d6a-3313959fda03.png)

Log plot of absolute number of cases in select countries:
![image](https://user-images.githubusercontent.com/25161793/231096968-0e1e8d29-5d40-4e74-b132-bbbace87737d.png)

These were all created by @trvrb using https://github.com/blab/rt-from-frequency-dynamics/tree/master/results/omicron-xbb116

Here are some further plots of relative growth advantages of XBB.1.16 vs XBB*+486P (comprising all XBB.1.5-like lineages) via covSpectrum, showing that XBB.1.16 is not just another XBB.1.5 but appears to outcompete it, at least in those countries: (take exact numbers with big grain of salt, but trends and significance is clear)
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/25161793/231100726-afce9e95-77ef-42d5-9095-c32a65686149.png">
from: https://cov-spectrum.org/explore/World/AllSamples/Past6M/variants?aaMutations=S%3A486P&nextcladePangoLineage=XBB*&variantQuery1=nextcladePangoLineage%3AXBB.1.16*&analysisMode=CompareToBaseline&

Checklist, from Slack:

- [x] NCoV file updates
  - [x] defaults/clade_emergence_dates.tsv
  - [x] defaults/clade_hierarchy.tsv
  - [x] defaults/clades.tsv
  - [x] defaults/clades_nextstrain.tsv
  - [x] defaults/color_ordering.tsv
  - [x] defaults/emerging_lineages.tsv
  - [x] changelog
- [x] Explain in PR why we are elevating
- [x] Start test build: will be at ".../open/23B/global/6m" etc, first builds should be there by 11am UTC
- [x] Check test build
- [x] Pass PR review
- [x] Merge PR
- [ ] Update [clade diagram figure](https://github.com/nextstrain/ncov-clades-schema)
- [ ] Update covariants
- [ ] Add new variant (with new name) to Nextclade dataset
- [ ] Trigger full runs on GISAID & Genbank once Nextclade updated
- [ ] Draft tweet
- [ ] Send tweet