### PR TITLE
Version nextclade binary for transition, i.e. `nextclade` -> `nextclade2`

### DIFF
--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,7 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 14 Dec 2023: Use `nextclade2` binary that makes the version explicit [PR 1089](https://github.com/nextstrain/ncov/pull/1089)
 - 17 June 2023: Update subsampling strategy for `nextstrain_profiles` to better equilibrate per-capita sampling rates across geographic regions. Primarily this update breaks out China and India as separate subsampling targets because of their large population sizes. It also fine tunes the per-region sampling targets. After this update, URL structure (ie https://nextstrain.org/ncov/gisaid/global/6m) is unchanged. [PR 1074](https://github.com/nextstrain/ncov/pull/1074)
 
 ## v13 (16 May 2023)

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -499,7 +499,7 @@ rule build_align:
             --sequences {input.sequences} \
             --strip-prefixes {params.strain_prefixes:q} \
             --output /dev/stdout 2> {params.sanitize_log} \
-            | nextclade run \
+            | nextclade2 run \
             --jobs {threads} \
             --input-dataset {input.nextclade_dataset} \
             --output-tsv {output.nextclade_qc} \


### PR DESCRIPTION
## Description of proposed changes

Soon we will release nextclade v3. Once nextclade v3 hits bioconda, workflows that rely on v2 syntax will break. To prevent this, this PR makes it explicit that the syntax used is for v2 and that the v2 binary `nextclade2` should be used.

This binary is in both the `nextstrain-base` docker image and in the `conda-base` managed conda environment.

Users who don't use either will have to add `nextclade2` to the path.

Over the next few weeks, we will transition repos to use `nextclade3`. The reason to add `nextclade2` now is so that workflows don't break if they haven't yet transitioned to `nextclade3` at the time of v3 release. It also makes it easy to search which workflows need to be changed.

## Testing

- CI

## Release checklist

 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
