### PR TITLE
Only apply global include file when combining samples

### DIFF
--- a/docs/src/reference/change_log.md
+++ b/docs/src/reference/change_log.md
@@ -5,6 +5,8 @@ We also use this change log to document new features that maintain backward comp
 
 ## New features since last version update
 
+- 22 July 2026: The workflow now warns when a subsampling set is configured with filters that drop all sequences.
+
 ## v18 (6 July 2026)
 
 - 10 October 2025: Add parameter `warning` to display provided string in warning banner in Auspice. This can be defined per build or at the top level config. [PR 1186](https://github.com/nextstrain/ncov/pull/1186)

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -282,7 +282,6 @@ rule subsample:
         """
     input:
         metadata = _get_unified_metadata,
-        include = config["files"]["include"],
         priorities = get_priorities,
         exclude = config["files"]["exclude"]
     output:
@@ -313,7 +312,6 @@ rule subsample:
         r"""
         augur filter \
             --metadata {input.metadata} \
-            --include {input.include} \
             --exclude {input.exclude} \
             {params.min_date} \
             {params.max_date} \
@@ -327,7 +325,8 @@ rule subsample:
             {params.sequences_per_group} \
             {params.subsample_max_sequences} \
             {params.sampling_scheme} \
-            --output-strains {output.strains} 2>&1 | tee {log}
+            --output-strains {output.strains} \
+            --empty-output-reporting warn 2>&1 | tee {log}
         """
 
 rule extract_subsampled_sequences:
@@ -424,12 +423,12 @@ rule priority_score:
 
 
 def _get_subsampled_files(wildcards):
-    subsampling_settings = _get_subsampling_settings(wildcards)
-
-    return [
+    files = [
         f"results/{wildcards.build_name}/sample-{subsample}.txt"
-        for subsample in subsampling_settings
+        for subsample in _get_subsampling_settings(wildcards)
     ]
+    files.append(config["files"]["include"])
+    return files
 
 rule combine_samples:
     input:


### PR DESCRIPTION
## Description of proposed changes

Previously, applying it to every subsampling set (intermediate augur filter call) guaranteed that there would always be at least one sequence in the output. This was prone to hiding issues with the per-sample filters.

`--empty-output-reporting warn` prevents augur filter from otherwise erroring on empty subsampling sets, which would be a breaking change. Empty subsampling sets now show a warning message in the command output.

## Related issue(s)

Noticed while working on https://github.com/nextstrain/augur/issues/2032

## Testing

Ran locally to confirm that workflow shows the following message after fixing the Augur bug.

> WARNING: All samples have been dropped! Check filter rules and metadata file format.

The empty subsampling set still runs and has no entry in the `combine_samples` log.

```
9428989 strains were dropped during filtering
	9430425 were dropped by `--exclude-all`
	564 were added back because they were in results/africa_6m/sample-region_early.txt
	176 were added back because they were in results/africa_6m/sample-context_early.txt
	695 were added back because they were in results/africa_6m/sample-context_recent.txt
	1 was added back because it was in defaults/include.txt
1436 strains passed all filters
```

## Release checklist

If this pull request introduces backward incompatible changes, complete the following steps for a new release of the workflow:

 - [ ] Determine the version number for the new release by incrementing [the most recent release](https://github.com/nextstrain/ncov/releases) (e.g., "v2" from "v1").
 - [ ] Update `docs/src/reference/change_log.md` in this pull request to document these changes and the new version number.
 - [ ] After merging, [create a new GitHub release](https://github.com/nextstrain/ncov/releases/new) with the new version number as the tag and release title.

If this pull request introduces new features, complete the following steps:

 - [x] Update `docs/src/reference/change_log.md` in this pull request to document these changes by the date they were added.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
