### PR TITLE
_Actually_ fix narrative links [#1135]

### DIFF
--- a/docs/src/visualization/narratives.rst
+++ b/docs/src/visualization/narratives.rst
@@ -5,8 +5,8 @@ Nextstrain Narratives allow you to pair a specific view of a dataset with text a
 
 For examples, `see our weekly Situation Reports <https://nextstrain.org/ncov-sit-reps>`__ from the first several months of the pandemic.
 
-You can `read more about narratives <https://nextstrain.org/docs/narratives/introduction>`__ or `watch our Nextstrain narratives tutorial videos <https://www.youtube.com/playlist?list=PLsFWZl6SQqWxN9SkbgdjU8sylIfhZNDiW>`_. We've also `provided a template narrative file <https://github.com/nextstrain/ncov/tree/master/narratives/template_narrative.md>`__ for you to edit.
+You can `read more about narratives <https://nextstrain.org/docs/narratives/introduction>`__ or `watch our Nextstrain narratives tutorial videos <https://www.youtube.com/playlist?list=PLsFWZl6SQqWxN9SkbgdjU8sylIfhZNDiW>`_. We've also `provided a template narrative file <https://github.com/nextstrain/ncov/tree/master/narratives/ncov_template_narrative.md>`__ for you to edit.
 
-You can preview the template narrative by navigating to https://nextstrain.org/community/narratives/nextstrain/ncov/template_narrative.
+You can preview the template narrative by navigating to https://nextstrain.org/community/narratives/nextstrain/ncov/template/narrative.
 
 If you get stuck, don't hesitate to `ask for help <https://discussion.nextstrain.org/>`__.


### PR DESCRIPTION
## Description of proposed changes

Correct links to narrative markdown file in repo and active narrative. 
