### PR TITLE
Version nextalign binary for transition

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -92,7 +92,7 @@ rule align:
             --sequences {input.sequences} \
             --strip-prefixes {params.strain_prefixes:q} \
             --output /dev/stdout 2> {params.sanitize_log} \
-            | nextalign run \
+            | nextalign2 run \
             --jobs={threads} \
             --reference {input.reference} \
             --genemap {input.genemap} \


### PR DESCRIPTION
## Description of proposed changes

Parallels "Version nextclade binary for transition" (8cf76ae2b).

## Related issue(s)

- Follow-up to #1089
- https://github.com/nextstrain/docker-base/pull/204#discussion_r1454189730

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
