### PR TITLE
Optimize `rule combine_samples`

### DIFF
--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -443,6 +443,7 @@ rule combine_samples:
         augur filter \
             --sequences {input.sequences} \
             --metadata {input.metadata} \
+            --skip-checks \
             --exclude-all \
             --include {input.include} \
             --output-sequences {output.sequences} \

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -434,9 +434,9 @@ rule combine_samples:
         sequences = "results/{build_name}/{build_name}_subsampled_sequences.fasta.xz",
         metadata = "results/{build_name}/{build_name}_subsampled_metadata.tsv.xz"
     log:
-        "logs/subsample_regions_{build_name}.txt"
+        "logs/combine_samples_{build_name}.txt"
     benchmark:
-        "benchmarks/subsample_regions_{build_name}.txt"
+        "benchmarks/combine_samples_{build_name}.txt"
     conda: config["conda_environment"]
     shell:
         r"""

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -438,6 +438,7 @@ rule combine_samples:
     benchmark:
         "benchmarks/combine_samples_{build_name}.txt"
     conda: config["conda_environment"]
+    threads: 2
     shell:
         r"""
         augur filter \
@@ -446,6 +447,7 @@ rule combine_samples:
             --skip-checks \
             --exclude-all \
             --include {input.include} \
+            --nthreads {threads} \
             --output-sequences {output.sequences} \
             --output-metadata {output.metadata} 2>&1 | tee {log}
         """


### PR DESCRIPTION
## Description of proposed changes

This rule became [noticeably slower](https://github.com/nextstrain/augur/issues/1833) with Augur 31.2.1. I tracked down a few reasons. This PR along with [Augur #1834](https://github.com/nextstrain/augur/pull/1834) should improve the run time of this rule to be faster than with previous versions of Augur.

## Testing

Testing notes in https://github.com/nextstrain/augur/issues/1833#issuecomment-3011435623

## Checklist

- [ ] Merge+release of https://github.com/nextstrain/augur/pull/1834
- [ ] Document new minimum Augur version requirement

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
