### PR TITLE
dev: Trim back the overgrown CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,11 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test-build:


### PR DESCRIPTION
Same reasoning as @tsibley in https://github.com/nextstrain/cli/commit/fab709a2f45fc74afe2a15038e877e4dd58ae222:

> Running on push _and_ PRs is often redundant.  For PRs, we really care
about the putative merge of the PR branch, and that's what "on:
pull_request" tests.  We typically do not need push-level CI results for
PRs.  On the other hand, CI results for every push to master are nice to
have both as a safety backstop and for the linear chain of CI history it
produces (e.g. to debug the impact of external changes on our CI).
>
> The primary downside I see is that you can no longer push without
opening a PR just to see what CI says, but I think that's an acceptable
tradeoff, especially now that draft PRs are a thing.  To mitigate this
downside, "on: workflow_dispatch" allows CI to be manually dispatched
for a specific branch/tag/commit if you _really_ don't want to open even
a draft PR.
>
> Trimming unnecessary CI jobs reduces the time to completion for CI runs
(good for the dev loop) and reduces organization-level job queuing,
which can negatively impact the workflows of other repos.

Noting that another downside is not having `push`-triggered CI runs on forks, but `workflow_dispatch` and draft PRs are good alternatives.