### PR TITLE
Demo prefilter rule for Nextstrain GISAID build

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -2,6 +2,7 @@ auspice_json_prefix: ncov_gisaid
 
 # Define custom rules for pre- or post-standard workflow processing of data.
 custom_rules:
+  - workflow/snakemake_rules/prefilter.smk
   - workflow/snakemake_rules/export_for_nextstrain.smk
 
 # These parameters are only used by the `export_for_nextstrain` rule and shouldn't need to be modified.
@@ -25,7 +26,7 @@ files:
 
 inputs:
   - name: gisaid
-    metadata: "s3://nextstrain-ncov-private/metadata.tsv.zst"
+    metadata: "data/prefiltered_metadata.tsv"
     aligned: "s3://nextstrain-ncov-private/aligned.fasta.zst"
     skip_sanitize_metadata: true
 

--- a/workflow/snakemake_rules/prefilter.smk
+++ b/workflow/snakemake_rules/prefilter.smk
@@ -1,0 +1,26 @@
+rule download_metadata:
+    params:
+        metadata_url="s3://nextstrain-ncov-private/metadata.tsv.zst",
+    output:
+        metadata="data/metadata.tsv.zst",
+    shell:
+        """
+        aws s3 cp {params.metadata_url} {output.metadata}
+        """
+
+rule filter_metadata:
+    input:
+        metadata="data/metadata.tsv.zst",
+    output:
+        metadata="data/prefiltered_metadata.tsv",
+    params:
+        max_sequences=500000,
+        group_by="division year month",
+    shell:
+        """
+        augur filter \
+            --metadata {input.metadata} \
+            --subsample-max-sequences {params.max_sequences} \
+            --group-by {params.group_by} \
+            --output-metadata {output.metadata}
+        """


### PR DESCRIPTION
## Description of proposed changes

Adds a prefilter rule to reduce the size of the input metadata for the GISAID build before running the whole workflow.

## Related issue(s)

Related to #814

## Testing

What steps should be taken to test the changes you've proposed?
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
