### PR TITLE
Create locations DataFrame with a strain index

### DIFF
--- a/scripts/sanitize_metadata.py
+++ b/scripts/sanitize_metadata.py
@@ -479,12 +479,13 @@ if __name__ == '__main__':
             # Parse GISAID location field into separate fields for geographic
             # scales. Replace missing field values with "?".
             if args.parse_location_field and args.parse_location_field in metadata.columns:
-                locations = pd.DataFrame(
-                    (
-                        parse_location_string(location, LOCATION_FIELDS)
-                        for location in metadata[args.parse_location_field].values
-                    )
+                locations = pd.DataFrame.from_dict(
+                    {
+                        strain: parse_location_string(location, LOCATION_FIELDS)
+                        for strain, location in metadata[args.parse_location_field].items()
+                    }, orient='index'
                 )
+                locations.index.name = metadata.index.name
 
                 # Combine new location columns with original metadata and drop the
                 # original location column.

--- a/tests/sanitize-metadata.t
+++ b/tests/sanitize-metadata.t
@@ -113,3 +113,23 @@ any duplicates in the output metadata.
   strain	gender	date	gisaid_epi_isl
   Spain/AS-242164052/2021	male	2020-10-01	EPI_ISL_2
   $ rm -f "$TMP/metadata.tsv"
+
+Specifying --parse-location-field produces extra rows. This is a bug.
+
+  $ cat >"$TMP/unsanitized_metadata.tsv" <<~~
+  > Virus name	gender	date	gisaid_epi_isl	Location
+  > hCoV-19/OneVirus/1/2020	male	2020-10-01	EPI_ISL_1	A
+  > SARS-CoV-2/AnotherVirus/1/2021	male	2020-10-01	EPI_ISL_2	B
+  > ~~
+  $ python3 ../scripts/sanitize_metadata.py \
+  >  --metadata "$TMP/unsanitized_metadata.tsv" \
+  >  --rename-fields "Virus name=strain" \
+  >  --parse-location-field Location \
+  >  --output "$TMP/metadata.tsv"
+  $ cat "$TMP/metadata.tsv"
+  	gender	date	gisaid_epi_isl	region	country	division	location
+  hCoV-19/OneVirus/1/2020	male	2020-10-01	EPI_ISL_1				
+  SARS-CoV-2/AnotherVirus/1/2021	male	2020-10-01	EPI_ISL_2				
+  0				A	?	?	?
+  1				B	?	?	?
+  $ rm -f "$TMP/metadata.tsv"

--- a/tests/sanitize-metadata.t
+++ b/tests/sanitize-metadata.t
@@ -114,7 +114,7 @@ any duplicates in the output metadata.
   Spain/AS-242164052/2021	male	2020-10-01	EPI_ISL_2
   $ rm -f "$TMP/metadata.tsv"
 
-Specifying --parse-location-field produces extra rows. This is a bug.
+Specifying --parse-location-field will populate accordingly.
 
   $ cat >"$TMP/unsanitized_metadata.tsv" <<~~
   > Virus name	gender	date	gisaid_epi_isl	Location
@@ -127,9 +127,7 @@ Specifying --parse-location-field produces extra rows. This is a bug.
   >  --parse-location-field Location \
   >  --output "$TMP/metadata.tsv"
   $ cat "$TMP/metadata.tsv"
-  	gender	date	gisaid_epi_isl	region	country	division	location
-  hCoV-19/OneVirus/1/2020	male	2020-10-01	EPI_ISL_1				
-  SARS-CoV-2/AnotherVirus/1/2021	male	2020-10-01	EPI_ISL_2				
-  0				A	?	?	?
-  1				B	?	?	?
+  strain	gender	date	gisaid_epi_isl	region	country	division	location
+  hCoV-19/OneVirus/1/2020	male	2020-10-01	EPI_ISL_1	A	?	?	?
+  SARS-CoV-2/AnotherVirus/1/2021	male	2020-10-01	EPI_ISL_2	B	?	?	?
   $ rm -f "$TMP/metadata.tsv"


### PR DESCRIPTION
## Description of proposed changes

Prior to that commit, DataFrames were not indexed by strain and used the
default counter index. The concat relied on both the locations and
metadata DataFrames having the same counter index. This was broken in
the linked commit when the metadata was switched to index on strain.

Solutions are to either (1) revert to using counter index for both, (2)
use strain index for both, or (3) ignore the index when concatenating.

A strain index has benefits and is used elsewhere in the script, so this
commit implements solution (2).

## Related issue(s)

Follow-up to #1062

## Testing

What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

- [x] Added and modified a test to show new behavior.

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
