### PR TITLE
docs: Remove commit history link

### DIFF
--- a/docs/src/guides/update-workflow.rst
+++ b/docs/src/guides/update-workflow.rst
@@ -3,7 +3,7 @@ Update the workflow
 
 We update the official workflow regularly with:
 
--  `curated metadata including latitudes/longitudes, clade annotations, and low quality sequences <https://github.com/nextstrain/ncov/commits/master>`__
+-  curated metadata including latitudes/longitudes, clade annotations, and low quality sequences
 -  bug fixes
 -  :doc:`new features <../reference/change_log>`
 


### PR DESCRIPTION
## Description of proposed changes

The commit history for the entire repo is not very meaningful to represent the text that is linked. I considered scoping to the `defaults/` folder with
<https://github.com/nextstrain/ncov/commits/master/defaults>, but that also shows many irrelevant commits. I think it's easiest to just drop this link.

Original motivation is CI failing on the URL rate limiting during docs linkcheck.

## Related issue(s)

- Fixes #1162
