### PR TITLE
ci.yaml: Pin `pathogen-repo-ci`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-build:
-    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@v0
     with:
       build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci
 


### PR DESCRIPTION
## Description of proposed changes

Pin the `pathogen-repo-ci` to v0, which is before changes for the "smart" workflow were added.

## Related issue(s)

Related to https://github.com/nextstrain/.github/issues/93

## Release checklist

Dev change only, no need for changelog updates or new release. 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
