### PR TITLE
Define python-version as a string

### DIFF
--- a/.github/workflows/rebuild-country.yml
+++ b/.github/workflows/rebuild-country.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: 3.9
+        python-version: "3.9"
 
     - name: Launch build
       run: |

--- a/.github/workflows/rebuild-gisaid-21L.yml
+++ b/.github/workflows/rebuild-gisaid-21L.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: 3.9
+        python-version: "3.9"
 
     - name: Launch build
       run: |

--- a/.github/workflows/rebuild-gisaid.yml
+++ b/.github/workflows/rebuild-gisaid.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: 3.9
+        python-version: "3.9"
 
     - name: Launch build
       run: |

--- a/.github/workflows/rebuild-open.yml
+++ b/.github/workflows/rebuild-open.yml
@@ -30,7 +30,7 @@ jobs:
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: 3.9
+        python-version: "3.9"
 
     - name: Launch build
       run: |

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -28,7 +28,7 @@ jobs:
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: 3.9
+        python-version: "3.9"
 
     - name: Revert build
       run: |


### PR DESCRIPTION
3.9 works fine without quotes because it still translates to "3.9". However, 3.10 translates to the float value 3.1 which gets evaluated as version string "3.1" which is not desirable.

Define the version a string to avoid the automatic conversion which is likely to cause unexpected issues in the future.

## Related issue(s)

Follow-up to #1063 
