### PR TITLE
Fix snakemake rule existence checks

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1394,6 +1394,14 @@ rule build_description:
         with open(output.description, "w", encoding = "utf-8") as o:
             o.write(template.safe_substitute(context))
 
+def rule_exists(name):
+    # Some versions of Snakemake throw a WorkflowError even with the
+    # three-arg getattr(), so catch any error and assume non-existence.
+    try:
+        return bool(getattr(rules, name, None))
+    except:
+        return False
+
 def get_auspice_config(w):
     """
     Auspice configs are chosen via this heirarchy:
@@ -1403,7 +1411,7 @@ def get_auspice_config(w):
     """
     if "auspice_config" in config["builds"].get(w.build_name, {}):
         return config["builds"][w.build_name]["auspice_config"]
-    if "auspice_config" in rules.__dict__:
+    if rule_exists("auspice_config"):
         return rules.auspice_config.output
     return config["files"]["auspice_config"]
 


### PR DESCRIPTION
We use the existence of certain rules to control the DAG and the way rules are stored internally changed in snakemake 7.32.1 <https://github.com/snakemake/snakemake/commit/65c79a48f956077839bb5ab1ea8d60a5f0ddecab>

This functionality is (probably?) only used for internal nextstrain builds where we use the `auspice_config` rule to programmatically generate the config.

On 2023-09-14 we [updated snakemake from 7.24.1 to 7.32.3 in our docker image](https://github.com/nextstrain/docker-base/pull/176). This caused our nCoV builds to (incorrectly) use the default auspice-config JSON rather than call the `auspice_config` rule to generate it. This can be seen by comparing the datasets from [Sept 12th](https://next.nextstrain.org/ncov/gisaid/global/6m/2023-09-12) and [Sept 15th](https://next.nextstrain.org/ncov/gisaid/global/6m/2023-09-15)