### PR TITLE
Specify Read the Docs build OS

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,4 +1,10 @@
 ---
 version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "mambaforge-22.9"
+
 conda:
   environment: docs/conda.yml


### PR DESCRIPTION
## Description of proposed changes

Read the Docs will soon require the specification of a build OS in our configuration file [1] and have already started temporary enforcement of this requirement as a warning. This commit follows the example in the RTD docs for conda environments [2], adding a `build` block using the latest supported Ubuntu and mambaforge.

[1] https://blog.readthedocs.com/use-build-os-config/
[2] https://docs.readthedocs.io/en/stable/config-file/v2.html#conda

## Related issue(s)

Fixes issue with CI that appeared in #1082

## Testing

 - [x] Test with CI while temporary "brownout" is in place