### PR TITLE
Gray out early clades

### DIFF
--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -134,9 +134,9 @@ refine:
 ancestral:
   inference: "joint"
 
-# Gray out clades that are older than 18 months when constructing a color ramp
 colors:
-  clade_recency: 18
+  # Months back to color clades, if "" then all clades are colored
+  clade_recency: ""
 
 # Frequencies settings
 frequencies:

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -136,7 +136,7 @@ ancestral:
 
 colors:
   default:
-    # Months back to color clades, if "all" then all clades are colored
+    # Amount of time back to color clades, if "all" then all clades are colored
     # Can be specified per build in builds.yaml
     clade_recency: "all"
 

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -134,6 +134,10 @@ refine:
 ancestral:
   inference: "joint"
 
+# Gray out clades that are older than 18 months when constructing a color ramp
+colors:
+  clade_recency: 18
+
 # Frequencies settings
 frequencies:
 

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -135,8 +135,10 @@ ancestral:
   inference: "joint"
 
 colors:
-  # Months back to color clades, if "" then all clades are colored
-  clade_recency: ""
+  # Months back to color clades, if "all" then all clades are colored
+  # Can be specified per build in builds.yaml
+  default:
+    clade_recency: "all"
 
 # Frequencies settings
 frequencies:

--- a/defaults/parameters.yaml
+++ b/defaults/parameters.yaml
@@ -135,9 +135,9 @@ ancestral:
   inference: "joint"
 
 colors:
-  # Months back to color clades, if "all" then all clades are colored
-  # Can be specified per build in builds.yaml
   default:
+    # Months back to color clades, if "all" then all clades are colored
+    # Can be specified per build in builds.yaml
     clade_recency: "all"
 
 # Frequencies settings

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 2 October 2024: Include a new parameter for `clade_recency` under `colors`. This parameter is used to define which clades should receive a color from the standard rainbow palette. A value of `6M` will cause clades with strains in the tree sampled within the last 6 months to be colored and earlier strains to not receive a color (and be colored in a palette of grays by Auspice). This `clade_recency` parameter is used in `builds.yaml` in `nextstrain_profiles` to color clades according for the `1m`, `2m`, `6m` and `all-time` timepoints. If `clade_recency` is not supplied then all clades will be colored. [PR 1132](https://github.com/nextstrain/ncov/pull/1132)
+
 - 30 September 2024: Use population-based weighted sampling for `nextstrain_profiles`. This requires a minimum Augur version of 25.3.0. PRs [1106](https://github.com/nextstrain/ncov/pull/1106), [1150](https://github.com/nextstrain/ncov/pull/1150), [1151](https://github.com/nextstrain/ncov/pull/1151)
 
 - 31 January 2024: Remove RBD-level related rules and files since this feature has been broken since May 2023 and is no longer relevant. [PR 1097](https://github.com/nextstrain/ncov/pull/1097)

--- a/docs/src/reference/workflow-config-file.rst
+++ b/docs/src/reference/workflow-config-file.rst
@@ -941,6 +941,33 @@ no_timetree
 -  description: Do not produce a time tree.
 -  default: ``false``
 
+colors
+------
+
+-  type: object
+-  description: Parameters for assigning colors in ``scripts/assign-colors.py``
+-  examples:
+
+.. code:: yaml
+
+   colors:
+     default:
+       clade_recency: ""
+     global-6m:
+       # Override clade recency colors for "global-6m" build
+       clade_recency: 6
+
+Each named traits configuration (``default`` or build-named) supports the following attributes:
+
+.. contents::
+   :local:
+
+clade_recency
+~~~~~~~~~~~~~
+
+-  type: integer
+-  description: if provided, restrict to clades found in tree within X months of present
+-  default: ````
 
 traits
 ------

--- a/docs/src/reference/workflow-config-file.rst
+++ b/docs/src/reference/workflow-config-file.rst
@@ -952,7 +952,7 @@ colors
 
    colors:
      default:
-       clade_recency: ""
+       clade_recency: "all"
      global-6m:
        # Override clade recency colors for "global-6m" build
        clade_recency: 6
@@ -966,8 +966,8 @@ clade_recency
 ~~~~~~~~~~~~~
 
 -  type: integer
--  description: if provided, restrict to clades found in tree within X months of present
--  default: ````
+-  description: if integer value is provided, restrict to clades found in tree within X months of present
+-  default: ``all``
 
 traits
 ------

--- a/docs/src/reference/workflow-config-file.rst
+++ b/docs/src/reference/workflow-config-file.rst
@@ -955,7 +955,7 @@ colors
        clade_recency: "all"
      global-6m:
        # Override clade recency colors for "global-6m" build
-       clade_recency: 6
+       clade_recency: "6M"
 
 Each named traits configuration (``default`` or build-named) supports the following attributes:
 
@@ -965,9 +965,10 @@ Each named traits configuration (``default`` or build-named) supports the follow
 clade_recency
 ~~~~~~~~~~~~~
 
--  type: integer
--  description: if integer value is provided, restrict to clades found in tree within X months of present
--  default: ``all``
+-  type: string
+-  format: `ISO 8601 <https://en.wikipedia.org/wiki/ISO_8601#Durations>`__ duration with optional ``P`` prefix (e.g. ``2M``, ``18M``, ``1Y6M``)
+-  description: restrict to clades found in tree within this duration from present
+-  default: ``all`` (no restriction)
 
 traits
 ------

--- a/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
@@ -340,6 +340,54 @@ refine:
 
 # if different traits should be reconstructed for some builds, specify here
 # otherwise the default trait config in defaults/parameters.yaml will used
+colors:
+  default:
+    clade_recency: "all"
+  global_1m:
+    clade_recency: "1M"
+  global_2m:
+    clade_recency: "2M"
+  global_6m:
+    clade_recency: "6M"
+  africa_1m:
+    clade_recency: "1M"
+  africa_2m:
+    clade_recency: "2M"
+  africa_6m:
+    clade_recency: "6M"
+  asia_1m:
+    clade_recency: "1M"
+  asia_2m:
+    clade_recency: "2M"
+  asia_6m:
+    clade_recency: "6M"
+  europe_1m:
+    clade_recency: "1M"
+  europe_2m:
+    clade_recency: "2M"
+  europe_6m:
+    clade_recency: "6M"
+  north-america_1m:
+    clade_recency: "1M"
+  north-america_2m:
+    clade_recency: "2M"
+  north-america_6m:
+    clade_recency: "6M"
+  oceania_1m:
+    clade_recency: "1M"
+  oceania_2m:
+    clade_recency: "2M"
+  oceania_6m:
+    clade_recency: "6M"
+  south-america_1m:
+    clade_recency: "1M"
+  south-america_2m:
+    clade_recency: "2M"
+  south-america_6m:
+    clade_recency: "6M"
+
+# if different traits should be reconstructed for some builds, specify here
+# otherwise the default trait config in defaults/parameters.yaml will used
 traits:
   global_1m:
     sampling_bias_correction: 2.5

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -332,47 +332,47 @@ colors:
   default:
     clade_recency: "all"
   global_1m:
-    clade_recency: 1
+    clade_recency: "1M"
   global_2m:
-    clade_recency: 2
+    clade_recency: "2M"
   global_6m:
-    clade_recency: 6
+    clade_recency: "6M"
   africa_1m:
-    clade_recency: 1
+    clade_recency: "1M"
   africa_2m:
-    clade_recency: 2
+    clade_recency: "2M"
   africa_6m:
-    clade_recency: 6
+    clade_recency: "6M"
   asia_1m:
-    clade_recency: 1
+    clade_recency: "1M"
   asia_2m:
-    clade_recency: 2
+    clade_recency: "2M"
   asia_6m:
-    clade_recency: 6
+    clade_recency: "6M"
   europe_1m:
-    clade_recency: 1
+    clade_recency: "1M"
   europe_2m:
-    clade_recency: 2
+    clade_recency: "2M"
   europe_6m:
-    clade_recency: 6
+    clade_recency: "6M"
   north-america_1m:
-    clade_recency: 1
+    clade_recency: "1M"
   north-america_2m:
-    clade_recency: 2
+    clade_recency: "2M"
   north-america_6m:
-    clade_recency: 6
+    clade_recency: "6M"
   oceania_1m:
-    clade_recency: 1
+    clade_recency: "1M"
   oceania_2m:
-    clade_recency: 2
+    clade_recency: "2M"
   oceania_6m:
-    clade_recency: 6
+    clade_recency: "6M"
   south-america_1m:
-    clade_recency: 1
+    clade_recency: "1M"
   south-america_2m:
-    clade_recency: 2
+    clade_recency: "2M"
   south-america_6m:
-    clade_recency: 6
+    clade_recency: "6M"
 
 # if different traits should be reconstructed for some builds, specify here
 # otherwise the default trait config in defaults/parameters.yaml will used

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -329,7 +329,7 @@ subsampling:
 # if different traits should be reconstructed for some builds, specify here
 # otherwise the default trait config in defaults/parameters.yaml will used
 colors:
-  reference:
+  default:
     clade_recency: "all"
   global_1m:
     clade_recency: 1
@@ -337,56 +337,42 @@ colors:
     clade_recency: 2
   global_6m:
     clade_recency: 6
-  global_all-time:
-    clade_recency: "all"
   africa_1m:
     clade_recency: 1
   africa_2m:
     clade_recency: 2
   africa_6m:
     clade_recency: 6
-  africa_all-time:
-    clade_recency: "all"
   asia_1m:
     clade_recency: 1
   asia_2m:
     clade_recency: 2
   asia_6m:
     clade_recency: 6
-  asia_all-time:
-    clade_recency: "all"
   europe_1m:
     clade_recency: 1
   europe_2m:
     clade_recency: 2
   europe_6m:
     clade_recency: 6
-  europe_all-time:
-    clade_recency: "all"
   north-america_1m:
     clade_recency: 1
   north-america_2m:
     clade_recency: 2
   north-america_6m:
     clade_recency: 6
-  north-america_all-time:
-    clade_recency: "all"
   oceania_1m:
     clade_recency: 1
   oceania_2m:
     clade_recency: 2
   oceania_6m:
     clade_recency: 6
-  oceania_all-time:
-    clade_recency: "all"
   south-america_1m:
     clade_recency: 1
   south-america_2m:
     clade_recency: 2
   south-america_6m:
     clade_recency: 6
-  south-america_all-time:
-    clade_recency: "all"
 
 # if different traits should be reconstructed for some builds, specify here
 # otherwise the default trait config in defaults/parameters.yaml will used

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -328,6 +328,68 @@ subsampling:
 
 # if different traits should be reconstructed for some builds, specify here
 # otherwise the default trait config in defaults/parameters.yaml will used
+colors:
+  reference:
+    clade_recency: ""
+  global_1m:
+    clade_recency: 1
+  global_2m:
+    clade_recency: 2
+  global_6m:
+    clade_recency: 6
+  global_all-time:
+    clade_recency: ""
+  africa_1m:
+    clade_recency: 1
+  africa_2m:
+    clade_recency: 2
+  africa_6m:
+    clade_recency: 6
+  africa_all-time:
+    clade_recency: ""
+  asia_1m:
+    clade_recency: 1
+  asia_2m:
+    clade_recency: 2
+  asia_6m:
+    clade_recency: 6
+  asia_all-time:
+    clade_recency: ""
+  europe_1m:
+    clade_recency: 1
+  europe_2m:
+    clade_recency: 2
+  europe_6m:
+    clade_recency: 6
+  europe_all-time:
+    clade_recency: ""
+  north-america_1m:
+    clade_recency: 1
+  north-america_2m:
+    clade_recency: 2
+  north-america_6m:
+    clade_recency: 6
+  north-america_all-time:
+    clade_recency: ""
+  oceania_1m:
+    clade_recency: 1
+  oceania_2m:
+    clade_recency: 2
+  oceania_6m:
+    clade_recency: 6
+  oceania_all-time:
+    clade_recency: ""
+  south-america_1m:
+    clade_recency: 1
+  south-america_2m:
+    clade_recency: 2
+  south-america_6m:
+    clade_recency: 6
+  south-america_all-time:
+    clade_recency: ""
+
+# if different traits should be reconstructed for some builds, specify here
+# otherwise the default trait config in defaults/parameters.yaml will used
 traits:
   reference:
     sampling_bias_correction: 2.5

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -330,7 +330,7 @@ subsampling:
 # otherwise the default trait config in defaults/parameters.yaml will used
 colors:
   reference:
-    clade_recency: ""
+    clade_recency: "all"
   global_1m:
     clade_recency: 1
   global_2m:
@@ -338,7 +338,7 @@ colors:
   global_6m:
     clade_recency: 6
   global_all-time:
-    clade_recency: ""
+    clade_recency: "all"
   africa_1m:
     clade_recency: 1
   africa_2m:
@@ -346,7 +346,7 @@ colors:
   africa_6m:
     clade_recency: 6
   africa_all-time:
-    clade_recency: ""
+    clade_recency: "all"
   asia_1m:
     clade_recency: 1
   asia_2m:
@@ -354,7 +354,7 @@ colors:
   asia_6m:
     clade_recency: 6
   asia_all-time:
-    clade_recency: ""
+    clade_recency: "all"
   europe_1m:
     clade_recency: 1
   europe_2m:
@@ -362,7 +362,7 @@ colors:
   europe_6m:
     clade_recency: 6
   europe_all-time:
-    clade_recency: ""
+    clade_recency: "all"
   north-america_1m:
     clade_recency: 1
   north-america_2m:
@@ -370,7 +370,7 @@ colors:
   north-america_6m:
     clade_recency: 6
   north-america_all-time:
-    clade_recency: ""
+    clade_recency: "all"
   oceania_1m:
     clade_recency: 1
   oceania_2m:
@@ -378,7 +378,7 @@ colors:
   oceania_6m:
     clade_recency: 6
   oceania_all-time:
-    clade_recency: ""
+    clade_recency: "all"
   south-america_1m:
     clade_recency: 1
   south-america_2m:
@@ -386,7 +386,7 @@ colors:
   south-america_6m:
     clade_recency: 6
   south-america_all-time:
-    clade_recency: ""
+    clade_recency: "all"
 
 # if different traits should be reconstructed for some builds, specify here
 # otherwise the default trait config in defaults/parameters.yaml will used

--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -333,6 +333,54 @@ refine:
 
 # if different traits should be reconstructed for some builds, specify here
 # otherwise the default trait config in defaults/parameters.yaml will used
+colors:
+  default:
+    clade_recency: "all"
+  global_1m:
+    clade_recency: "1M"
+  global_2m:
+    clade_recency: "2M"
+  global_6m:
+    clade_recency: "6M"
+  africa_1m:
+    clade_recency: "1M"
+  africa_2m:
+    clade_recency: "2M"
+  africa_6m:
+    clade_recency: "6M"
+  asia_1m:
+    clade_recency: "1M"
+  asia_2m:
+    clade_recency: "2M"
+  asia_6m:
+    clade_recency: "6M"
+  europe_1m:
+    clade_recency: "1M"
+  europe_2m:
+    clade_recency: "2M"
+  europe_6m:
+    clade_recency: "6M"
+  north-america_1m:
+    clade_recency: "1M"
+  north-america_2m:
+    clade_recency: "2M"
+  north-america_6m:
+    clade_recency: "6M"
+  oceania_1m:
+    clade_recency: "1M"
+  oceania_2m:
+    clade_recency: "2M"
+  oceania_6m:
+    clade_recency: "6M"
+  south-america_1m:
+    clade_recency: "1M"
+  south-america_2m:
+    clade_recency: "2M"
+  south-america_6m:
+    clade_recency: "6M"
+
+# if different traits should be reconstructed for some builds, specify here
+# otherwise the default trait config in defaults/parameters.yaml will used
 traits:
   reference:
     sampling_bias_correction: 2.5

--- a/scripts/assign-colors.py
+++ b/scripts/assign-colors.py
@@ -1,9 +1,19 @@
 import argparse
 import pandas as pd
+from datetime import datetime, timedelta
 
 # Forced colours MUST NOT appear in the ordering TSV
 forced_colors = {
 }
+
+def date_within_last_n_months(date_str, cutoff_date):
+    if 'XX' in date_str:
+        return False  # Ignore uncertain dates
+    try:
+        date = datetime.strptime(date_str, "%Y-%m-%d")
+        return date >= cutoff_date
+    except ValueError:
+        return False
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -15,6 +25,7 @@ if __name__ == '__main__':
     parser.add_argument('--color-schemes', type=str, required=True, help="input color schemes file")
     parser.add_argument('--metadata', type=str, help="if provided, restrict colors to only those found in metadata")
     parser.add_argument('--clade-node-data', type=str, help="if provided, restrict to only those clades found in tree")
+    parser.add_argument('--clade-recency', type=int, help="if provided, restrict to clades found in tree within X months of present")
     parser.add_argument('--output', type=str, required=True, help="output colors tsv")
     args = parser.parse_args()
 
@@ -36,26 +47,41 @@ if __name__ == '__main__':
     if args.metadata:
         metadata = pd.read_csv(args.metadata, delimiter='\t')
         for name, trait in assignment.items():
-            if name in metadata:
+            if name in metadata['strain'].values:
                 subset_present = [x for x in assignment[name] if x in metadata[name].unique()]
                 assignment[name] = subset_present
-            if name in metadata and 'focal' in metadata:
+            if name in metadata['strain'].values and 'focal' in metadata.columns:
                 focal_list = metadata.loc[metadata['focal'] == True, name].unique()
                 subset_focal = [x for x in assignment[name] if x in focal_list]
                 assignment[name] = subset_focal
 
-    # if node json is supplied, restrict to clades names in the tree
+    # if node json is supplied, restrict to clades names in the tree within the specified recency
     if args.clade_node_data and "clade_membership" in assignment:
         with open(args.clade_node_data) as fh:
             import json
             clades = json.load(fh)['nodes']
 
-        # generate a set of present values
-        subset_present = set([x["clade_membership"] for x in clades.values()])
-        # restrict to only those present while maintaining order
-        assignment["clade_membership"] = [x for x in assignment["clade_membership"]
-                                          if x in subset_present]
+        if args.clade_recency and args.metadata:
+            # Calculate the cutoff date based on clade_recency (number of months ago from today)
+            cutoff_date = datetime.today() - timedelta(days=args.clade_recency * 30)  # approximate months as 30 days
 
+            # Generate a set of present values within the specified recency
+            subset_present = set()
+            metadata = pd.read_csv(args.metadata, delimiter='\t')
+            for strain, info in clades.items():
+                if strain in metadata['strain'].values:
+                    date_str = metadata.loc[metadata['strain'] == strain, 'date'].values[0]
+                    if date_within_last_n_months(date_str, cutoff_date):
+                        subset_present.add(info["clade_membership"])
+
+            # Restrict to only those present while maintaining order
+            assignment["clade_membership"] = [x for x in assignment["clade_membership"]
+                                              if x in subset_present]
+        else:
+            # If no clade_recency is provided, look for all clades present in the tree
+            subset_present = set([x["clade_membership"] for x in clades.values()])
+            assignment["clade_membership"] = [x for x in assignment["clade_membership"]
+                                              if x in subset_present]
 
     schemes = {}
     counter = 0

--- a/scripts/assign-colors.py
+++ b/scripts/assign-colors.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     parser.add_argument('--color-schemes', type=str, required=True, help="input color schemes file")
     parser.add_argument('--metadata', type=str, help="if provided, restrict colors to only those found in metadata")
     parser.add_argument('--clade-node-data', type=str, help="if provided, restrict to only those clades found in tree")
-    parser.add_argument('--clade-recency', type=int, nargs='?', const=None, help="if provided, restrict to clades found in tree within X months of present")
+    parser.add_argument('--clade-recency', type=int, help="if provided, restrict to clades found in tree within X months of present")
     parser.add_argument('--output', type=str, required=True, help="output colors tsv")
     args = parser.parse_args()
 

--- a/scripts/assign-colors.py
+++ b/scripts/assign-colors.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     parser.add_argument('--color-schemes', type=str, required=True, help="input color schemes file")
     parser.add_argument('--metadata', type=str, help="if provided, restrict colors to only those found in metadata")
     parser.add_argument('--clade-node-data', type=str, help="if provided, restrict to only those clades found in tree")
-    parser.add_argument('--clade-recency', type=int, help="if provided, restrict to clades found in tree within X months of present")
+    parser.add_argument('--clade-recency', type=int, nargs='?', const=None, help="if provided, restrict to clades found in tree within X months of present")
     parser.add_argument('--output', type=str, required=True, help="output colors tsv")
     args = parser.parse_args()
 
@@ -61,7 +61,7 @@ if __name__ == '__main__':
             import json
             clades = json.load(fh)['nodes']
 
-        if args.clade_recency and args.metadata:
+        if args.clade_recency is not None and args.metadata:
             # Calculate the cutoff date based on clade_recency (number of months ago from today)
             cutoff_date = datetime.today() - timedelta(days=args.clade_recency * 30)  # approximate months as 30 days
 

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -186,7 +186,7 @@ def _get_clade_recency_argument(wildcards):
     elif isinstance(clade_recency_setting, int):
         return "--clade-recency " + shquote(str(clade_recency_setting))
     else:
-        return ""
+        raise Exception(f'clade_recency must be "all" or an integer number of months. Got: {clade_recency_setting!r}')
 
 def _get_trait_columns_by_wildcards(wildcards):
     if wildcards.build_name in config["traits"]:

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -177,6 +177,15 @@ def _get_clade_recency_for_wildcards(wildcards):
         return config["colors"]["clade_recency"]
     # else return sensible default value
     else:
+        return "all"
+
+def _get_clade_recency_argument(wildcards):
+    clade_recency_setting = _get_clade_recency_for_wildcards(wildcards)
+    if clade_recency_setting == "all":
+        return ""
+    elif isinstance(clade_recency_setting, int):
+        return "--clade-recency " + shquote(str(clade_recency_setting))
+    else:
         return ""
 
 def _get_trait_columns_by_wildcards(wildcards):

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -172,9 +172,9 @@ def _get_clade_recency_for_wildcards(wildcards):
     # check if builds.yaml contains colors:{build_name}:clade_recency
     if wildcards.build_name in config["colors"] and 'clade_recency' in config["colors"][wildcards.build_name]:
         return config["colors"][wildcards.build_name]["clade_recency"]
-    # check if builds.yaml or parameters.yaml contains colors:clade_recency
-    elif "colors" in config and "clade_recency" in config["colors"]:
-        return config["colors"]["clade_recency"]
+    # check if builds.yaml or parameters.yaml contains colors:default:clade_recency
+    elif "colors" in config and "clade_recency" in config["colors"]["default"]:
+        return config["colors"]["default"]["clade_recency"]
     # else return sensible default value
     else:
         return "all"

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -169,10 +169,15 @@ def _get_metadata_by_wildcards(wildcards):
     return _get_metadata_by_build_name(wildcards.build_name)
 
 def _get_clade_recency_for_wildcards(wildcards):
+    # check if builds.yaml contains colors:{build_name}:clade_recency
     if wildcards.build_name in config["colors"] and 'clade_recency' in config["colors"][wildcards.build_name]:
         return config["colors"][wildcards.build_name]["clade_recency"]
+    # check if builds.yaml or parameters.yaml contains colors:clade_recency
+    elif "colors" in config and "clade_recency" in config["colors"]:
+        return config["colors"]["clade_recency"]
+    # else return sensible default value
     else:
-        return config["colors"]["default"]["clade_recency"]
+        return ""
 
 def _get_trait_columns_by_wildcards(wildcards):
     if wildcards.build_name in config["traits"]:

--- a/workflow/snakemake_rules/common.smk
+++ b/workflow/snakemake_rules/common.smk
@@ -168,6 +168,12 @@ def _get_metadata_by_wildcards(wildcards):
     """
     return _get_metadata_by_build_name(wildcards.build_name)
 
+def _get_clade_recency_for_wildcards(wildcards):
+    if wildcards.build_name in config["colors"] and 'clade_recency' in config["colors"][wildcards.build_name]:
+        return config["colors"][wildcards.build_name]["clade_recency"]
+    else:
+        return config["colors"]["default"]["clade_recency"]
+
 def _get_trait_columns_by_wildcards(wildcards):
     if wildcards.build_name in config["traits"]:
         return config["traits"][wildcards.build_name]["columns"]

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1105,6 +1105,8 @@ rule colors:
         color_schemes = config["files"]["color_schemes"],
         metadata="results/{build_name}/metadata_adjusted.tsv.xz",
         clades = rules.clades.output.clade_data
+    params:
+        clade_recency = config["colors"]["clade_recency"]
     output:
         colors = "results/{build_name}/colors.tsv"
     log:
@@ -1124,6 +1126,7 @@ rule colors:
             --color-schemes {input.color_schemes} \
             --output {output.colors} \
             --clade-node-data {input.clades} \
+            --clade-recency {params.clade_recency} \
             --metadata {input.metadata} 2>&1 | tee {log}
         """
 

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1106,7 +1106,7 @@ rule colors:
         metadata="results/{build_name}/metadata_adjusted.tsv.xz",
         clades = rules.clades.output.clade_data
     params:
-        clade_recency = config["colors"]["clade_recency"]
+        clade_recency = _get_clade_recency_for_wildcards
     output:
         colors = "results/{build_name}/colors.tsv"
     log:

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1106,7 +1106,7 @@ rule colors:
         metadata="results/{build_name}/metadata_adjusted.tsv.xz",
         clades = rules.clades.output.clade_data
     params:
-        clade_recency = _get_clade_recency_for_wildcards
+        clade_recency_argument = _get_clade_recency_argument
     output:
         colors = "results/{build_name}/colors.tsv"
     log:
@@ -1126,7 +1126,7 @@ rule colors:
             --color-schemes {input.color_schemes} \
             --output {output.colors} \
             --clade-node-data {input.clades} \
-            --clade-recency {params.clade_recency} \
+            {params.clade_recency_argument} \
             --metadata {input.metadata} 2>&1 | tee {log}
         """
 


### PR DESCRIPTION
## Description of proposed changes

This PR is attempting to solve the same problem as #1129, but in a different fashion. In this case, we keep the subsampling in the 6m, 2m and 1m builds the same as before and so keep the long contextual tail going from 6m / 2m / 1m back to the beginning of the pandemic. However, I've added new functionality to the `assign-colors.py` script that takes in a `--clade-recency` parameter. This specifies the number of months back to look for circulating clades. So for example, `--clade-recency 6` would use tips in the previous 6 months and only keep `clade_membership` in this time period. I added parameter logic to specify `--clade-recency` of `6` vs `2` vs `1` for `6m`, `2m` and `1m` builds. The `all-time` builds include all clades.

Here's some comparisons.

#### [global/6m](https://nextstrain.org/staging/ncov/gisaid/trial/gray-out-early-clades/global/6m)

_Live_

<img width="918" alt="Screenshot 2024-07-26 at 6 24 11 PM" src="https://github.com/user-attachments/assets/e3d47cef-8d41-4a59-aa90-9188ab558515">

_PR_

<img width="918" alt="Screenshot 2024-07-26 at 6 25 26 PM" src="https://github.com/user-attachments/assets/18905b3b-09fe-4cac-aede-bbd57b5a18ed">

#### [global/2m](https://nextstrain.org/staging/ncov/gisaid/trial/gray-out-early-clades/global/2m)

_Live_

<img width="918" alt="Screenshot 2024-07-26 at 6 26 20 PM" src="https://github.com/user-attachments/assets/132162c3-bb5c-408b-b30b-27f988952053">

_PR_

<img width="918" alt="Screenshot 2024-07-26 at 6 26 50 PM" src="https://github.com/user-attachments/assets/afc96587-c708-4673-988e-88180afdb2be">

#### [global/1m](https://nextstrain.org/staging/ncov/gisaid/trial/gray-out-early-clades/global/1m)

_Live_

<img width="918" alt="Screenshot 2024-07-26 at 6 27 46 PM" src="https://github.com/user-attachments/assets/fc00b751-db8f-45fb-86c1-54cc29aaeed3">

_PR_

<img width="918" alt="Screenshot 2024-07-26 at 6 28 20 PM" src="https://github.com/user-attachments/assets/8215c960-bf4f-4668-965f-2dd9be077fba">

------------------------------------

I think this is a big improvement. We no longer have 3 highly similar similar shades of red for currently circulating clades. It also seems semantically appropriate to gray out these early clades to correspond to "context". This the same thing we do for regions outside of the focal region ala [south-america/6m?c=country](https://next.nextstrain.org/ncov/gisaid/south-america/6m?c=country)

My preference would be to merge this PR (after code review) and reconsider the previous time-based sampling PR #1129. I think we'll eventually need to move the `min_date` up from 2020, but with clade colors fixed it's not so urgent. Additionally, having this strategy of gray clades outside of focal window would work with alternative time-based sampling windows.

## Testing

Tested locally and via trial build (URLs linked above). However, this adds a new `parameters.yaml` option. I tested and it shouldn't break existing builds that don't specify `colors:clade_recency`, but attention here wouldn't hurt.

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.
