### PR TITLE
readthedocs.yml: explicit Sphinx configuration

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,3 +8,6 @@ build:
 
 conda:
   environment: docs/conda.yml
+
+sphinx:
+  configuration: docs/src/conf.py


### PR DESCRIPTION
## Description of proposed changes

Prompted by deprecation of RTD's auto-detection of Sphinx configs 
<https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/>

## Related issue(s)

Related to https://github.com/nextstrain/public/issues/15

## Checklist

- [x] Checks pass
