### PR TITLE
Remove AUGUR_RECURSION_LIMIT

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -12,10 +12,6 @@ from collections import OrderedDict
 import textwrap
 import time
 
-# Set the maximum recursion limit globally for all shell commands, to avoid
-# issues with large trees crashing the workflow.  Preserve Snakemake's default
-# use of Bash's "strict mode", as we rely on that behaviour.
-shell.prefix("set -euo pipefail; export AUGUR_RECURSION_LIMIT=10000; ")
 
 # Store the user's configuration prior to loading defaults, so we can check for
 # reused subsampling scheme names in the user's config. We need to make a deep

--- a/nextstrain_profiles/nextstrain-scicore/submit.sh
+++ b/nextstrain_profiles/nextstrain-scicore/submit.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
- 
+
 #SBATCH --output=log/%j.out                 # where to store the output ( %j is the JOBID )
 #SBATCH --error=log/%j.err                  # where to store error messages
 
@@ -7,8 +7,5 @@
 source /scicore/home/neher/neher/miniconda3/etc/profile.d/conda.sh
 conda activate nextstrain
 export AUGUR_MINIFY_JSON=1
-export AUGUR_RECURSION_LIMIT=10000
 
 {exec_job}
-
-


### PR DESCRIPTION
The AUGUR_RECURSION_LIMIT is set to 10,000 by default since Augur 22.0.0 and the workflow's minimum required Augur version is now 22.0.1¹

¹ https://github.com/nextstrain/ncov/blob/d34a0cf67890fc6b33e003247b90e900ac02c80c/workflow/envs/nextstrain.yaml#L7

## Testing

What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
