### PR TITLE
Document the rebuild-100k development subsample

### DIFF
--- a/docs/dev_docs.md
+++ b/docs/dev_docs.md
@@ -75,4 +75,10 @@ These will run the respective phylogenetic build pipelines starting from the pre
 This will ask for an optional “trial name” and upload intermediate files to  `nextstrain-ncov-private/trial/$TRIAL_NAME` and `nextstrain-staging/files/ncov/open/trial/$TRIAL_NAME`; if you don't supply this you will overwrite the files at `nextstrain-ncov-private` and `nextstrain-data/files/ncov/open`, as well as the trees at `nextstrain.org/ncov/gisaid/REGION` and `nextstrain.org/ncov/open/REGION`
 The GitHub action will follow along with the AWS job so that you can monitor the progress; as of October 2021 each action took around 3 hours.
 
+## Generating the 100k development subsample
+
+The GitHub Action `rebuild-100k` runs weekly (Mondays, via cron) and can also be [triggered manually](https://github.com/nextstrain/ncov/actions).
+It runs the `upload` target with `nextstrain_profiles/100k/config-open.yaml` to produce a roughly 100k-sequence open subsample — a smaller, representative dataset used for development and testing — and uploads the resulting intermediate files.
+See [remote inputs](https://docs.nextstrain.org/projects/ncov/en/latest/reference/remote_inputs.html) for where these files are published.
+
 If you want to test a particular branch, you can select the branch to use for the trial build when running the Github action.


### PR DESCRIPTION
Fifth and final PR in the pandemic-era cruft cleanup series (after #1208, #1209, #1210, #1211).

## Motivation

The cleanup plan called for keeping the `rebuild-100k` workflow but documenting it (it ran weekly but was absent from the developer docs), and for fixing the Terra guide if the v17 GCS removal had broken it.

## Changes

- **Document `rebuild-100k`** in `docs/dev_docs.md`: a short section explaining that the action runs weekly to produce a ~100k-sequence open subsample for development/testing and uploads the intermediate files, with a pointer to the remote-inputs reference.

## Verified, no change needed

- **Terra guide** (`docs/src/guides/run-analysis-on-terra.rst`): I checked whether the v17 removal of Google Cloud Storage support made it stale. It did **not** — the Terra guide runs the **WDL workflow via Dockstore/Cromwell**, and its `gs://` paths are Cromwell `File` inputs handled natively by Terra. That's independent of the Snakemake `path_or_url` GCS support that was removed. So the guide is left as-is.
- **`my_profiles/` doc references** (`files.rst`, `glossary.rst`): left as-is — they correctly describe `my_profiles/` as a deprecated-but-still-usable local directory (it remains gitignored), so they're accurate.

## Test plan

- [ ] Docs build + link check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)