### PR TITLE
dev: Remove python-version input to setup-nextstrain-cli action

### DIFF
--- a/.github/workflows/rebuild-100k.yml
+++ b/.github/workflows/rebuild-100k.yml
@@ -14,8 +14,6 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      with:
-        python-version: "3.10"
 
     - name: Launch GISAID build
       run: |

--- a/.github/workflows/rebuild-country.yml
+++ b/.github/workflows/rebuild-country.yml
@@ -28,8 +28,6 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      with:
-        python-version: "3.10"
 
     - name: Launch build
       run: |

--- a/.github/workflows/rebuild-gisaid-21L.yml
+++ b/.github/workflows/rebuild-gisaid-21L.yml
@@ -28,8 +28,6 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      with:
-        python-version: "3.10"
 
     - name: Launch build
       run: |

--- a/.github/workflows/rebuild-gisaid.yml
+++ b/.github/workflows/rebuild-gisaid.yml
@@ -28,8 +28,6 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      with:
-        python-version: "3.10"
 
     - name: Launch build
       run: |

--- a/.github/workflows/rebuild-open.yml
+++ b/.github/workflows/rebuild-open.yml
@@ -29,8 +29,6 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      with:
-        python-version: "3.10"
 
     - name: Launch build
       run: |

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -27,8 +27,6 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      with:
-        python-version: "3.10"
 
     - name: Revert build
       run: |


### PR DESCRIPTION
Deprecated and no longer used as setup-python isn't called.

Related-to: <https://github.com/nextstrain/.github/pull/55>