### PR TITLE
feat: use nightly nextclade tree

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -455,7 +455,7 @@ rule prepare_nextclade:
         Downloading reference files for nextclade (used for alignment and qc).
         """
     output:
-        nextclade_dataset = "data/sars-cov-2-nextclade-defaults",
+        nextclade_dataset = directory("data/sars-cov-2-nextclade-defaults"),
     params:
         name = config["nextclade_dataset"],
     conda: config["conda_environment"]


### PR DESCRIPTION
## Description of proposed changes

- [x] switch Nextclade dataset to directory format (which allows to replace dataset files)
- [x] replace reference tree in the dataset with the nightly tree from https://nextstrain.org/staging/nextclade/sars-cov-2

This allows to bypass laggy Nextclade dataset updates and use the latest data always. Which may or may not be what we want.

This aims to be a workaround until the dataset updates are sorted out.

Potential problems:
- nightly trees are not systematically reviewed and can contain bugs
- does any other parts of the dataset need to be updated along with the tree? (such as pathogen.json)
- does any other repos need to be updated to use nightly tree? (e.g. ncov-ingest) i.e. is there an assumption that the exact same dataset is used in 2 or more places?

## Related issue(s)

None I could find

## Testing

I need help with this

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
