### PR TITLE
Check for empty user-defined subsampling scheme

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -34,6 +34,10 @@ import time
 # [4] https://github.com/snakemake/snakemake/blob/a7ac40c96d6e2af47102563d0478a2220e2a2ab7/snakemake/workflow.py#L1088-L1094
 # [5] https://github.com/snakemake/snakemake/blob/a7ac40c96d6e2af47102563d0478a2220e2a2ab7/snakemake/utils.py#L455-L476
 user_subsampling = copy.deepcopy(config.get("subsampling", {}))
+if user_subsampling is None:
+    logger.error("ERROR: The configuration file you have provided defines a `subsampling` section that appears to be empty.")
+    logger.error("Check that section of your configuration file to confirm that it isn't empty and that its contents are properly indented below the `subsampling` key.")
+    sys.exit(1)
 
 configfile: "defaults/parameters.yaml"
 


### PR DESCRIPTION
## Description of proposed changes

Adds a check for an empty user-defined subsampling scheme and provides a helpful error message when this happens to replace the unhelpful `AttributeError` message users would get before when the workflow tried to access a nonexistent method of a `NoneType`.

This error can happen when a user defines a custom subsampling scheme where the contents are not properly indented below the `subsampling` key. The resulting config is still a valid YAML file, so the emptiness of the subsampling scheme needs to be checked specifically. We could probably handle this better and more generically with a more stringent YAML schema.

Along the lines of that last point, I tried adding the following lines to the config schema to prevent an empty subsampling scheme:

```yaml
  subsampling:
    type: object
    minProperties: 1
```

This change did not catch the issue with the user-defined configuration, however, because we call the validation function after we load the default config file and it is during this step that Snakemake throws an error (presumably when deep-merging the user-provided and default config files).

Next, I tried validating both before and after the `configfile` declaration in the Snakefile. This change catches the incorrect config file and prints the following error for the user:

```
WorkflowError in file /Users/jhuddlesfredhutch.org/projects/nextstrain/ncov/Snakefile, line 36:
Error validating config file.
ValidationError: None is not of type 'object'

Failed validating 'type' in schema['properties']['subsampling']:
    OrderedDict([('type', 'object'), ('minProperties', 1)])

On instance['subsampling']:
    None
  File "/Users/jhuddlesfredhutch.org/projects/nextstrain/ncov/Snakefile", line 36, in <module>
```

I like that this error gets generated from the schema without additional code added to the workflow itself. I wish the error from this validation step provided more details to the user about what specifically went wrong. The error I provide in the commit of this PR seems more helpful to the user, even though it requires a modification to the workflow

## Testing

 - [x] Tested with a broken builds YAML where the subsampling scheme was not properly indented
 - [x] Tested with CI
