### PR TITLE
.github/docs: Only run linkcheck on scheduled runs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,12 +4,8 @@ on:
   push:
     branches:
       - master
-    paths: &paths
-      - docs/**
-      - .github/workflows/docs.yaml
 
   pull_request:
-    paths: *paths
 
   workflow_dispatch:
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,3 +24,4 @@ jobs:
     with:
       docs-directory: docs/
       environment-file: docs/conda.yml
+      run-linkcheck: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## Description of proposed changes

Reduce noise from false positive linkchecks by only running linkcheck for the scheduled workflow runs.

## Related issue(s)

Related to https://github.com/nextstrain/.github/pull/170

## Checklist 

- [x] Checks pass