### PR TITLE
ci: Bump dependency versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - run: pip install cram nextstrain-augur
       - run: cram --shell=/bin/bash tests/sanitize-metadata.t
 

--- a/.github/workflows/rebuild-100k.yml
+++ b/.github/workflows/rebuild-100k.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   gisaid:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:

--- a/.github/workflows/rebuild-country.yml
+++ b/.github/workflows/rebuild-country.yml
@@ -23,13 +23,13 @@ env:
 
 jobs:
   gisaid:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Launch build
       run: |

--- a/.github/workflows/rebuild-gisaid-21L.yml
+++ b/.github/workflows/rebuild-gisaid-21L.yml
@@ -23,13 +23,13 @@ env:
 
 jobs:
   gisaid-21L:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Launch build
       run: |

--- a/.github/workflows/rebuild-gisaid.yml
+++ b/.github/workflows/rebuild-gisaid.yml
@@ -23,13 +23,13 @@ env:
 
 jobs:
   gisaid:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Launch build
       run: |

--- a/.github/workflows/rebuild-open.yml
+++ b/.github/workflows/rebuild-open.yml
@@ -24,13 +24,13 @@ env:
 
 jobs:
   open:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Launch build
       run: |

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -22,13 +22,13 @@ env:
 
 jobs:
   revert:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
       with:
-        python-version: "3.9"
+        python-version: "3.10"
 
     - name: Revert build
       run: |

--- a/.github/workflows/sync-redirects.yaml
+++ b/.github/workflows/sync-redirects.yaml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository_owner == 'nextstrain'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
 
       - name: Upgrade Python toolchain


### PR DESCRIPTION
Addresses checkout/v2 deprecation warning

checkout -> v4
python -> 3.10
ubuntu -> 22.04
