### PR TITLE
Update time based sampling

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -165,19 +165,21 @@ subsampling:
   # Custom subsampling logic for regions over 1m
   # Grouping by division for North America and Oceania
   # 4000 total
-  # 4:1 ratio of recent to early
+  # 10:1 ratio of recent to early
   # 4:1 ratio of focal to context
   nextstrain_region_grouped_by_division_1m:
     # Early focal samples for region
     focal_early:
       group_by: "division year month"
-      max_sequences: 640
+      max_sequences: 256
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
-      max_sequences: 160
+      max_sequences: 64
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -196,19 +198,21 @@ subsampling:
   # Custom subsampling logic for regions over 2m
   # Grouping by division for North America and Oceania
   # 4000 total
-  # 4:1 ratio of recent to early
+  # 10:1 ratio of recent to early
   # 4:1 ratio of focal to context
   nextstrain_region_grouped_by_division_2m:
     # Early focal samples for region
     focal_early:
       group_by: "division year month"
-      max_sequences: 640
+      max_sequences: 256
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
-      max_sequences: 160
+      max_sequences: 64
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -227,19 +231,21 @@ subsampling:
   # Custom subsampling logic for regions over 6m
   # Grouping by division for North America and Oceania
   # 4000 total
-  # 4:1 ratio of recent to early
+  # 10:1 ratio of recent to early
   # 4:1 ratio of focal to context
   nextstrain_region_grouped_by_division_6m:
     # Early focal samples for region
     focal_early:
       group_by: "division year month"
-      max_sequences: 640
+      max_sequences: 256
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
-      max_sequences: 160
+      max_sequences: 64
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -275,32 +281,36 @@ subsampling:
   # Grouping by division
   # Separating three buckets for China, India and elsewhere
   # 4375 total
-  # 4:1 ratio of recent to early
+  # 10:1 ratio of recent to early
   # 4:1 ratio of focal to context
   # 3:2:2 proportions of Asia, China, India
   nextstrain_region_asia_grouped_by_division_1m:
     # Early focal samples for Asia
     asia_early:
       group_by: "division year month"
-      max_sequences: 300
+      max_sequences: 120
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     # Early focal samples for China
     china_early:
       group_by: "division year month"
-      max_sequences: 200
+      max_sequences: 80
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=China'"
     # Early focal samples for India
     india_early:
       group_by: "division year month"
-      max_sequences: 200
+      max_sequences: 80
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=India'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
-      max_sequences: 175
+      max_sequences: 70
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region=Asia'"
     # Recent focal samples for Asia
@@ -313,13 +323,13 @@ subsampling:
     china_recent:
       group_by: "division week"
       max_sequences: 800
-      max_date: "--min-date 1M"
+      min_date: "--min-date 1M"
       exclude: "--exclude-where 'country!=China'"
     # Recent focal samples for India
     india_recent:
       group_by: "division week"
       max_sequences: 800
-      max_date: "--min-date 1M"
+      min_date: "--min-date 1M"
       exclude: "--exclude-where 'country!=India'"
     # Early contextual samples from the rest of the world
     context_recent:
@@ -332,32 +342,36 @@ subsampling:
   # Grouping by division
   # Separating three buckets for China, India and elsewhere
   # 4375 total
-  # 4:1 ratio of recent to early
+  # 10:1 ratio of recent to early
   # 4:1 ratio of focal to context
   # 3:2:2 proportions of Asia, China, India
   nextstrain_region_asia_grouped_by_division_2m:
     # Early focal samples for Asia
     asia_early:
       group_by: "division year month"
-      max_sequences: 300
+      max_sequences: 120
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     # Early focal samples for China
     china_early:
       group_by: "division year month"
-      max_sequences: 200
+      max_sequences: 80
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=China'"
     # Early focal samples for India
     india_early:
       group_by: "division year month"
-      max_sequences: 200
+      max_sequences: 80
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=India'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
-      max_sequences: 175
+      max_sequences: 70
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region=Asia'"
     # Recent focal samples for Asia
@@ -370,13 +384,13 @@ subsampling:
     china_recent:
       group_by: "division week"
       max_sequences: 800
-      max_date: "--min-date 2M"
+      min_date: "--min-date 2M"
       exclude: "--exclude-where 'country!=China'"
     # Recent focal samples for India
     india_recent:
       group_by: "division week"
       max_sequences: 800
-      max_date: "--min-date 2M"
+      min_date: "--min-date 2M"
       exclude: "--exclude-where 'country!=India'"
     # Early contextual samples from the rest of the world
     context_recent:
@@ -389,32 +403,36 @@ subsampling:
   # Grouping by division
   # Separating three buckets for China, India and elsewhere
   # 4375 total
-  # 4:1 ratio of recent to early
+  # 10:1 ratio of recent to early
   # 4:1 ratio of focal to context
   # 3:2:2 proportions of Asia, China, India
   nextstrain_region_asia_grouped_by_division_6m:
     # Early focal samples for Asia
     asia_early:
       group_by: "division year month"
-      max_sequences: 300
+      max_sequences: 120
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     # Early focal samples for China
     china_early:
       group_by: "division year month"
-      max_sequences: 200
+      max_sequences: 80
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=China'"
     # Early focal samples for India
     india_early:
       group_by: "division year month"
-      max_sequences: 200
+      max_sequences: 80
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=India'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
-      max_sequences: 175
+      max_sequences: 70
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region=Asia'"
     # Recent focal samples for Asia
@@ -427,13 +445,13 @@ subsampling:
     china_recent:
       group_by: "division year month"
       max_sequences: 800
-      max_date: "--min-date 6M"
+      min_date: "--min-date 6M"
       exclude: "--exclude-where 'country!=China'"
     # Recent focal samples for India
     india_recent:
       group_by: "division year month"
       max_sequences: 800
-      max_date: "--min-date 6M"
+      min_date: "--min-date 6M"
       exclude: "--exclude-where 'country!=India'"
     # Early contextual samples from the rest of the world
     context_recent:
@@ -473,19 +491,21 @@ subsampling:
   # Custom subsampling logic for regions over 1m
   # Grouping by country for Africa, Asia, Europe and South America
   # 4000 total
-  # 4:1 ratio of recent to early
+  # 10:1 ratio of recent to early
   # 4:1 ratio of focal to context
   nextstrain_region_grouped_by_country_1m:
     # Early focal samples for region
     focal_early:
       group_by: "country year month"
-      max_sequences: 640
+      max_sequences: 256
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
-      max_sequences: 160
+      max_sequences: 64
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -504,19 +524,21 @@ subsampling:
   # Custom subsampling logic for regions over 2m
   # Grouping by country for Africa, Asia, Europe and South America
   # 4000 total
-  # 4:1 ratio of recent to early
+  # 10:1 ratio of recent to early
   # 4:1 ratio of focal to context
   nextstrain_region_grouped_by_country_2m:
     # Early focal samples for region
     focal_early:
       group_by: "country year month"
-      max_sequences: 640
+      max_sequences: 256
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
-      max_sequences: 160
+      max_sequences: 64
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -535,19 +557,21 @@ subsampling:
   # Custom subsampling logic for regions over 6m
   # Grouping by country for Africa, Asia, Europe and South America
   # 4000 total
-  # 4:1 ratio of recent to early
+  # 10:1 ratio of recent to early
   # 4:1 ratio of focal to context
   nextstrain_region_grouped_by_country_6m:
     # Early focal samples for region
     focal_early:
       group_by: "country year month"
-      max_sequences: 640
+      max_sequences: 256
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
-      max_sequences: 160
+      max_sequences: 64
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -580,48 +604,58 @@ subsampling:
       exclude: "--exclude-where 'region={region}'"
 
   # Custom subsampling logic for global region over 1m
-  # 5125 total (expect ~3400)
-  # 4:1 ratio of recent to early
-  # all eight regions equal except Oceania at 20%
+  # ~4500 total (expect ~3400)
+  # 10:1 ratio of recent to early
+  # recent is present to 1m, n = 4120
+  # early is 1m to 25m, n = 412
+  # regions are proportional to population size
   nextstrain_global_1m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 60
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 200
+      max_sequences: 80
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 175
+      max_sequences: 70
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 50
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 175
+      max_sequences: 70
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 100
+      max_sequences: 40
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 90
+      max_sequences: 36
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 15
+      max_sequences: 6
+      min_date: "--min-date 25M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
@@ -666,48 +700,58 @@ subsampling:
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over 2m
-  # 5125 total (expect ~3400)
-  # 4:1 ratio of recent to early
-  # all eight regions equal except Oceania at 20%
+  # ~4500 total (expect ~3400)
+  # 10:1 ratio of recent to early
+  # recent is present to 2m, n = 4120
+  # early is 2m to 26m, n = 412
+  # regions are proportional to population size
   nextstrain_global_2m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 60
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 200
+      max_sequences: 80
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 175
+      max_sequences: 70
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 50
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 175
+      max_sequences: 70
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 100
+      max_sequences: 40
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 90
+      max_sequences: 36
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 15
+      max_sequences: 6
+      min_date: "--min-date 26M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
@@ -752,48 +796,58 @@ subsampling:
       exclude: "--exclude-where 'region!=Oceania'"
 
   # Custom subsampling logic for global region over 6m
-  # 5125 total (expect ~3400)
-  # 4:1 ratio of recent to early
-  # all eight regions equal except Oceania at 20%
+  # ~4500 total (expect ~3400)
+  # 10:1 ratio of recent to early
+  # recent is present to 6m, n = 4120
+  # early is 6m to 30m, n = 412
+  # regions are proportional to population size
   nextstrain_global_6m:
     africa_early:
       group_by: "country year month"
-      max_sequences: 150
+      max_sequences: 60
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
-      max_sequences: 200
+      max_sequences: 80
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
-      max_sequences: 175
+      max_sequences: 70
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
-      max_sequences: 125
+      max_sequences: 50
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
-      max_sequences: 175
+      max_sequences: 70
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
-      max_sequences: 100
+      max_sequences: 40
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
-      max_sequences: 90
+      max_sequences: 36
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
-      max_sequences: 15
+      max_sequences: 6
+      min_date: "--min-date 30M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
@@ -839,7 +893,7 @@ subsampling:
 
   # Custom subsampling logic for global region over all-time
   # 4320 total (expect ~3200)
-  # all eight regions equal except Oceania at 20%
+  # regions are proportional to population size
   nextstrain_global_all_time:
     africa:
       group_by: "country year month"

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -20,7 +20,9 @@ genes: ["ORF1a", "ORF1b", "S", "ORF3a", "E", "M", "ORF6", "ORF7a", "ORF7b", "ORF
 use_nextalign: true
 include_hcov19_prefix: True
 
+# use custom include file that doesn't specify Wuhan/1
 files:
+  include: "nextstrain_profiles/nextstrain-gisaid/include.txt"
   description: "nextstrain_profiles/nextstrain-gisaid/nextstrain_description.md"
 
 inputs:
@@ -927,6 +929,10 @@ subsampling:
       group_by: "division year month"
       max_sequences: 75
       exclude: "--exclude-where 'region!=Oceania'"
+
+# root via temporal fit rather than explicit outgroup
+refine:
+  root: "best"
 
 # if different traits should be reconstructed for some builds, specify here
 # otherwise the default trait config in defaults/parameters.yaml will used

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -174,14 +174,14 @@ subsampling:
     focal_early:
       group_by: "division year month"
       max_sequences: 256
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
       max_sequences: 64
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -207,14 +207,14 @@ subsampling:
     focal_early:
       group_by: "division year month"
       max_sequences: 256
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
       max_sequences: 64
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -240,14 +240,14 @@ subsampling:
     focal_early:
       group_by: "division year month"
       max_sequences: 256
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
       max_sequences: 64
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -291,28 +291,28 @@ subsampling:
     asia_early:
       group_by: "division year month"
       max_sequences: 120
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     # Early focal samples for China
     china_early:
       group_by: "division year month"
       max_sequences: 80
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=China'"
     # Early focal samples for India
     india_early:
       group_by: "division year month"
       max_sequences: 80
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=India'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
       max_sequences: 70
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region=Asia'"
     # Recent focal samples for Asia
@@ -352,28 +352,28 @@ subsampling:
     asia_early:
       group_by: "division year month"
       max_sequences: 120
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     # Early focal samples for China
     china_early:
       group_by: "division year month"
       max_sequences: 80
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=China'"
     # Early focal samples for India
     india_early:
       group_by: "division year month"
       max_sequences: 80
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=India'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
       max_sequences: 70
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region=Asia'"
     # Recent focal samples for Asia
@@ -413,28 +413,28 @@ subsampling:
     asia_early:
       group_by: "division year month"
       max_sequences: 120
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     # Early focal samples for China
     china_early:
       group_by: "division year month"
       max_sequences: 80
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=China'"
     # Early focal samples for India
     india_early:
       group_by: "division year month"
       max_sequences: 80
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=India'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
       max_sequences: 70
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region=Asia'"
     # Recent focal samples for Asia
@@ -500,14 +500,14 @@ subsampling:
     focal_early:
       group_by: "country year month"
       max_sequences: 256
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
       max_sequences: 64
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -533,14 +533,14 @@ subsampling:
     focal_early:
       group_by: "country year month"
       max_sequences: 256
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
       max_sequences: 64
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -566,14 +566,14 @@ subsampling:
     focal_early:
       group_by: "country year month"
       max_sequences: 256
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!={region}'"
     # Early contextual samples from the rest of the world
     context_early:
       group_by: "country year month"
       max_sequences: 64
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region={region}'"
     # Recent focal samples for region
@@ -609,55 +609,55 @@ subsampling:
   # ~4500 total (expect ~3400)
   # 10:1 ratio of recent to early
   # recent is present to 1m, n = 4120
-  # early is 1m to 25m, n = 412
+  # early is 1m to 13M, n = 412
   # regions are proportional to population size
   nextstrain_global_1m:
     africa_early:
       group_by: "country year month"
       max_sequences: 60
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
       max_sequences: 80
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
       max_sequences: 70
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
       max_sequences: 50
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
       max_sequences: 70
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
       max_sequences: 40
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
       max_sequences: 36
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
       max_sequences: 6
-      min_date: "--min-date 25M"
+      min_date: "--min-date 13M"
       max_date: "--max-date 1M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
@@ -705,55 +705,55 @@ subsampling:
   # ~4500 total (expect ~3400)
   # 10:1 ratio of recent to early
   # recent is present to 2m, n = 4120
-  # early is 2m to 26m, n = 412
+  # early is 2m to 14M, n = 412
   # regions are proportional to population size
   nextstrain_global_2m:
     africa_early:
       group_by: "country year month"
       max_sequences: 60
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
       max_sequences: 80
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
       max_sequences: 70
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
       max_sequences: 50
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
       max_sequences: 70
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
       max_sequences: 40
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
       max_sequences: 36
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
       max_sequences: 6
-      min_date: "--min-date 26M"
+      min_date: "--min-date 14M"
       max_date: "--max-date 2M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:
@@ -801,55 +801,55 @@ subsampling:
   # ~4500 total (expect ~3400)
   # 10:1 ratio of recent to early
   # recent is present to 6m, n = 4120
-  # early is 6m to 30m, n = 412
+  # early is 6m to 18M, n = 412
   # regions are proportional to population size
   nextstrain_global_6m:
     africa_early:
       group_by: "country year month"
       max_sequences: 60
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Africa'"
     asia_early:
       group_by: "country year month"
       max_sequences: 80
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Asia' 'country=China' 'country=India'"
     china_early:
       group_by: "division year month"
       max_sequences: 70
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=China'"
     europe_early:
       group_by: "country year month"
       max_sequences: 50
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Europe'"
     india_early:
       group_by: "division year month"
       max_sequences: 70
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'country!=India'"
     north_america_early:
       group_by: "division year month"
       max_sequences: 40
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=North America'"
     south_america_early:
       group_by: "country year month"
       max_sequences: 36
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=South America'"
     oceania_early:
       group_by: "division year month"
       max_sequences: 6
-      min_date: "--min-date 30M"
+      min_date: "--min-date 18M"
       max_date: "--max-date 6M"
       exclude: "--exclude-where 'region!=Oceania'"
     africa_recent:


### PR DESCRIPTION
## Description of proposed changes

Currently, we focus on a recent time window in many of our ncov analyses. For example, [ncov/gisaid/north-america/6m](https://nextstrain.org/ncov/gisaid/north-america/6m), does more intensive sampling of the previous 6 months (aiming for ~4000 "recent" samples and ~1000 "early" samples). However, as the past continues to recede (as it does) we're getting more and more early context that isn't so relevant for understanding circulating diversity. Here's the live 6m tree for example:

<img width="861" alt="Screenshot 2024-07-25 at 11 52 12 AM" src="https://github.com/user-attachments/assets/0a5a3b84-c18e-4441-94ad-4d2820931402">

Once selective sweeps occur, we can largely forget about past evolution when looking at current diversity. This had previously prompted us to make the ["21L" builds that root to clade 21L / lineage BA.2](https://github.com/nextstrain/ncov/pull/1029).

At this point, we're getting closer and closer to wanting the same thing with a clade 24A / lineage JN.1 rooting. However, this strategy is clearly not sustainable. In 4 more years we don't want to have have 4 different rootings, all of which require  updating and it not being clear to users what they should be looking at.

This PR addresses the issue in a simple fashion, basically making ncov work more like seasonal-flu or avian-flu where there is recent focal samples and older contextual samples, but the contextual samples only go back a year rather than many.

Here's the resulting global 6m tree:
 
<img width="915" alt="Screenshot 2024-07-25 at 12 24 56 PM" src="https://github.com/user-attachments/assets/44cf2fec-3c2b-403d-af3f-4dff0be91e19">

Results from running this PR can be seen at:

- [global/6m](https://nextstrain.org/staging/ncov/gisaid/trial/time-based-sampling-v2/global/6m)
- [global/2m](https://nextstrain.org/staging/ncov/gisaid/trial/time-based-sampling-v2/global/2m)
- [global/1m](https://nextstrain.org/staging/ncov/gisaid/trial/time-based-sampling-v2/global/1m)
- [africa/6m](https://nextstrain.org/staging/ncov/gisaid/trial/time-based-sampling-v2/africa/6m)
etc...

This is using a 10:1 ratio of recent to early samples and doing a +1 year back for early samples. For for the 6m analysis, it's 0m to 6m back as recent focal samples and 6m to 18m back as early contextual samples.

I had tried a +2 year context as well, but it didn't seem to add much understanding while taking up additional screen real estate and additional color ramp. You can compare here however: [global/6m](https://nextstrain.org/staging/ncov/gisaid/trial/time-based-sampling/global/6m)

The the biggest worry I see here is that people currently landing at [ncov/gisaid/global/6m](https://nextstrain.org/ncov/gisaid/global/6m) can see what's currently circulating and get all the context that they may need going back to the beginning of the pandemic (with well known VOCs, etc...).

If we did merge this, we should make two showcase cards on the splash page to direct to `6m` vs `all-time` to (partially) address this. Also, if we did merge this, I'd imagine deprecating the 21L builds, where we'd remove them from the automated GitHub Actions rebuild, remove them from the manifest and add redirects to go from [ncov/gisaid/21L/global/6m](https://nextstrain.org/ncov/gisaid/21Lglobal/6m) to [ncov/gisaid/global/6m](https://nextstrain.org/ncov/gisaid/global/6m).

The other approach to this same issue would be take older clades (and conceivably Pango lineages) and make these gray while keeping the color ramp only for more recent clades. This strategy is also not mutually exclusive and we do could do both or neither. I'll try to put together a separate PR for the clade colors idea. Though even if colors update fixes things enough for the time being, I do think we'll eventually want to do something like this strategy. But it's possible this is a couple years down the road.

In addition to code review, I'd appreciate 👍 / 👎 feedback on whether you prefer this to the current sampling strategy.

## Testing

Tested locally and via GitHub Action trial builds.

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.


