### PR TITLE
Add warnings

### DIFF
--- a/.github/workflows/rebuild-100k.yml
+++ b/.github/workflows/rebuild-100k.yml
@@ -8,30 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  gisaid:
-    permissions:
-      id-token: write
-    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
-    secrets: inherit
-    with:
-      runtime: aws-batch
-      run: |
-        set -x
-
-        declare -a config
-        config+=(slack_token=$SLACK_TOKEN)
-
-        nextstrain build \
-          --detach \
-          --cpus 16 \
-          --memory 31GiB \
-          . \
-            upload \
-            --configfile nextstrain_profiles/100k/config-gisaid.yaml \
-            --config "${config[@]}" \
-            --set-threads tree=8
-      artifact-name: gisaid-build-output
-
   open:
     permissions:
       id-token: write

--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,7 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 10 October 2025: Add parameter `warning` to display provided string in warning banner in Auspice. This can be defined per build or at the top level config. [PR 1186](https://github.com/nextstrain/ncov/pull/1186)
 - 29 July 2025: Improved performance of calls to `augur filter`. This requires a minimum Augur version of 31.3.0. [PR 1178](https://github.com/nextstrain/ncov/pull/1178)
 
 ## v17 (17 July 2025)

--- a/docs/src/reference/workflow-config-file.rst
+++ b/docs/src/reference/workflow-config-file.rst
@@ -193,6 +193,11 @@ title
 -  type: string
 -  description: Build-specific title to provide to ``augur export`` and display as the title of the analysis in Auspice.
 
+warning
+~~~~~~~
+
+- type: string
+- description: Build-specific warning to provide to ``augur export`` and display in a warning banner in Auspice.
 
 .. _configuration-subsampling:
 
@@ -425,6 +430,13 @@ title
 
 -  type: string
 -  description: Title to provide to ``augur export`` and display as the title of the analysis in Auspice. Note that this is only used if a title is not defined for the individual build in the ``builds`` object.
+
+
+warning
+-------
+
+-  type: string
+-  description: Warning to provide to ``augur export`` and display in a warning banner in Auspice. Note that this is only used if a warning is not defined for the individual build in the ``builds`` object.
 
 
 genes

--- a/nextstrain_profiles/nextstrain-ci/builds.yaml
+++ b/nextstrain_profiles/nextstrain-ci/builds.yaml
@@ -7,6 +7,8 @@ inputs:
     metadata: "data/example_metadata.tsv"
     sequences: "data/example_sequences.fasta.gz"
 
+warning: "Test warning"
+
 builds:
   # Override the default Nextstrain European build's subsampling scheme for more
   # stable subsampling of a fixed dataset in continuous integration tests.

--- a/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid-21L/builds.yaml
@@ -19,6 +19,7 @@ slack_channel: "#ncov-gisaid-updates"
 
 genes: ["ORF1a", "ORF1b", "S", "ORF3a", "E", "M", "ORF6", "ORF7a", "ORF7b", "ORF8", "N", "ORF9b"]
 include_hcov19_prefix: True
+warning: "On Oct 1, 2025, we received an email from GISAID stating that they will no longer be updating the flat file of EpiCoV data they've historically provisioned to Nextstrain since Feb 2020. Updates to these analyses are on hold while we sort out alternative strategies to pull in new data from GISAID. In the meantime, updates to /ncov/open/ should continue at their regular weekly cadence."
 
 files:
   # This file is produced by a custom clades_21L rule in our prefiltering rules

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -18,6 +18,7 @@ slack_channel: "#ncov-gisaid-updates"
 
 genes: ["ORF1a", "ORF1b", "S", "ORF3a", "E", "M", "ORF6", "ORF7a", "ORF7b", "ORF8", "N", "ORF9b"]
 include_hcov19_prefix: True
+warning: "Warning: The GISAID EpiCoV API has not been updated since Sept 27, 2025. The analysis is no longer up-to-date."
 
 files:
   description: "nextstrain_profiles/nextstrain-gisaid/nextstrain_description.md"

--- a/nextstrain_profiles/nextstrain-gisaid/builds.yaml
+++ b/nextstrain_profiles/nextstrain-gisaid/builds.yaml
@@ -18,7 +18,7 @@ slack_channel: "#ncov-gisaid-updates"
 
 genes: ["ORF1a", "ORF1b", "S", "ORF3a", "E", "M", "ORF6", "ORF7a", "ORF7b", "ORF8", "N", "ORF9b"]
 include_hcov19_prefix: True
-warning: "Warning: The GISAID EpiCoV API has not been updated since Sept 27, 2025. The analysis is no longer up-to-date."
+warning: "On Oct 1, 2025, we received an email from GISAID stating that they will no longer be updating the flat file of EpiCoV data they've historically provisioned to Nextstrain since Feb 2020. Updates to these analyses are on hold while we sort out alternative strategies to pull in new data from GISAID. In the meantime, updates to /ncov/open/ should continue at their regular weekly cadence."
 
 files:
   description: "nextstrain_profiles/nextstrain-gisaid/nextstrain_description.md"

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -1192,6 +1192,15 @@ def export_title(wildcards):
         location_title = location_name.replace("-", " ").title()
         return f"Genomic epidemiology of novel coronavirus - {location_title}-focused subsampling"
 
+def export_warning(wildcards):
+    warning = config["builds"][wildcards.build_name].get("warning", False) or \
+              config.get("warning", False)
+
+    if warning and isinstance(warning, str):
+        return f"--warning {warning!r}"
+    else:
+        return ""
+
 def _get_node_data_by_wildcards(wildcards):
     """Return a list of node data files to include for a given build's wildcards.
     """
@@ -1280,7 +1289,8 @@ rule export:
     benchmark:
         "benchmarks/export_{build_name}.txt"
     params:
-        title = export_title
+        title = export_title,
+        warning = export_warning,
     resources:
         # Memory use scales primarily with the size of the metadata file.
         mem_mb=12000
@@ -1296,6 +1306,7 @@ rule export:
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \
             --title {params.title:q} \
+            {params.warning} \
             --description {input.description} \
             --output {output.auspice_json} 2>&1 | tee {log}
         """


### PR DESCRIPTION
## Description of proposed changes

Adds config param `warning` to support warning banners for builds. 
Includes a warning banner for the nextstrain-gisaid builds, feel free to edit the warning message as needed. 

## Related issue(s)

Resolves https://github.com/nextstrain/ncov/issues/1185

## Release checklist

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
