### PR TITLE
Revert "Use weighted sampling for recent samples in global builds"

### DIFF
--- a/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
@@ -294,7 +294,6 @@ subsampling:
       max_date: "--max-date 1M"
     recent:
       group_by: "country week"
-      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 1M"
 
@@ -309,7 +308,6 @@ subsampling:
       max_date: "--max-date 2M"
     recent:
       group_by: "country week"
-      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 2M"
 
@@ -324,7 +322,6 @@ subsampling:
       max_date: "--max-date 6M"
     recent:
       group_by: "country year month"
-      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 6M"
 

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -286,7 +286,6 @@ subsampling:
       max_date: "--max-date 1M"
     recent:
       group_by: "country week"
-      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 1M"
 
@@ -301,7 +300,6 @@ subsampling:
       max_date: "--max-date 2M"
     recent:
       group_by: "country week"
-      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 2M"
 
@@ -316,7 +314,6 @@ subsampling:
       max_date: "--max-date 6M"
     recent:
       group_by: "country year month"
-      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 6M"
 

--- a/nextstrain_profiles/nextstrain-open/builds.yaml
+++ b/nextstrain_profiles/nextstrain-open/builds.yaml
@@ -286,7 +286,6 @@ subsampling:
       max_date: "--max-date 1M"
     recent:
       group_by: "country week"
-      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 1M"
 
@@ -301,7 +300,6 @@ subsampling:
       max_date: "--max-date 2M"
     recent:
       group_by: "country week"
-      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 2M"
 
@@ -316,7 +314,6 @@ subsampling:
       max_date: "--max-date 6M"
     recent:
       group_by: "country year month"
-      group_by_weights: "defaults/population_weights.tsv"
       max_sequences: 4100
       min_date: "--min-date 6M"
 


### PR DESCRIPTION
Reverts unapproved PR nextstrain/ncov#1161 due to being not a trivial change reducing recent sample from the expected ~4k to undesirably low ~1.2k

Population weighting is nice, but not at the expense of uncompensated severe downsampling.

See https://github.com/nextstrain/ncov/pull/1161#issuecomment-2556934384 for explanation.

I don't know whether that's due to a misconfiguration of population weighting or that population weighting requires continuous tweaking as currently implemented to keep numbers as expected. What do you think @victorlin?

We might be able to just workaround by increasing the sample to above ~4k, but that seems risky and not ideal.