### PR TITLE
fix: Quote "3.10" in rebuild-100k.yml to prevent parsing as decimal

### DIFF
--- a/.github/workflows/rebuild-100k.yml
+++ b/.github/workflows/rebuild-100k.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Launch build
       run: |


### PR DESCRIPTION
It seems that YAML interprets values like 3.10 as decimals, instead of strings (https://yaml.org/spec/1.2.2/#24-tags) So we need to put version strings in quotes in things like `python-version: "3.10"` Bug where this was root cause: ncov rebuild-100k workflow: https://github.com/nextstrain/ncov/blob/8765cd96660f2a0a923074886899ebda678abc89/.github/workflows/rebuild-100k.yml#L18 https://github.com/nextstrain/ncov/actions/runs/4721332745/jobs/8374484699#step:3:7

Things seem to have fine while we didn’t use Python version 3.10 as unquoted 3.9 is still 3.9 and cast back to string “3.9”. But trailing 0 gets chopped off.

## Testing

- [x] Test run workflow to see if this fixes it