### PR TITLE
gisaid/21L: Use only the 21L sequence from references

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid-21L/prefilter.smk
+++ b/nextstrain_profiles/nextstrain-gisaid-21L/prefilter.smk
@@ -92,7 +92,8 @@ rule gisaid_21L_aligned:
         exec 2> {log:q}
 
         < {input.references:q} \
-          zstd \
+          seqkit grep --by-name --pattern 21L \
+        | zstd \
         > {output.aligned}
 
         < {input.aligned:q} \


### PR DESCRIPTION
## Description of proposed changes

data/references_sequences.fasta contains both `Wuhan/Hu-1/2019` and `21L`. The aligned input is expected to contain `Wuhan/Hu-1/2019` so the merging with references_sequences.fasta is really only for 21L.

## Related issue(s)

Fixes #1153 

## Checklist

- [x] Tested locally with a dummy file for `input.aligned`
- [x] [Trial build](https://github.com/nextstrain/ncov/actions/runs/11115317297) is successful
- [x] ~Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.~ not necessary - changes are within a Nextstrain profile
