### PR TITLE
Add new lineages to emerging_lineages.tsv and color_ordering.tsv

### DIFF
--- a/defaults/color_ordering.tsv
+++ b/defaults/color_ordering.tsv
@@ -34040,8 +34040,15 @@ emerging_lineage	BN.1
 emerging_lineage	CH.1.1
 emerging_lineage	XAY
 emerging_lineage	XBC
-emerging_lineage	FE.1
 emerging_lineage	XBB.1.9
+emerging_lineage	XBB.1.9.1
+emerging_lineage	XBB.1.9.2
+emerging_lineage	EG.5
+emerging_lineage	XBB.1.42
+emerging_lineage	XBB.1.22.1
+emerging_lineage	XBB.1.19
+emerging_lineage	XBB.1.17.1
+emerging_lineage	FE.1
 emerging_lineage	XBB.2.3
 
 ################

--- a/defaults/emerging_lineages.tsv
+++ b/defaults/emerging_lineages.tsv
@@ -24,10 +24,10 @@ clade	gene	site	alt
 20D	nuc	13536	T
 20D	nuc	23731	T
 
-20E (EU1)	clade	20A
-20E (EU1)	nuc	22227	T
-20E (EU1)	nuc	28932	T
-20E (EU1)	nuc	29645	T
+20E	clade	20A
+20E	nuc	22227	T
+20E	nuc	28932	T
+20E	nuc	29645	T
 
 20F	clade	20B
 20F	nuc	1163	T
@@ -45,143 +45,149 @@ clade	gene	site	alt
 20G	nuc	28472	T
 20G	nuc	28869	T
 
-20H (Beta, V2)	clade	20C
-20H (Beta, V2)	nuc	23012	A
-20H (Beta, V2)	nuc	23063	T
-20H (Beta, V2)	nuc	23403	G
-20H (Beta, V2)	nuc	26456	T
+20H	clade	20C
+20H	nuc	23012	A
+20H	nuc	23063	T
+20H	nuc	23403	G
+20H	nuc	26456	T
 
-20I (Alpha, V1)	clade	20B
-20I (Alpha, V1)	nuc	14676	T
-20I (Alpha, V1)	nuc	15279	T
-20I (Alpha, V1)	nuc	23063	T
+20I	clade	20B
+20I	nuc	14676	T
+20I	nuc	15279	T
+20I	nuc	23063	T
 
-20J (Gamma, V3)	clade	20B
-20J (Gamma, V3)	nuc	733	C
-20J (Gamma, V3)	nuc	2749	T
-20J (Gamma, V3)	nuc	3828	T
-20J (Gamma, V3)	nuc	5648	C
-20J (Gamma, V3)	nuc	12778	T
-20J (Gamma, V3)	nuc	13860	T
+20J	clade	20B
+20J	nuc	733	C
+20J	nuc	2749	T
+20J	nuc	3828	T
+20J	nuc	5648	C
+20J	nuc	12778	T
+20J	nuc	13860	T
 
-21A (Delta)	clade	20A
-21A (Delta)	nuc	21618	G
-21A (Delta)	nuc	26767	C
-21A (Delta)	nuc	28461	G
+21A	clade	20A
+21A	nuc	21618	G
+21A	nuc	26767	C
+21A	nuc	28461	G
 
-21B (Kappa)	clade	20A
-21B (Kappa)	nuc	17523	T
-21B (Kappa)	nuc	22917	G
-21B (Kappa)	nuc	23012	C
-21B (Kappa)	nuc	27638	C
-21B (Kappa)	nuc	28881	T
-21B (Kappa)	nuc	29402	T
+21B	clade	20A
+21B	nuc	17523	T
+21B	nuc	22917	G
+21B	nuc	23012	C
+21B	nuc	27638	C
+21B	nuc	28881	T
+21B	nuc	29402	T
 
-21C (Epsilon)	clade	20C
-21C (Epsilon)	nuc	17014	T
-21C (Epsilon)	nuc	21600	T
-21C (Epsilon)	nuc	22018	T
-21C (Epsilon)	nuc	22917	G
+21C	clade	20C
+21C	nuc	17014	T
+21C	nuc	21600	T
+21C	nuc	22018	T
+21C	nuc	22917	G
 
-21D (Eta)	clade	20A
-21D (Eta)	nuc	14407	T
-21D (Eta)	nuc	20724	G
-21D (Eta)	nuc	23593	C
-21D (Eta)	nuc	24224	C
-21D (Eta)	nuc	24748	T
+21D	clade	20A
+21D	nuc	14407	T
+21D	nuc	20724	G
+21D	nuc	23593	C
+21D	nuc	24224	C
+21D	nuc	24748	T
 
-21E (Theta)	clade	20B
-21E (Theta)	nuc	12049	T
-21E (Theta)	nuc	23341	C
-21E (Theta)	nuc	23604	A
-21E (Theta)	nuc	24187	A
-21E (Theta)	nuc	24836	A
+21E	clade	20B
+21E	nuc	12049	T
+21E	nuc	23341	C
+21E	nuc	23604	A
+21E	nuc	24187	A
+21E	nuc	24836	A
 
-21F (Iota)	clade	20C
-21F (Iota)	nuc	16500	C
-21F (Iota)	nuc	20262	G
-21F (Iota)	nuc	21575	T
-21F (Iota)	nuc	22320	G
+21F	clade	20C
+21F	nuc	16500	C
+21F	nuc	20262	G
+21F	nuc	21575	T
+21F	nuc	22320	G
 
-21G (Lambda)	clade	20D
-21G (Lambda)	nuc	21786	T
-21G (Lambda)	nuc	21789	T
-21G (Lambda)	nuc	22917	A
-21G (Lambda)	nuc	23031	C
+21G	clade	20D
+21G	nuc	21786	T
+21G	nuc	21789	T
+21G	nuc	22917	A
+21G	nuc	23031	C
 
-21H (Mu)	clade	20A
-21H (Mu)	nuc	3428	G
-21H (Mu)	nuc	4878	T
-21H (Mu)	nuc	11451	G
-21H (Mu)	nuc	13057	T
-21H (Mu)	nuc	17491	T
-21H (Mu)	nuc	27925	A
+21H	clade	20A
+21H	nuc	3428	G
+21H	nuc	4878	T
+21H	nuc	11451	G
+21H	nuc	13057	T
+21H	nuc	17491	T
+21H	nuc	27925	A
 
-21I (Delta)	clade	21A (Delta)
-21I (Delta)	nuc	5184	T
-21I (Delta)	nuc	9891	T
-21I (Delta)	nuc	22227	T
+21I	clade	21A
+21I	nuc	5184	T
+21I	nuc	9891	T
+21I	nuc	22227	T
 
-21J (Delta)	clade	21A (Delta)
-21J (Delta)	nuc	11332	G
-21J (Delta)	nuc	19220	T
+21J	clade	21A
+21J	nuc	11332	G
+21J	nuc	19220	T
 
-21K (Omicron)	clade	21M (Omicron)
-21K (Omicron)	nuc	15240	T
-21K (Omicron)	nuc	23202	A
-21K (Omicron)	nuc	23525	T
-21K (Omicron)	nuc	27259	C
+21K	clade	21M
+21K	nuc	15240	T
+21K	nuc	23202	A
+21K	nuc	23525	T
+21K	nuc	27259	C
 
-21L (Omicron)	clade	21M (Omicron)
-21L (Omicron)	nuc	21618	T
-21L (Omicron)	nuc	22775	A
+21L	clade	21M
+21L	nuc	21618	T
+21L	nuc	22775	A
 
-21M (Omicron)	clade	20B
-21M (Omicron)	nuc	18163	G
-21M (Omicron)	nuc	23599	G
+21M	clade	20B
+21M	nuc	18163	G
+21M	nuc	23599	G
 
-22A (Omicron)	clade	21L (Omicron)
-22A (Omicron)	nuc	12160	A
-22A (Omicron)	nuc	9866	C
-22A (Omicron)	nuc	28724	T
+22A	clade	21L
+22A	nuc	12160	A
+22A	nuc	9866	C
+22A	nuc	28724	T
 
-22B (Omicron)	clade	21L (Omicron)
-22B (Omicron)	nuc	12160	A
-22B (Omicron)	nuc	9866	C
-22B (Omicron)	nuc	27259	A
+22B	clade	21L
+22B	nuc	12160	A
+22B	nuc	9866	C
+22B	nuc	27259	A
 
-22C (Omicron)	clade	21L (Omicron)
-22C (Omicron)	nuc	22917	A
-22C (Omicron)	nuc	23673	T
+22C	clade	21L
+22C	nuc	22917	A
+22C	nuc	23673	T
 
-22D (Omicron)	clade	21L (Omicron)
-22D (Omicron)	nuc	3796	T
-22D (Omicron)	nuc	26275	G
+22D	clade	21L
+22D	nuc	3796	T
+22D	nuc	26275	G
 
-22E (Omicron)	clade	22B (Omicron)
-22E (Omicron)	nuc	14257	C
-22E (Omicron)	nuc	16935	A
-22E (Omicron)	nuc	28312	T
-22E (Omicron)	nuc	22942	A
+22E	clade	22B
+22E	nuc	14257	C
+22E	nuc	16935	A
+22E	nuc	28312	T
+22E	nuc	22942	A
 
-22F (Omicron)	clade	21L (Omicron)
-22F (Omicron)	nuc	15461	A
-22F (Omicron)	nuc	17859	C
-22F (Omicron)	nuc	23019	C
-22F (Omicron)	nuc	26275	G
+22F	clade	21L
+22F	nuc	15461	A
+22F	nuc	17859	C
+22F	nuc	23019	C
+22F	nuc	26275	G
 
-23A (Omicron)	clade	22F (Omicron)
-23A (Omicron)	nuc	22317	T
-23A (Omicron)	nuc	23018	C
-23A (Omicron)	nuc	27915	T
+23A	clade	22F
+23A	nuc	22317	T
+23A	nuc	23018	C
+23A	nuc	27915	T
 
-BA.2.3.20	clade	21L (Omicron)
+23B	clade	22F
+23B	nuc	12730	A
+23B	nuc	14856	G
+23B	nuc	18703	T
+23B	nuc	28447	G
+
+BA.2.3.20	clade	21L
 BA.2.3.20	nuc	6770	G
 BA.2.3.20	nuc	22332	A
 BA.2.3.20	nuc	17678	T
 BA.2.3.20	nuc	23013	G
 
-BN.1	clade	22D (Omicron)
+BN.1	clade	22D
 BN.1	nuc	22599	C
 BN.1	nuc	22629	C
 BN.1	nuc	23031	C
@@ -201,7 +207,7 @@ XAY	nuc	22899	A
 XAY	nuc	23679	T
 XAY	nuc	27575	G
 
-CH.1.1	clade	22D (Omicron)
+CH.1.1	clade	22D
 CH.1.1	nuc	3857	A
 CH.1.1	nuc	23019	C
 CH.1.1	nuc	22599	C
@@ -209,17 +215,56 @@ CH.1.1	nuc	20741	G
 CH.1.1	nuc	22893	C
 CH.1.1	nuc	22917	G
 
-FE.1	clade	22F (Omicron)
+FE.1	clade	22F
 FE.1	nuc	3662	G
 FE.1	nuc	8001	G
 FE.1	nuc	26012	G
 
-XBB.1.9	clade	22F (Omicron)
+XBB.1.9	clade	22F
 XBB.1.9	nuc	5720	A
 XBB.1.9	nuc	12789	T
 XBB.1.9	nuc	28297	C
 
-XBB.2.3	clade	22F (Omicron)
+XBB.1.9.1	clade	XBB.1.9
+XBB.1.9.1	nuc	11956	T
+XBB.1.9.1	nuc	23018	C
+
+XBB.1.9.2	clade	XBB.1.9
+XBB.1.9.2	nuc	16878	T
+XBB.1.9.2	nuc	23018	C
+XBB.1.9.2	nuc	27507	C
+
+XBB.2.3	clade	22F
 XBB.2.3	nuc	4234	T
 XBB.2.3	nuc	23123	T
 XBB.2.3	nuc	27431	T
+
+XBB.1.22.1	clade	22F
+XBB.1.22.1	nuc	22161	G
+XBB.1.22.1	nuc	23018	C
+XBB.1.22.1	nuc	28297	C
+
+XBB.1.42	clade	22F
+XBB.1.42	nuc	5720	A
+XBB.1.42	nuc	12789	T
+XBB.1.42	nuc	16878	T
+XBB.1.42	nuc	23401	G
+XBB.1.42	nuc	28297	C
+
+XBB.1.17.1	clade	22F
+XBB.1.17.1	nuc	1670	T
+XBB.1.17.1	nuc	22205	C
+XBB.1.17.1	nuc	23018	C
+XBB.1.17.1	nuc	27995	C
+
+XBB.1.19	clade	22F
+XBB.1.19	nuc	10042	G
+XBB.1.19	nuc	21363	T
+XBB.1.19	nuc	23018	C
+XBB.1.19	nuc	27915	G
+
+EG.5	clade	XBB.1.9.2
+EG.5	nuc	2334	T
+EG.5	nuc	9693	T
+EG.5	nuc	22480	T
+EG.5	nuc	22930	A


### PR DESCRIPTION
## Description of proposed changes

Add new lineages to emerging_lineages.tsv and color_ordering.tsv:
- XBB.1.9.1
- XBB.1.9.2
- EG.5
- XBB.1.42
- XBB.1.22.1
- XBB.1.19
- XBB.1.17.1

See the following report for a discussion of these lineages: https://github.com/neherlab/SARS-CoV-2_variant-reports/blob/main/reports/variant_report_latest_draft.md

## Testing

- [ ] ~Running a local 100k test build~ this didn't actually work, it _recreated_ the 100k dataset rather than build
- [ ] Running gisaid/open test builds, will be at `update-emerging-lineages` on staging

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
