### PR TITLE
Use weighted sampling for recent samples in global builds

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
@@ -294,6 +294,7 @@ subsampling:
       max_date: "--max-date 1M"
     recent:
       group_by: "country week"
+      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 1M"
 
@@ -308,6 +309,7 @@ subsampling:
       max_date: "--max-date 2M"
     recent:
       group_by: "country week"
+      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 2M"
 
@@ -322,6 +324,7 @@ subsampling:
       max_date: "--max-date 6M"
     recent:
       group_by: "country year month"
+      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 6M"
 

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -286,6 +286,7 @@ subsampling:
       max_date: "--max-date 1M"
     recent:
       group_by: "country week"
+      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 1M"
 
@@ -300,6 +301,7 @@ subsampling:
       max_date: "--max-date 2M"
     recent:
       group_by: "country week"
+      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 2M"
 
@@ -314,6 +316,7 @@ subsampling:
       max_date: "--max-date 6M"
     recent:
       group_by: "country year month"
+      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 6M"
 

--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -286,6 +286,7 @@ subsampling:
       max_date: "--max-date 1M"
     recent:
       group_by: "country week"
+      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 1M"
 
@@ -300,6 +301,7 @@ subsampling:
       max_date: "--max-date 2M"
     recent:
       group_by: "country week"
+      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 2M"
 
@@ -314,6 +316,7 @@ subsampling:
       max_date: "--max-date 6M"
     recent:
       group_by: "country year month"
+      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 6M"
 


### PR DESCRIPTION
This should have been a part of #1106 but got lost in translation.

[GISAID trial build](https://github.com/nextstrain/ncov/actions/runs/11866290700) links:

- [global/1m](https://nextstrain.org/staging/ncov/gisaid/trial/victorlin-weight-global-recent/global/1m)
- [global/2m](https://nextstrain.org/staging/ncov/gisaid/trial/victorlin-weight-global-recent/global/2m)
- [global/6m](https://nextstrain.org/staging/ncov/gisaid/trial/victorlin-weight-global-recent/global/6m)
