### PR TITLE
docs: Unpin docutils

### DIFF
--- a/docs/conda.yml
+++ b/docs/conda.yml
@@ -9,7 +9,7 @@ dependencies:
     - recommonmark
     - requests
     - sphinx
-    - docutils<0.18
+    - docutils
     - sphinx-argparse
     - sphinx-autobuild
     - sphinx-copybutton


### PR DESCRIPTION
Prompted by https://github.com/nextstrain/ncov/issues/1126

Unpinning docutils to be able to pull in the latest sphinx-argparse to fix doc builds.

## Testing

What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
