### PR TITLE
Update subsampling

### DIFF
--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 17 June 2023: Update subsampling strategy for `nextstrain_profiles` to better equilibrate per-capita sampling rates across geographic regions. Primarily this update breaks out China and India as separate subsampling targets because of their large population sizes. It also fine tunes the per-region sampling targets. After this update, URL structure (ie https://nextstrain.org/ncov/gisaid/global/6m) is unchanged. [PR 1074](https://github.com/nextstrain/ncov/pull/1074)
+
 ## v13 (16 May 2022)
 
 - 16 May 2023: Update workflow to support [Augur v22](https://github.com/nextstrain/augur/releases/tag/22.0.0) which updates the `augur clades` interface and structure of the output files to allow specifying the clade label & coloring keys. Because we use custom scripts to parse these files this worflow also needed updating. This change results in a simplifying of the nCoV pipeline (PR [1000](https://github.com/nextstrain/ncov/pull/1000)).

--- a/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
@@ -77,19 +77,19 @@ builds:
     region: Africa
     title: Evolution SARS-CoV-2 relative to clade 21L reference virus with subsampling focused on Africa since pandemic start
   asia_1m:
-    subsampling_scheme: nextstrain_region_grouped_by_country_1m
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_1m
     region: Asia
     title: Evolution SARS-CoV-2 relative to clade 21L reference virus with subsampling focused on Asia over the past month
   asia_2m:
-    subsampling_scheme: nextstrain_region_grouped_by_country_2m
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_2m
     region: Asia
     title: Evolution SARS-CoV-2 relative to clade 21L reference virus with subsampling focused on Asia over the past 2 months
   asia_6m:
-    subsampling_scheme: nextstrain_region_grouped_by_country_6m
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_6m
     region: Asia
     title: Evolution SARS-CoV-2 relative to clade 21L reference virus with subsampling focused on Asia over the past 6 months
   asia_all-time:
-    subsampling_scheme: nextstrain_region_grouped_by_country_all_time
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_all_time
     region: Asia
     title: Evolution SARS-CoV-2 relative to clade 21L reference virus with subsampling focused on Asia since pandemic start
   europe_1m:
@@ -277,6 +277,205 @@ subsampling:
     context:
       group_by: "country year month"
       max_sequences: 800
+      exclude: "--exclude-where 'region={region}'"
+
+  # Custom subsampling logic for region Asia over 1m
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_1m:
+    # Early focal samples for Asia
+    asia_early:
+      group_by: "division year month"
+      max_sequences: 300
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Early focal samples for China
+    china_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=China'"
+    # Early focal samples for India
+    india_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 175
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'region=Asia'"
+    # Recent focal samples for Asia
+    asia_recent:
+      group_by: "division year month"
+      max_sequences: 1200
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Recent focal samples for China
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=China'"
+    # Recent focal samples for India
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 700
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'region=Asia'"
+
+  # Custom subsampling logic for region Asia over 2m
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_2m:
+    # Early focal samples for Asia
+    asia_early:
+      group_by: "division year month"
+      max_sequences: 300
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Early focal samples for China
+    china_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=China'"
+    # Early focal samples for India
+    india_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 175
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'region=Asia'"
+    # Recent focal samples for Asia
+    asia_recent:
+      group_by: "division year month"
+      max_sequences: 1200
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Recent focal samples for China
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=China'"
+    # Recent focal samples for India
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 700
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'region=Asia'"
+
+  # Custom subsampling logic for region Asia over 6m
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_6m:
+    # Early focal samples for Asia
+    asia_early:
+      group_by: "division year month"
+      max_sequences: 300
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Early focal samples for China
+    china_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=China'"
+    # Early focal samples for India
+    india_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 175
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'region=Asia'"
+    # Recent focal samples for Asia
+    asia_recent:
+      group_by: "division year month"
+      max_sequences: 1200
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Recent focal samples for China
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=China'"
+    # Recent focal samples for India
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 700
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'region=Asia'"
+
+  # Custom subsampling logic for region Asia over all-time
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_all_time:
+    # Focal samples for Asia
+    asia:
+      group_by: "division year month"
+      max_sequences: 1500
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Focal samples for China
+    china:
+      group_by: "division year month"
+      max_sequences: 1000
+      exclude: "--exclude-where 'country!=China'"
+    # Focal samples for India
+    india:
+      group_by: "division year month"
+      max_sequences: 1000
+      exclude: "--exclude-where 'country!=India'"
+    # Contextual samples from the rest of the world
+    context:
+      group_by: "country year month"
+      max_sequences: 875
       exclude: "--exclude-where 'region={region}'"
 
   # Custom subsampling logic for regions over 1m

--- a/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
@@ -389,33 +389,43 @@ subsampling:
       exclude: "--exclude-where 'region={region}'"
 
   # Custom subsampling logic for global region over 1m
-  # 4000 total
-  # 4:1 ratio of focal to context
-  # all regions equal except Oceania at 33%
+  # 5125 total (expect ~3400)
+  # 4:1 ratio of recent to early
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_1m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
@@ -432,12 +442,22 @@ subsampling:
       group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 1M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
       max_sequences: 600
@@ -455,33 +475,43 @@ subsampling:
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over 2m
-  # 4000 total
-  # 4:1 ratio of focal to context
-  # all regions equal except Oceania at 33%
+  # 5125 total (expect ~3400)
+  # 4:1 ratio of recent to early
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_2m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
@@ -491,128 +521,166 @@ subsampling:
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division week"
-      max_sequences: 200
+      max_sequences: 100
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over 6m
-  # 4000 total
-  # 4:1 ratio of focal to context
-  # all regions equal except Oceania at 33%
+  # 5125 total (expect ~3400)
+  # 4:1 ratio of recent to early
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_6m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 50
+      max_sequences: 25
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 500
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 500
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division year month"
-      max_sequences: 200
+      max_sequences: 100
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over all-time
-  # 4000 total
-  # all regions equal except Oceania at 33%
+  # 4320 total (expect ~3200)
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_all_time:
     africa:
       group_by: "country year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=Africa'"
     asia:
       group_by: "country year month"
-      max_sequences: 750
-      exclude: "--exclude-where 'region!=Asia'"
+      max_sequences: 600
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china:
+      group_by: "division year month"
+      max_sequences: 600
+      exclude: "--exclude-where 'country!=China'"
     europe:
       group_by: "country year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=Europe'"
+    india:
+      group_by: "division year month"
+      max_sequences: 600
+      exclude: "--exclude-where 'country!=India'"
     north_america:
       group_by: "division year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=North America'"
     south_america:
       group_by: "country year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=South America'"
     oceania:
       group_by: "division year month"
-      max_sequences: 250
+      max_sequences: 120
       exclude: "--exclude-where 'region!=Oceania'"
 
 # Root to clade 21L

--- a/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
@@ -594,17 +594,17 @@ subsampling:
   nextstrain_global_1m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 150
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 200
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
@@ -614,22 +614,22 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 100
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 90
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 50
+      max_sequences: 15
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
@@ -639,37 +639,37 @@ subsampling:
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 800
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
     india_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
-      max_sequences: 600
+      max_sequences: 400
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 360
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division week"
-      max_sequences: 200
+      max_sequences: 60
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Oceania'"
 
@@ -680,17 +680,17 @@ subsampling:
   nextstrain_global_2m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 150
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 200
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
@@ -700,37 +700,37 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 100
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 90
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 50
+      max_sequences: 15
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country week"
-      max_sequences: 500
+      max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country week"
-      max_sequences: 500
+      max_sequences: 800
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'country!=China'"
     europe_recent:
@@ -740,22 +740,22 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 400
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country week"
-      max_sequences: 500
+      max_sequences: 360
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division week"
-      max_sequences: 100
+      max_sequences: 60
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
 
@@ -766,17 +766,17 @@ subsampling:
   nextstrain_global_6m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 150
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 200
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
@@ -786,37 +786,37 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 100
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 90
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 25
+      max_sequences: 15
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country year month"
-      max_sequences: 500
+      max_sequences: 600
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country year month"
-      max_sequences: 500
+      max_sequences: 800
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_recent:
       group_by: "division year month"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'country!=China'"
     europe_recent:
@@ -826,22 +826,22 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_recent:
       group_by: "division year month"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division year month"
-      max_sequences: 500
+      max_sequences: 400
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country year month"
-      max_sequences: 500
+      max_sequences: 360
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division year month"
-      max_sequences: 100
+      max_sequences: 60
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
 
@@ -851,35 +851,35 @@ subsampling:
   nextstrain_global_all_time:
     africa:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 750
       exclude: "--exclude-where 'region!=Africa'"
     asia:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 1000
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 875
       exclude: "--exclude-where 'country!=China'"
     europe:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 625
       exclude: "--exclude-where 'region!=Europe'"
     india:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 875
       exclude: "--exclude-where 'country!=India'"
     north_america:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 500
       exclude: "--exclude-where 'region!=North America'"
     south_america:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 450
       exclude: "--exclude-where 'region!=South America'"
     oceania:
       group_by: "division year month"
-      max_sequences: 120
+      max_sequences: 75
       exclude: "--exclude-where 'region!=Oceania'"
 
 # Root to clade 21L

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -586,17 +586,17 @@ subsampling:
   nextstrain_global_1m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 150
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 200
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
@@ -606,22 +606,22 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 100
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 90
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 50
+      max_sequences: 15
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
@@ -631,37 +631,37 @@ subsampling:
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 800
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
     india_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
-      max_sequences: 600
+      max_sequences: 400
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 360
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division week"
-      max_sequences: 200
+      max_sequences: 60
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Oceania'"
 
@@ -672,17 +672,17 @@ subsampling:
   nextstrain_global_2m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 150
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 200
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
@@ -692,37 +692,37 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 100
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 90
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 50
+      max_sequences: 15
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country week"
-      max_sequences: 500
+      max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country week"
-      max_sequences: 500
+      max_sequences: 800
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'country!=China'"
     europe_recent:
@@ -732,22 +732,22 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 400
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country week"
-      max_sequences: 500
+      max_sequences: 360
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division week"
-      max_sequences: 100
+      max_sequences: 60
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
 
@@ -758,17 +758,17 @@ subsampling:
   nextstrain_global_6m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 150
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 200
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
@@ -778,37 +778,37 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 100
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 90
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 25
+      max_sequences: 15
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country year month"
-      max_sequences: 500
+      max_sequences: 600
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country year month"
-      max_sequences: 500
+      max_sequences: 800
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_recent:
       group_by: "division year month"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'country!=China'"
     europe_recent:
@@ -818,22 +818,22 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_recent:
       group_by: "division year month"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division year month"
-      max_sequences: 500
+      max_sequences: 400
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country year month"
-      max_sequences: 500
+      max_sequences: 360
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division year month"
-      max_sequences: 100
+      max_sequences: 60
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
 
@@ -843,35 +843,35 @@ subsampling:
   nextstrain_global_all_time:
     africa:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 750
       exclude: "--exclude-where 'region!=Africa'"
     asia:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 1000
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 875
       exclude: "--exclude-where 'country!=China'"
     europe:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 625
       exclude: "--exclude-where 'region!=Europe'"
     india:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 875
       exclude: "--exclude-where 'country!=India'"
     north_america:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 500
       exclude: "--exclude-where 'region!=North America'"
     south_america:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 450
       exclude: "--exclude-where 'region!=South America'"
     oceania:
       group_by: "division year month"
-      max_sequences: 120
+      max_sequences: 75
       exclude: "--exclude-where 'region!=Oceania'"
 
 # if different traits should be reconstructed for some builds, specify here

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -381,33 +381,43 @@ subsampling:
       exclude: "--exclude-where 'region={region}'"
 
   # Custom subsampling logic for global region over 1m
-  # 4000 total
-  # 4:1 ratio of focal to context
-  # all regions equal except Oceania at 33%
+  # 5125 total (expect ~3400)
+  # 4:1 ratio of recent to early
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_1m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
@@ -424,12 +434,22 @@ subsampling:
       group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 1M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
       max_sequences: 600
@@ -447,33 +467,43 @@ subsampling:
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over 2m
-  # 4000 total
-  # 4:1 ratio of focal to context
-  # all regions equal except Oceania at 33%
+  # 5125 total (expect ~3400)
+  # 4:1 ratio of recent to early
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_2m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
@@ -483,128 +513,166 @@ subsampling:
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division week"
-      max_sequences: 200
+      max_sequences: 100
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over 6m
-  # 4000 total
-  # 4:1 ratio of focal to context
-  # all regions equal except Oceania at 33%
+  # 5125 total (expect ~3400)
+  # 4:1 ratio of recent to early
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_6m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 50
+      max_sequences: 25
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 500
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 500
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division year month"
-      max_sequences: 200
+      max_sequences: 100
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over all-time
-  # 4000 total
-  # all regions equal except Oceania at 33%
+  # 4320 total (expect ~3200)
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_all_time:
     africa:
       group_by: "country year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=Africa'"
     asia:
       group_by: "country year month"
-      max_sequences: 750
-      exclude: "--exclude-where 'region!=Asia'"
+      max_sequences: 600
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china:
+      group_by: "division year month"
+      max_sequences: 600
+      exclude: "--exclude-where 'country!=China'"
     europe:
       group_by: "country year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=Europe'"
+    india:
+      group_by: "division year month"
+      max_sequences: 600
+      exclude: "--exclude-where 'country!=India'"
     north_america:
       group_by: "division year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=North America'"
     south_america:
       group_by: "country year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=South America'"
     oceania:
       group_by: "division year month"
-      max_sequences: 250
+      max_sequences: 120
       exclude: "--exclude-where 'region!=Oceania'"
 
 # if different traits should be reconstructed for some builds, specify here

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -70,19 +70,19 @@ builds:
     region: Africa
     title: Genomic epidemiology of SARS-CoV-2 with subsampling focused on Africa since pandemic start
   asia_1m:
-    subsampling_scheme: nextstrain_region_grouped_by_country_1m
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_1m
     region: Asia
     title: Genomic epidemiology of SARS-CoV-2 with subsampling focused on Asia over the past month
   asia_2m:
-    subsampling_scheme: nextstrain_region_grouped_by_country_2m
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_2m
     region: Asia
     title: Genomic epidemiology of SARS-CoV-2 with subsampling focused on Asia over the past 2 months
   asia_6m:
-    subsampling_scheme: nextstrain_region_grouped_by_country_6m
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_6m
     region: Asia
     title: Genomic epidemiology of SARS-CoV-2 with subsampling focused on Asia over the past 6 months
   asia_all-time:
-    subsampling_scheme: nextstrain_region_grouped_by_country_all_time
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_all_time
     region: Asia
     title: Genomic epidemiology of SARS-CoV-2 with subsampling focused on Asia since pandemic start
   europe_1m:
@@ -269,6 +269,205 @@ subsampling:
     context:
       group_by: "country year month"
       max_sequences: 800
+      exclude: "--exclude-where 'region={region}'"
+
+  # Custom subsampling logic for region Asia over 1m
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_1m:
+    # Early focal samples for Asia
+    asia_early:
+      group_by: "division year month"
+      max_sequences: 300
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Early focal samples for China
+    china_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=China'"
+    # Early focal samples for India
+    india_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 175
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'region=Asia'"
+    # Recent focal samples for Asia
+    asia_recent:
+      group_by: "division year month"
+      max_sequences: 1200
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Recent focal samples for China
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=China'"
+    # Recent focal samples for India
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 700
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'region=Asia'"
+
+  # Custom subsampling logic for region Asia over 2m
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_2m:
+    # Early focal samples for Asia
+    asia_early:
+      group_by: "division year month"
+      max_sequences: 300
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Early focal samples for China
+    china_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=China'"
+    # Early focal samples for India
+    india_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 175
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'region=Asia'"
+    # Recent focal samples for Asia
+    asia_recent:
+      group_by: "division year month"
+      max_sequences: 1200
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Recent focal samples for China
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=China'"
+    # Recent focal samples for India
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 700
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'region=Asia'"
+
+  # Custom subsampling logic for region Asia over 6m
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_6m:
+    # Early focal samples for Asia
+    asia_early:
+      group_by: "division year month"
+      max_sequences: 300
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Early focal samples for China
+    china_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=China'"
+    # Early focal samples for India
+    india_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 175
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'region=Asia'"
+    # Recent focal samples for Asia
+    asia_recent:
+      group_by: "division year month"
+      max_sequences: 1200
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Recent focal samples for China
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=China'"
+    # Recent focal samples for India
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 700
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'region=Asia'"
+
+  # Custom subsampling logic for region Asia over all-time
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_all_time:
+    # Focal samples for Asia
+    asia:
+      group_by: "division year month"
+      max_sequences: 1500
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Focal samples for China
+    china:
+      group_by: "division year month"
+      max_sequences: 1000
+      exclude: "--exclude-where 'country!=China'"
+    # Focal samples for India
+    india:
+      group_by: "division year month"
+      max_sequences: 1000
+      exclude: "--exclude-where 'country!=India'"
+    # Contextual samples from the rest of the world
+    context:
+      group_by: "country year month"
+      max_sequences: 875
       exclude: "--exclude-where 'region={region}'"
 
   # Custom subsampling logic for regions over 1m

--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -381,33 +381,43 @@ subsampling:
       exclude: "--exclude-where 'region={region}'"
 
   # Custom subsampling logic for global region over 1m
-  # 4000 total
-  # 4:1 ratio of focal to context
-  # all regions equal except Oceania at 33%
+  # 5125 total (expect ~3400)
+  # 4:1 ratio of recent to early
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_1m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
@@ -424,15 +434,25 @@ subsampling:
       group_by: "country week"
       max_sequences: 600
       min_date: "--min-date 1M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country week"
-      max_sequences: 1500
+      max_sequences: 600
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
-      max_sequences: 1500
+      max_sequences: 600
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
@@ -447,33 +467,43 @@ subsampling:
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over 2m
-  # 4000 total
-  # 4:1 ratio of focal to context
-  # all regions equal except Oceania at 33%
+  # 5125 total (expect ~3400)
+  # 4:1 ratio of recent to early
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_2m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
@@ -483,128 +513,166 @@ subsampling:
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_recent:
+      group_by: "division week"
+      max_sequences: 500
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division week"
-      max_sequences: 200
+      max_sequences: 100
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over 6m
-  # 4000 total
-  # 4:1 ratio of focal to context
-  # all regions equal except Oceania at 33%
+  # 5125 total (expect ~3400)
+  # 4:1 ratio of recent to early
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_6m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_early:
+      group_by: "division year month"
+      max_sequences: 125
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 125
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 50
+      max_sequences: 25
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
-      exclude: "--exclude-where 'region!=Asia'"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 500
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Europe'"
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 500
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division year month"
-      max_sequences: 200
+      max_sequences: 100
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over all-time
-  # 4000 total
-  # all regions equal except Oceania at 33%
+  # 4320 total (expect ~3200)
+  # all eight regions equal except Oceania at 20%
   nextstrain_global_all_time:
     africa:
       group_by: "country year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=Africa'"
     asia:
       group_by: "country year month"
-      max_sequences: 750
-      exclude: "--exclude-where 'region!=Asia'"
+      max_sequences: 600
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    china:
+      group_by: "division year month"
+      max_sequences: 600
+      exclude: "--exclude-where 'country!=China'"
     europe:
       group_by: "country year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=Europe'"
+    india:
+      group_by: "division year month"
+      max_sequences: 600
+      exclude: "--exclude-where 'country!=India'"
     north_america:
       group_by: "division year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=North America'"
     south_america:
       group_by: "country year month"
-      max_sequences: 750
+      max_sequences: 600
       exclude: "--exclude-where 'region!=South America'"
     oceania:
       group_by: "division year month"
-      max_sequences: 250
+      max_sequences: 120
       exclude: "--exclude-where 'region!=Oceania'"
 
 # GenBank data includes "Wuhan-Hu-1/2019" which we use as the root for this build

--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -70,19 +70,19 @@ builds:
     region: Africa
     title: Genomic epidemiology of SARS-CoV-2 with subsampling focused on Africa since pandemic start
   asia_1m:
-    subsampling_scheme: nextstrain_region_grouped_by_country_1m
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_1m
     region: Asia
     title: Genomic epidemiology of SARS-CoV-2 with subsampling focused on Asia over the past month
   asia_2m:
-    subsampling_scheme: nextstrain_region_grouped_by_country_2m
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_2m
     region: Asia
     title: Genomic epidemiology of SARS-CoV-2 with subsampling focused on Asia over the past 2 months
   asia_6m:
-    subsampling_scheme: nextstrain_region_grouped_by_country_6m
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_6m
     region: Asia
     title: Genomic epidemiology of SARS-CoV-2 with subsampling focused on Asia over the past 6 months
   asia_all-time:
-    subsampling_scheme: nextstrain_region_grouped_by_country_all_time
+    subsampling_scheme: nextstrain_region_asia_grouped_by_division_all_time
     region: Asia
     title: Genomic epidemiology of SARS-CoV-2 with subsampling focused on Asia since pandemic start
   europe_1m:
@@ -269,6 +269,205 @@ subsampling:
     context:
       group_by: "country year month"
       max_sequences: 800
+      exclude: "--exclude-where 'region={region}'"
+
+  # Custom subsampling logic for region Asia over 1m
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_1m:
+    # Early focal samples for Asia
+    asia_early:
+      group_by: "division year month"
+      max_sequences: 300
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Early focal samples for China
+    china_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=China'"
+    # Early focal samples for India
+    india_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 175
+      max_date: "--max-date 1M"
+      exclude: "--exclude-where 'region=Asia'"
+    # Recent focal samples for Asia
+    asia_recent:
+      group_by: "division year month"
+      max_sequences: 1200
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Recent focal samples for China
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=China'"
+    # Recent focal samples for India
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 1M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 700
+      min_date: "--min-date 1M"
+      exclude: "--exclude-where 'region=Asia'"
+
+  # Custom subsampling logic for region Asia over 2m
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_2m:
+    # Early focal samples for Asia
+    asia_early:
+      group_by: "division year month"
+      max_sequences: 300
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Early focal samples for China
+    china_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=China'"
+    # Early focal samples for India
+    india_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 175
+      max_date: "--max-date 2M"
+      exclude: "--exclude-where 'region=Asia'"
+    # Recent focal samples for Asia
+    asia_recent:
+      group_by: "division year month"
+      max_sequences: 1200
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Recent focal samples for China
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=China'"
+    # Recent focal samples for India
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 2M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 700
+      min_date: "--min-date 2M"
+      exclude: "--exclude-where 'region=Asia'"
+
+  # Custom subsampling logic for region Asia over 6m
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of recent to early
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_6m:
+    # Early focal samples for Asia
+    asia_early:
+      group_by: "division year month"
+      max_sequences: 300
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Early focal samples for China
+    china_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=China'"
+    # Early focal samples for India
+    india_early:
+      group_by: "division year month"
+      max_sequences: 200
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_early:
+      group_by: "country year month"
+      max_sequences: 175
+      max_date: "--max-date 6M"
+      exclude: "--exclude-where 'region=Asia'"
+    # Recent focal samples for Asia
+    asia_recent:
+      group_by: "division year month"
+      max_sequences: 1200
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Recent focal samples for China
+    china_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=China'"
+    # Recent focal samples for India
+    india_recent:
+      group_by: "division year month"
+      max_sequences: 800
+      max_date: "--min-date 6M"
+      exclude: "--exclude-where 'country!=India'"
+    # Early contextual samples from the rest of the world
+    context_recent:
+      group_by: "country year month"
+      max_sequences: 700
+      min_date: "--min-date 6M"
+      exclude: "--exclude-where 'region=Asia'"
+
+  # Custom subsampling logic for region Asia over all-time
+  # Grouping by division
+  # Separating three buckets for China, India and elsewhere
+  # 4375 total
+  # 4:1 ratio of focal to context
+  # 3:2:2 proportions of Asia, China, India
+  nextstrain_region_asia_grouped_by_division_all_time:
+    # Focal samples for Asia
+    asia:
+      group_by: "division year month"
+      max_sequences: 1500
+      exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
+    # Focal samples for China
+    china:
+      group_by: "division year month"
+      max_sequences: 1000
+      exclude: "--exclude-where 'country!=China'"
+    # Focal samples for India
+    india:
+      group_by: "division year month"
+      max_sequences: 1000
+      exclude: "--exclude-where 'country!=India'"
+    # Contextual samples from the rest of the world
+    context:
+      group_by: "country year month"
+      max_sequences: 875
       exclude: "--exclude-where 'region={region}'"
 
   # Custom subsampling logic for regions over 1m

--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -586,17 +586,17 @@ subsampling:
   nextstrain_global_1m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 150
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 200
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
@@ -606,22 +606,22 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 100
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 90
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 50
+      max_sequences: 15
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
@@ -631,37 +631,37 @@ subsampling:
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 800
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'country!=China'"
     europe_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 500
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
     india_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
-      max_sequences: 600
+      max_sequences: 400
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country week"
-      max_sequences: 600
+      max_sequences: 360
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division week"
-      max_sequences: 200
+      max_sequences: 60
       min_date: "--min-date 1M"
       exclude: "--exclude-where 'region!=Oceania'"
 
@@ -672,17 +672,17 @@ subsampling:
   nextstrain_global_2m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 150
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 200
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
@@ -692,37 +692,37 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 100
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 90
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 50
+      max_sequences: 15
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country week"
-      max_sequences: 500
+      max_sequences: 600
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country week"
-      max_sequences: 500
+      max_sequences: 800
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'country!=China'"
     europe_recent:
@@ -732,22 +732,22 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division week"
-      max_sequences: 500
+      max_sequences: 400
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country week"
-      max_sequences: 500
+      max_sequences: 360
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division week"
-      max_sequences: 100
+      max_sequences: 60
       min_date: "--min-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
 
@@ -758,17 +758,17 @@ subsampling:
   nextstrain_global_6m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 150
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 200
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
@@ -778,37 +778,37 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 175
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 125
+      max_sequences: 100
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 90
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 25
+      max_sequences: 15
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
       group_by: "country year month"
-      max_sequences: 500
+      max_sequences: 600
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_recent:
       group_by: "country year month"
-      max_sequences: 500
+      max_sequences: 800
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_recent:
       group_by: "division year month"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'country!=China'"
     europe_recent:
@@ -818,22 +818,22 @@ subsampling:
       exclude: "--exclude-where 'region!=Europe'"
     india_recent:
       group_by: "division year month"
-      max_sequences: 500
+      max_sequences: 700
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'country!=India'"
     north_america_recent:
       group_by: "division year month"
-      max_sequences: 500
+      max_sequences: 400
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_recent:
       group_by: "country year month"
-      max_sequences: 500
+      max_sequences: 360
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_recent:
       group_by: "division year month"
-      max_sequences: 100
+      max_sequences: 60
       min_date: "--min-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
 
@@ -843,35 +843,35 @@ subsampling:
   nextstrain_global_all_time:
     africa:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 750
       exclude: "--exclude-where 'region!=Africa'"
     asia:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 1000
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 875
       exclude: "--exclude-where 'country!=China'"
     europe:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 625
       exclude: "--exclude-where 'region!=Europe'"
     india:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 875
       exclude: "--exclude-where 'country!=India'"
     north_america:
       group_by: "division year month"
-      max_sequences: 600
+      max_sequences: 500
       exclude: "--exclude-where 'region!=North America'"
     south_america:
       group_by: "country year month"
-      max_sequences: 600
+      max_sequences: 450
       exclude: "--exclude-where 'region!=South America'"
     oceania:
       group_by: "division year month"
-      max_sequences: 120
+      max_sequences: 75
       exclude: "--exclude-where 'region!=Oceania'"
 
 # GenBank data includes "Wuhan-Hu-1/2019" which we use as the root for this build


### PR DESCRIPTION
## Description of proposed changes

In the current "global" analyses, treating China and India each as just another country in Asia was resulting in much smaller per-capita sampling rates relative to most other countries. For example, in the current gisaid/global/6m tree we have 66 viruses from Guatemala (population 17M), 62 viruses from Costa Rica (population 5M), 18 viruses from India (population 1400M) and 21 viruses from China (population 1400M). This is a ~1000-fold difference in per-capita sampling intensity.

This PR partially addresses this issue by splitting out China and India into their own buckets when subsampling in the `global` build targets. This results in buckets of North America (580M), South America (420M), Europe (750M), Africa (1.2B), Oceania (44M), India (1.4B), China (1.4B) and Asia minus India and China (1.8B). Additionally, this commit makes a small correction to reduce Oceania to 20% region count relative to other regions from previous 33%.

Within the builds that focus on `region=Asia` there is currently less intensive per-capita sampling in China and India relative to other countries in Asia. For example, the current gisaid/asia/6m tree has 144 viruses from China (population 1.4B), 96 viruses from India (population 1.4B), 118 viruses from Thailand (population 70M) and 53 viruses from Laos (population 7M). This a 100-fold difference in sampling intensity between Laos and India. 

This PR splits Asia-focused builds to have 4 geographic buckets rather than the previous 2, arriving at China, India, Asia (minus China and India) and global context. This won't fully address differential per-capita sampling intensity in Asia, but is a simple addition that should go a long way.

## Testing

Trial runs for this PR exist at:
- https://nextstrain.org/staging/ncov/gisaid/trial/update-subsampling/global/6m
- https://nextstrain.org/staging/ncov/gisaid/trial/update-subsampling/asia/6m

You can see that the global map looks improved:

![Screen Shot 2023-06-14 at 5 19 00 PM](https://github.com/nextstrain/ncov/assets/1176109/115554ff-7322-4540-a874-5b2823b180d5)

where the 6m build has 412 viruses from China and 417 viruses from India out of a total of 3197.

If we compare regions here, we have:

- North America: 516 in 580M = 0.9 per million
- South America: 534 in 420M = 1.3 per million
- Europe: 499 in 750M = 0.7 per million
- Africa: 377 in 1.2B = 0.3 per million
- Oceania: 116 in 44M = 2.6 per million
- Asia minus China and India: 326 in 1.8B = 0.2 per million
- China: 412 in 1.4B = 0.3 per million
- India: 417 in 1.4B = 0.3 per million

The `builds.yaml` is asking for more viruses from Asia than China or India and so lower counts here should be reflective of lack of available sequences.

The map from the `asia` build also looks improved:

![Screen Shot 2023-06-14 at 5 30 40 PM](https://github.com/nextstrain/ncov/assets/1176109/7245cd70-f0af-4654-9b32-a9016e330c68)

with 897 viruses from China, 688 viruses from India and 1076 viruses from else in Asia.

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.