### PR TITLE
Update Suffolk lat/long

### DIFF
--- a/defaults/lat_longs.tsv
+++ b/defaults/lat_longs.tsv
@@ -10030,7 +10030,7 @@ location	Sucre EC	-0.7326786000000001	-80.41990564699557
 location	Sueca	39.2025604	-0.3111645
 location	Südoststeiermark	46.85967165	15.850364747446001
 location	Suesca	5.103373	-73.799748
-location	Suffolk	42.3544455	-70.9788771
+location	Suffolk	52.2410014	1.046683
 location	Suffolk County	40.9849	-72.6151
 location	Suffolk County MA	42.3544455	-70.9788771
 location	Suffolk County NY	40.8832318	-72.8578027
@@ -14917,4 +14917,3 @@ country	Oceania	-25.0562891	152.008576
 country	South America	-13.083583	-58.470721
 
 region	Asia	30.451098	86.654576
-


### PR DESCRIPTION
Prompted by https://github.com/nextstrain/seasonal-flu/issues/155.

The "Suffolk" location should be the location in UK based on ncov-ingest/source-data/gisaid_geoLocationRules.tsv¹ since all other "Suffolk" entries are corrected to "Suffolk County".

¹ https://github.com/nextstrain/ncov-ingest/blob/d3fa3b990ea417e3188537e1125f032169e55b69/source-data/gisaid_geoLocationRules.tsv