### PR TITLE
Fix RBD level coloring and filter

### DIFF
--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,7 +5,10 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 30 January 2024: Fix RBD-level coloring by updating clade label and clade parsing. [PR 1094](https://github.com/nextstrain/ncov/pull/1094)
+
 - 14 Dec 2023: Use `nextclade2` binary that makes the version explicit [PR 1089](https://github.com/nextstrain/ncov/pull/1089)
+
 - 17 June 2023: Update subsampling strategy for `nextstrain_profiles` to better equilibrate per-capita sampling rates across geographic regions. Primarily this update breaks out China and India as separate subsampling targets because of their large population sizes. It also fine tunes the per-region sampling targets. After this update, URL structure (ie https://nextstrain.org/ncov/gisaid/global/6m) is unchanged. [PR 1074](https://github.com/nextstrain/ncov/pull/1074)
 
 ## v13 (16 May 2023)

--- a/scripts/assign_rbd_levels.py
+++ b/scripts/assign_rbd_levels.py
@@ -7,12 +7,12 @@ import argparse
 def find_matching_nodes(clades_fname, basal_clade_label, tree_fname):
     basal_node_name = None
     with open(clades_fname) as fh:
-        for name, node_data in json.load(fh)['nodes'].items():
-            if node_data.get('clade_annotation', '') == basal_clade_label:
+        for name, node_data in json.load(fh)['branches'].items():
+            if node_data.get('labels', {}).get('clade', '') == basal_clade_label:
                 basal_node_name = name
                 break
     if not basal_node_name:
-        print(f"WARNING: no node found with a clade_annotation of {basal_clade_label}. This script will proceed, but no levels will be exported.")
+        print(f"WARNING: no branch found with a clade of {basal_clade_label}. This script will proceed, but no levels will be exported.")
         return set()
     print(f"Node representing {basal_clade_label}: {basal_node_name}")
     T = Phylo.read(tree_fname, 'newick')

--- a/workflow/snakemake_rules/export_for_nextstrain.smk
+++ b/workflow/snakemake_rules/export_for_nextstrain.smk
@@ -303,7 +303,6 @@ rule auspice_config:
                 "pango_lineage",
                 "Nextclade_pango",
                 "region",
-                "level",
                 "country",
                 "division",
                 location_filter,

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1307,6 +1307,8 @@ rule assign_rbd_levels:
         basal_clade_label="21L (Omicron)"
     output:
         node_data="results/{build_name}/rbd_levels.json",
+    log:
+        "logs/assign_rbd_levels_{build_name}.txt"
     benchmark:
         "benchmarks/assign_levels_{build_name}.txt",
     conda:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1304,7 +1304,7 @@ rule assign_rbd_levels:
         tree = "results/{build_name}/tree.nwk",
     params:
         config=config["files"]["rbd_level_definitions"],
-        basal_clade_label="21L (Omicron)"
+        basal_clade_label="21L (BA.2)"
     output:
         node_data="results/{build_name}/rbd_levels.json",
     log:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1310,7 +1310,7 @@ rule assign_rbd_levels:
     log:
         "logs/assign_rbd_levels_{build_name}.txt"
     benchmark:
-        "benchmarks/assign_levels_{build_name}.txt",
+        "benchmarks/assign_rbd_levels_{build_name}.txt",
     conda:
         config["conda_environment"],
     shell:


### PR DESCRIPTION
## Description of proposed changes

Came down this rabbit hole when I was thinking about [augur export v2 and the filter footers](https://github.com/nextstrain/augur/pull/1384#pullrequestreview-1847695155). I noticed the [ncov build](https://next.nextstrain.org/ncov/gisaid/global/6m@2024-01-29) had empty filter footers for `level` and `rbd_level` and investigated. 

See commits for details.

## Testing

- [x] [Test build](https://github.com/nextstrain/ncov/actions/runs/7702226205) - visible at https://next.nextstrain.org/staging/ncov/gisaid/trial/fix-rbd/global/6m?c=rbd_level

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
