### PR TITLE
sanitize_metadata: Filter duplicates after strain column transformations

### DIFF
--- a/tests/sanitize-metadata.t
+++ b/tests/sanitize-metadata.t
@@ -95,3 +95,22 @@ Rename fields and strip prefixes.
   $ grep "SARS-CoV-2" "$TMP/metadata.tsv"
   [1]
   $ rm -f "$TMP/metadata.tsv"
+
+De-duplication happens before strain name sanitization, so there may still be
+duplicates the output metadata.
+
+  $ cat >"$TMP/unsanitized_metadata.tsv" <<~~
+  > Virus name	gender	date	gisaid_epi_isl
+  > hCoV-19/Spain/AS-242164052/2021	male	2020-10-01	EPI_ISL_1
+  > hCoV-19/Spain/AS- 242164052/2021	male	2020-10-01	EPI_ISL_2
+  > ~~
+  $ python3 ../scripts/sanitize_metadata.py \
+  >  --metadata "$TMP/unsanitized_metadata.tsv" \
+  >  --rename-fields "Virus name=strain" \
+  >  --strip-prefixes "hCoV-19/" \
+  >  --output "$TMP/metadata.tsv"
+  $ cat "$TMP/metadata.tsv"
+  strain	gender	date	gisaid_epi_isl
+  Spain/AS-242164052/2021	male	2020-10-01	EPI_ISL_1
+  Spain/AS-242164052/2021	male	2020-10-01	EPI_ISL_2
+  $ rm -f "$TMP/metadata.tsv"

--- a/tests/sanitize-metadata.t
+++ b/tests/sanitize-metadata.t
@@ -96,8 +96,8 @@ Rename fields and strip prefixes.
   [1]
   $ rm -f "$TMP/metadata.tsv"
 
-De-duplication happens before strain name sanitization, so there may still be
-duplicates the output metadata.
+De-duplication happens after strain name sanitization, so there should not be
+any duplicates in the output metadata.
 
   $ cat >"$TMP/unsanitized_metadata.tsv" <<~~
   > Virus name	gender	date	gisaid_epi_isl
@@ -111,6 +111,5 @@ duplicates the output metadata.
   >  --output "$TMP/metadata.tsv"
   $ cat "$TMP/metadata.tsv"
   strain	gender	date	gisaid_epi_isl
-  Spain/AS-242164052/2021	male	2020-10-01	EPI_ISL_1
   Spain/AS-242164052/2021	male	2020-10-01	EPI_ISL_2
   $ rm -f "$TMP/metadata.tsv"


### PR DESCRIPTION
## Description of proposed changes

Previously, duplicates were filtered before strain column transformations. These transformations could have resulted in a final output file containing duplicates.

Filter duplicates after strain column transformations but before other transformations to avoid unnecessarily transforming rows that would be dropped by duplicate filtering.

This also requires strain column transformations when mapping strain names to database IDs.

## Related issue(s)

<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Fixes #1049

## Testing

- [x] Added and modified a test to show new behavior.

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
